### PR TITLE
Refactor/#20 api response

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/common/ApiResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/ApiResponse.java
@@ -1,0 +1,37 @@
+package com.uranus.taskmanager.api.common;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+	private final int code;
+	private final HttpStatus status;
+	private final String message;
+	private final T data;
+
+	public ApiResponse(HttpStatus status, String message, T data) {
+		this.code = status.value();
+		this.status = status;
+		this.message = message;
+		this.data = data;
+	}
+
+	public static <T> ApiResponse<T> ok(String message, T data) {
+		return new ApiResponse<>(HttpStatus.OK, message, data);
+	}
+
+	public static <T> ApiResponse<T> okWithNoContent(String message) {
+		return new ApiResponse<>(HttpStatus.NO_CONTENT, message, null);
+	}
+
+	public static <T> ApiResponse<T> created(String message, T data) {
+		return new ApiResponse<>(HttpStatus.CREATED, message, data);
+	}
+
+	public static <T> ApiResponse<T> fail(HttpStatus status, String message, T data) {
+		return new ApiResponse<>(status, message, data);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/common/CommonException.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/CommonException.java
@@ -1,0 +1,23 @@
+package com.uranus.taskmanager.api.common;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class CommonException extends RuntimeException {
+	private final String message;
+	private final HttpStatus httpStatus;
+
+	public CommonException(String message, HttpStatus httpStatus) {
+		this.message = message;
+		this.httpStatus = httpStatus;
+	}
+
+	public CommonException(String message,
+		HttpStatus httpStatus, Throwable cause) {
+		super(cause);
+		this.message = message;
+		this.httpStatus = httpStatus;
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/common/FieldErrorDto.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/FieldErrorDto.java
@@ -1,0 +1,16 @@
+package com.uranus.taskmanager.api.common;
+
+import lombok.Getter;
+
+@Getter
+public class FieldErrorDto {
+	private final String field;
+	private final String rejectedValue;
+	private final String message;
+
+	public FieldErrorDto(String field, String rejectedValue, String message) {
+		this.field = field;
+		this.rejectedValue = rejectedValue;
+		this.message = message;
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/controller/AuthController.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/AuthController.java
@@ -1,14 +1,15 @@
 package com.uranus.taskmanager.api.controller;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.uranus.taskmanager.api.auth.LoginRequired;
 import com.uranus.taskmanager.api.auth.SessionKey;
+import com.uranus.taskmanager.api.common.ApiResponse;
 import com.uranus.taskmanager.api.request.LoginRequest;
 import com.uranus.taskmanager.api.response.LoginResponse;
 import com.uranus.taskmanager.api.service.AuthService;
@@ -31,7 +32,7 @@ public class AuthController {
 	private final AuthService authService;
 
 	@PostMapping("/login")
-	public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest,
+	public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest,
 		HttpServletRequest request) {
 		LoginResponse loginResponse = authService.login(loginRequest);
 
@@ -42,20 +43,20 @@ public class AuthController {
 		 * loginId가 null은 아니지만 DB에 없고 email을 통해 조회한 경우, 또는 그 반대의 케이스.
 		 */
 		HttpSession session = request.getSession();
-
 		session.setAttribute(SessionKey.LOGIN_MEMBER, loginResponse.getLoginId());
 
-		return ResponseEntity.status(HttpStatus.OK).body(loginResponse);
+		return ApiResponse.ok("Login Success", loginResponse);
 	}
 
+	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@LoginRequired
 	@PostMapping("/logout")
-	public ResponseEntity<Void> logout(HttpServletRequest request) {
+	public ApiResponse<Void> logout(HttpServletRequest request) {
 		HttpSession session = request.getSession(false);
 		if (session != null) {
 			session.invalidate();
 		}
-		return ResponseEntity.noContent().build(); // Todo: 추후에 ApiResponse 클래스 만들고 리팩토링
+		return ApiResponse.okWithNoContent("Logout Success");
 	}
 
 }

--- a/src/main/java/com/uranus/taskmanager/api/controller/GlobalExceptionHandler.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/GlobalExceptionHandler.java
@@ -1,17 +1,17 @@
 package com.uranus.taskmanager.api.controller;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
+import java.util.Objects;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ProblemDetail;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.uranus.taskmanager.api.common.ApiResponse;
+import com.uranus.taskmanager.api.common.FieldErrorDto;
 import com.uranus.taskmanager.api.exception.AuthenticationException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -20,67 +20,72 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	@ExceptionHandler(Exception.class)
-	public ResponseEntity<ProblemDetail> unexpectedException(Exception exception) {
-
+	public ApiResponse<Void> unexpectedException(Exception exception) {
 		log.error("Unexpected Exception: ", exception);
 
-		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
-		problemDetail.setTitle("Unexpected Exception");
-		problemDetail.setDetail("An unexpected problem has occurred");
-
-		return ResponseEntity
-			.status(HttpStatus.BAD_REQUEST)
-			.body(problemDetail);
+		return ApiResponse.fail(HttpStatus.INTERNAL_SERVER_ERROR,
+			"A unexpected problem has occured",
+			null);
 	}
 
+	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	@ExceptionHandler(RuntimeException.class)
-	public ResponseEntity<ProblemDetail> unexpectedRuntimeException(RuntimeException exception) {
-
+	public ApiResponse<Void> unexpectedRuntimeException(RuntimeException exception) {
 		log.error("Unexpected RuntimeException :", exception);
 
-		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
-		problemDetail.setTitle("Unexpected RuntimeException");
-		problemDetail.setDetail("An unexpected problem has occurred");
-
-		return ResponseEntity
-			.status(HttpStatus.BAD_REQUEST)
-			.body(problemDetail);
+		return ApiResponse.fail(HttpStatus.INTERNAL_SERVER_ERROR,
+			"A unexpected problem has occured",
+			null);
 	}
 
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(MethodArgumentNotValidException.class)
-	public ResponseEntity<ProblemDetail> handleValidationException(MethodArgumentNotValidException exception) {
-
+	public ApiResponse<List<FieldErrorDto>> handleValidationException(MethodArgumentNotValidException exception) {
 		log.error("Field Validation Failed: ", exception);
 
+		/*
+		 * Todo: data안에 검증을 실패한 필드를 다음 처럼 표현하는 것이 과연 좋은가?
+		 * "data": {
+		 *    {
+		 *      "field" : "***",
+		 * 		"rejectedValue" : "***",
+		 * 		"message" : "***"
+		 *    },
+		 * 	  ...
+		 * }
+		 */
 		BindingResult bindingResult = exception.getBindingResult();
-		Map<String, String> fieldErrors = new HashMap<>();
+		List<FieldErrorDto> errors = bindingResult.getFieldErrors().stream()
+			.map(error -> new FieldErrorDto(
+				error.getField(),
+				Objects.toString(error.getRejectedValue(), ""), // null이면 빈 문자열 처리
+				error.getDefaultMessage()
+			))
+			.toList();
 
-		for (FieldError fieldError : bindingResult.getFieldErrors()) {
-			fieldErrors.put(fieldError.getField(), fieldError.getDefaultMessage());
-		}
+		/*
+		 * Todo: 아래 방법을 다시 고려
+		 */
+		// Map<String, String> fieldErrors = new HashMap<>();
+		//
+		// for (FieldError fieldError : bindingResult.getFieldErrors()) {
+		// 	fieldErrors.put(fieldError.getField(), fieldError.getDefaultMessage());
+		// }
 
-		ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
-		problemDetail.setTitle("Field Validation Error");
-		problemDetail.setDetail("One or more fields have validation errors");
-		problemDetail.setProperty("fieldErrors", fieldErrors);
-
-		return ResponseEntity
-			.status(HttpStatus.BAD_REQUEST)
-			.body(problemDetail);
+		return ApiResponse.fail(HttpStatus.BAD_REQUEST,
+			"One or more fields have validation errors",
+			errors);
 	}
 
+	@ResponseStatus(HttpStatus.UNAUTHORIZED)
 	@ExceptionHandler(AuthenticationException.class)
-	public ResponseEntity<ProblemDetail> handleAuthenticationException(AuthenticationException exception) {
-
+	public ApiResponse<?> handleAuthenticationException(AuthenticationException exception) {
 		log.error("Authentication Related Exception: ", exception);
 
-		ProblemDetail problemDetail = ProblemDetail.forStatus(exception.getHttpStatus());
-		problemDetail.setTitle(exception.getTitle());
-		problemDetail.setDetail(exception.getMessage());
-
-		return ResponseEntity
-			.status(exception.getHttpStatus())
-			.body(problemDetail);
+		return ApiResponse.fail(exception.getHttpStatus(),
+			exception.getMessage(),
+			null); // Todo: AuthenticationException을 상속받은 예외 클래스에 잘못된 필드를 넘기는 것을 고려(이후 data에 넘기기)
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/controller/MemberController.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/MemberController.java
@@ -1,12 +1,11 @@
 package com.uranus.taskmanager.api.controller;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.uranus.taskmanager.api.common.ApiResponse;
 import com.uranus.taskmanager.api.request.SignupRequest;
 import com.uranus.taskmanager.api.response.SignupResponse;
 import com.uranus.taskmanager.api.service.MemberService;
@@ -30,9 +29,9 @@ public class MemberController {
 	private final MemberService memberService;
 
 	@PostMapping("/signup")
-	public ResponseEntity<SignupResponse> signup(@Valid @RequestBody SignupRequest signupRequest) {
+	public ApiResponse<SignupResponse> signup(@Valid @RequestBody SignupRequest signupRequest) {
 		SignupResponse signupResponse = memberService.signup(signupRequest);
-		return ResponseEntity.status(HttpStatus.OK).body(signupResponse);
+		return ApiResponse.created("Signup Success", signupResponse);
 	}
 
 }

--- a/src/main/java/com/uranus/taskmanager/api/controller/WorkspaceController.java
+++ b/src/main/java/com/uranus/taskmanager/api/controller/WorkspaceController.java
@@ -1,14 +1,15 @@
 package com.uranus.taskmanager.api.controller;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.uranus.taskmanager.api.common.ApiResponse;
 import com.uranus.taskmanager.api.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.response.WorkspaceResponse;
 import com.uranus.taskmanager.api.service.WorkspaceService;
@@ -23,20 +24,34 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/v1/workspaces")
 public class WorkspaceController {
 
+	/**
+	 * Todo 1
+	 * 워크스페이스 관련 모든 작업은 기본적으로 @LoginRequired 필요
+	 * 워크스페이스 내의 권한 자격을 나타내는 @Role 구현
+	 * 특정 워크스페이스의 이름, 설명 수정은 @Role({"ADMIN"})
+	 * 특정 워크스페이스의 삭제는 @Role({"ADMIN"})
+	 * Todo 2
+	 * 워크스페이스 생성(비밀번호 설정 추가)
+	 * 워크스페이스 이름, 설명 수정
+	 * 워크스페이스 삭제
+	 * 워크스페이스 비밀번호 설정(만약 없으면 설정, 있으면 수정)
+	 * 멤버가 속한 워크스페이스 목록 조회(Member에서 할지 고민)
+	 * 워크스페이스 멤버 초대(ADMIN만 가능)
+	 * 워크스페이스 참여(워크스페이스 코드, 비밀번호를 통해)
+	 */
 	private final WorkspaceService workspaceService;
 
+	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping
-	public ResponseEntity<WorkspaceResponse> createWorkspace(@RequestBody @Valid WorkspaceCreateRequest request) {
+	public ApiResponse<WorkspaceResponse> createWorkspace(@RequestBody @Valid WorkspaceCreateRequest request) {
 		WorkspaceResponse response = workspaceService.create(request);
-		log.info("[WorkspaceController.createWorkspace] response = {}", response);
-		return ResponseEntity.status(HttpStatus.CREATED).body(response);
+		return ApiResponse.created("Workspace Created", response);
 	}
 
 	@GetMapping("/{workspaceId}")
-	public ResponseEntity<WorkspaceResponse> getWorkspace(@PathVariable String workspaceId) {
+	public ApiResponse<WorkspaceResponse> getWorkspace(@PathVariable String workspaceId) {
 		WorkspaceResponse response = workspaceService.get(workspaceId);
-		log.info("[WorkspaceController.getWorkspace] response = {}", response);
-		return ResponseEntity.status(HttpStatus.OK).body(response);
+		return ApiResponse.ok("Workspace Found", response);
 	}
 
 }

--- a/src/main/java/com/uranus/taskmanager/api/exception/AuthenticationException.java
+++ b/src/main/java/com/uranus/taskmanager/api/exception/AuthenticationException.java
@@ -2,26 +2,15 @@ package com.uranus.taskmanager.api.exception;
 
 import org.springframework.http.HttpStatus;
 
-import lombok.Getter;
+import com.uranus.taskmanager.api.common.CommonException;
 
-@Getter
-public abstract class AuthenticationException extends RuntimeException {
+public abstract class AuthenticationException extends CommonException {
 
-	private final String title;
-	private final String message;
-	private final HttpStatus httpStatus;
-
-	public AuthenticationException(String title, String message, HttpStatus httpStatus) {
-		this.title = title;
-		this.message = message;
-		this.httpStatus = httpStatus;
+	public AuthenticationException(String message, HttpStatus httpStatus) {
+		super(message, httpStatus);
 	}
 
-	public AuthenticationException(String message, String title,
-		HttpStatus httpStatus, Throwable cause) {
-		super(cause);
-		this.title = title;
-		this.message = message;
-		this.httpStatus = httpStatus;
+	public AuthenticationException(String message, HttpStatus httpStatus, Throwable cause) {
+		super(message, httpStatus, cause);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/exception/InvalidLoginIdentityException.java
+++ b/src/main/java/com/uranus/taskmanager/api/exception/InvalidLoginIdentityException.java
@@ -4,15 +4,14 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidLoginIdentityException extends AuthenticationException {
 
-	private static final String TITLE = "Invalid Login ID or Email";
 	private static final String MESSAGE = "Please provide a valid login ID or Email.";
 	private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
 
 	public InvalidLoginIdentityException() {
-		super(TITLE, MESSAGE, HTTP_STATUS);
+		super(MESSAGE, HTTP_STATUS);
 	}
 
 	public InvalidLoginIdentityException(Throwable cause) {
-		super(TITLE, MESSAGE, HTTP_STATUS, cause);
+		super(MESSAGE, HTTP_STATUS, cause);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/exception/InvalidLoginPasswordException.java
+++ b/src/main/java/com/uranus/taskmanager/api/exception/InvalidLoginPasswordException.java
@@ -3,15 +3,15 @@ package com.uranus.taskmanager.api.exception;
 import org.springframework.http.HttpStatus;
 
 public class InvalidLoginPasswordException extends AuthenticationException {
-	private static final String TITLE = "Invalid Login Password";
+
 	private static final String MESSAGE = "Please provide a valid login pasword.";
 	private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
 
 	public InvalidLoginPasswordException() {
-		super(TITLE, MESSAGE, HTTP_STATUS);
+		super(MESSAGE, HTTP_STATUS);
 	}
 
 	public InvalidLoginPasswordException(Throwable cause) {
-		super(TITLE, MESSAGE, HTTP_STATUS, cause);
+		super(MESSAGE, HTTP_STATUS, cause);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/exception/UserNotLoggedInException.java
+++ b/src/main/java/com/uranus/taskmanager/api/exception/UserNotLoggedInException.java
@@ -3,15 +3,15 @@ package com.uranus.taskmanager.api.exception;
 import org.springframework.http.HttpStatus;
 
 public class UserNotLoggedInException extends AuthenticationException {
-	private static final String TITLE = "Login Required";
+
 	private static final String MESSAGE = "Login is required to access.";
 	private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
 
 	public UserNotLoggedInException() {
-		super(TITLE, MESSAGE, HTTP_STATUS);
+		super(MESSAGE, HTTP_STATUS);
 	}
 
 	public UserNotLoggedInException(Throwable cause) {
-		super(TITLE, MESSAGE, HTTP_STATUS, cause);
+		super(MESSAGE, HTTP_STATUS, cause);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/exception/WorkspaceException.java
+++ b/src/main/java/com/uranus/taskmanager/api/exception/WorkspaceException.java
@@ -1,0 +1,15 @@
+package com.uranus.taskmanager.api.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.common.CommonException;
+
+public abstract class WorkspaceException extends CommonException {
+	public WorkspaceException(String message, HttpStatus httpStatus) {
+		super(message, httpStatus);
+	}
+
+	public WorkspaceException(String message, HttpStatus httpStatus, Throwable cause) {
+		super(message, httpStatus, cause);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/exception/WorkspaceNotFoundException.java
+++ b/src/main/java/com/uranus/taskmanager/api/exception/WorkspaceNotFoundException.java
@@ -1,0 +1,17 @@
+package com.uranus.taskmanager.api.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class WorkspaceNotFoundException extends WorkspaceException {
+	
+	private static final String MESSAGE = "Workspace was not found for given code.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
+
+	public WorkspaceNotFoundException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public WorkspaceNotFoundException(Throwable cause) {
+		super(MESSAGE, HTTP_STATUS, cause);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/request/SignupRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/request/SignupRequest.java
@@ -11,9 +11,9 @@ import lombok.Getter;
 @Builder
 public class SignupRequest {
 
-	@NotBlank(message = "User ID must not be blank")
+	@NotBlank(message = "Login ID must not be blank")
 	@Pattern(regexp = "^[a-zA-Z0-9]{2,20}$",
-		message = "User ID must be alphanumeric"
+		message = "Login ID must be alphanumeric"
 			+ " and must be between 2 and 20 characters")
 	private final String loginId;
 

--- a/src/main/java/com/uranus/taskmanager/api/service/AuthService.java
+++ b/src/main/java/com/uranus/taskmanager/api/service/AuthService.java
@@ -22,11 +22,7 @@ public class AuthService {
 
 	@Transactional
 	public LoginResponse login(LoginRequest loginRequest) {
-		/**
-		 * Todo
-		 * loginId, email 조회와 password 검증 분리
-		 * password 암호화 로직 후에 검증 로직 수정
-		 */
+
 		Member member = memberRepository.findByLoginIdOrEmail(loginRequest.getLoginId(), loginRequest.getEmail())
 			.orElseThrow(InvalidLoginIdentityException::new);
 

--- a/src/main/java/com/uranus/taskmanager/api/service/WorkspaceService.java
+++ b/src/main/java/com/uranus/taskmanager/api/service/WorkspaceService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.uranus.taskmanager.api.domain.workspace.Workspace;
+import com.uranus.taskmanager.api.exception.WorkspaceNotFoundException;
 import com.uranus.taskmanager.api.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.response.WorkspaceResponse;
@@ -18,21 +19,24 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class WorkspaceService {
 
+	/**
+	 * Todo
+	 * UserWorkspaceService, AdminWorkspaceService, ReaderWorkspaceService 분리 고려
+	 */
+
 	private final WorkspaceRepository workspaceRepository;
 
 	@Transactional
 	public WorkspaceResponse create(WorkspaceCreateRequest request) {
 		Workspace workspace = workspaceRepository.save(request.toEntity());
 		workspace.setWorkspaceCode(UUID.randomUUID().toString());
-		log.info("[WorkspaceService.create] workspace = {}", workspace);
 		return WorkspaceResponse.fromEntity(workspace);
 	}
 
 	@Transactional(readOnly = true)
 	public WorkspaceResponse get(String workspaceCode) {
 		Workspace workspace = workspaceRepository.findByWorkspaceCode(workspaceCode)
-			// RuntimeException -> WorkspaceNotFoundException 정의 예정
-			.orElseThrow(() -> new RuntimeException("Workspace was not found!"));
+			.orElseThrow(WorkspaceNotFoundException::new);
 		return WorkspaceResponse.fromEntity(workspace);
 	}
 

--- a/src/test/java/com/uranus/taskmanager/api/controller/AuthControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/controller/AuthControllerTest.java
@@ -54,8 +54,8 @@ class AuthControllerTest {
 				.session(session)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(loginRequest))))
-			.andExpect(jsonPath("$.loginId").value("user123"))
-			.andExpect(jsonPath("$.email").value("test@gmail.com"))
+			.andExpect(jsonPath("$.data.loginId").value("user123"))
+			.andExpect(jsonPath("$.data.email").value("test@gmail.com"))
 			.andExpect(status().isOk())
 			.andDo(print());
 
@@ -76,7 +76,7 @@ class AuthControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(loginRequest)))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.fieldErrors.password").value("Password must not be blank"))
+			.andExpect(jsonPath("$.data..message").value("Password must not be blank"))
 			.andDo(print());
 
 	}

--- a/src/test/java/com/uranus/taskmanager/api/controller/MemberControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/controller/MemberControllerTest.java
@@ -1,5 +1,6 @@
 package com.uranus.taskmanager.api.controller;
 
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.params.provider.Arguments.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
@@ -55,18 +56,18 @@ class MemberControllerTest {
 
 	@ParameterizedTest
 	@CsvSource({
-		"'testtesttesttesttest1', 'User ID must be alphanumeric and must be between 2 and 20 characters'",
-		"'1', 'User ID must be alphanumeric and must be between 2 and 20 characters'",
-		"'test!!', 'User ID must be alphanumeric and must be between 2 and 20 characters'",
-		"'한글아이디', 'User ID must be alphanumeric and must be between 2 and 20 characters'",
-		"'test1한글', 'User ID must be alphanumeric and must be between 2 and 20 characters'",
+		"'testtesttesttesttest1', 'Login ID must be alphanumeric and must be between 2 and 20 characters'",
+		"'1', 'Login ID must be alphanumeric and must be between 2 and 20 characters'",
+		"'test!!', 'Login ID must be alphanumeric and must be between 2 and 20 characters'",
+		"'한글아이디', 'Login ID must be alphanumeric and must be between 2 and 20 characters'",
+		"'test1한글', 'Login ID must be alphanumeric and must be between 2 and 20 characters'",
 	})
 	@DisplayName("회원 가입에 loginId는 영문과 숫자 조합에 2~20자를 지켜야한다")
 	void test2(String loginId, String loginIdValidMsg) throws Exception {
 		SignupRequest signupRequest = SignupRequest.builder()
 			.loginId(loginId)
 			.email("testemail@gmail.com")
-			.password("Testpassword!")
+			.password("Testpassword1234!")
 			.build();
 		String requestBody = objectMapper.writeValueAsString(signupRequest);
 
@@ -74,7 +75,7 @@ class MemberControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.fieldErrors.loginId").value(loginIdValidMsg))
+			.andExpect(jsonPath("$.data..message").value(loginIdValidMsg))
 			.andDo(print());
 	}
 
@@ -102,16 +103,15 @@ class MemberControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.fieldErrors.password")
-				.value(passwordValidMsg))
+			.andExpect(jsonPath("$.data..message").value(passwordValidMsg))
 			.andDo(print());
 	}
 
 	static Stream<Arguments> provideInvalidInputs() {
 		return Stream.of(
 			arguments(null, null, null), // null
-			arguments("", "", ""),   // 빈 문자열
-			arguments(" ", " ", " ")  // 공백
+			arguments("", "", ""), // 빈 문자열
+			arguments(" ", " ", " ") // 공백
 		);
 	}
 
@@ -132,9 +132,9 @@ class MemberControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.fieldErrors.loginId").exists())
-			.andExpect(jsonPath("$.fieldErrors.email").exists())
-			.andExpect(jsonPath("$.fieldErrors.password").exists())
+			.andExpect(jsonPath("$.data[*].field").value(hasItem("loginId")))
+			.andExpect(jsonPath("$.data[*].field").value(hasItem("email")))
+			.andExpect(jsonPath("$.data[*].field").value(hasItem("password")))
 			.andDo(print());
 	}
 

--- a/src/test/java/com/uranus/taskmanager/api/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/controller/WorkspaceControllerTest.java
@@ -1,5 +1,6 @@
 package com.uranus.taskmanager.api.controller;
 
+import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.params.provider.Arguments.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -75,8 +76,7 @@ class WorkspaceControllerTest {
 	@ParameterizedTest
 	@MethodSource("provideInvalidInputs")
 	@DisplayName("워크스페이스 생성: name과 description은 null, 빈 문자열, 공백이면 안된다")
-	public void test2(String name, String description) throws
-		Exception {
+	public void test2(String name, String description) throws Exception {
 		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
 			.name(name)
 			.description(description)
@@ -87,10 +87,7 @@ class WorkspaceControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.title").value("Field Validation Error"))
-			.andExpect(jsonPath("$.detail").value("One or more fields have validation errors"))
-			.andExpect(jsonPath("$.fieldErrors.name").exists())
-			.andExpect(jsonPath("$.fieldErrors.description").exists())
+			.andExpect(jsonPath("$.message").value("One or more fields have validation errors"))
 			.andDo(print());
 	}
 
@@ -120,8 +117,8 @@ class WorkspaceControllerTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.fieldErrors.name").value(nameValidMsg))
-			.andExpect(jsonPath("$.fieldErrors.description").value(descriptionValidMsg))
+			.andExpect(jsonPath("$.data[*].message").value(hasItem(nameValidMsg)))
+			.andExpect(jsonPath("$.data[*].message").value(hasItem(descriptionValidMsg)))
 			.andDo(print());
 	}
 
@@ -155,10 +152,10 @@ class WorkspaceControllerTest {
 
 		mockMvc.perform(get("/api/v1/workspaces/{workspaceCode}", workspaceCode))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.id").value(1L))
-			.andExpect(jsonPath("$.workspaceCode").value(workspaceCode))
-			.andExpect(jsonPath("$.name").value("Test workspace"))
-			.andExpect(jsonPath("$.description").value("Test description"));
+			.andExpect(jsonPath("$.data.id").value(1L))
+			.andExpect(jsonPath("$.data.workspaceCode").value(workspaceCode))
+			.andExpect(jsonPath("$.data.name").value("Test workspace"))
+			.andExpect(jsonPath("$.data.description").value("Test description"));
 	}
 
 }

--- a/src/test/java/com/uranus/taskmanager/integrationtest/WorkspaceIntegrationTest.java
+++ b/src/test/java/com/uranus/taskmanager/integrationtest/WorkspaceIntegrationTest.java
@@ -52,9 +52,9 @@ class WorkspaceIntegrationTest {
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody))
 			.andExpect(status().isCreated())
-			.andExpect(jsonPath("$.name").value("Test Workspace"))
-			.andExpect(jsonPath("$.description").value("Test Description"))
-			.andExpect(jsonPath("$.workspaceCode").exists())
+			.andExpect(jsonPath("$.data.name").value("Test Workspace"))
+			.andExpect(jsonPath("$.data.description").value("Test Description"))
+			.andExpect(jsonPath("$.data.workspaceCode").exists())
 			.andDo(print());
 	}
 


### PR DESCRIPTION
## 🚀 설명
- `ApiResponse`라는 공통 응답 클래스를 만들어서 적용
- `CommonException`이라는 상위 커스텀 예외를 만들어서, 하위 예외들이 해당 예외를 상속 받도록 리팩토링
- 예시: `CommonException` -> `AuthenticationException` -> `UserNotLoggedInException`
```json
{
  "code" : "***",
  "status" : "***",
  "message" : "***",
  "data" : {
     "field1" : "***",
     "field2" : "***",
   }
}
```

---
## ✅ 변경 사항
- [x] 공통으로 상속 받아서 사용할 상위 커스텀 예외 CommonException 추가
- [x] 도메인 별로 상위 예외가 해당 예외를 상속 받도록 리팩토링
- [x] 공통 응답 클래스 `ApiResponse` 추가
- [x] `ApiResponse<XxxDto>` 형태로 응답하도록 리팩토링
- [x] `ResponseEntity` 대신 `@ResponseStatus` 적용
- [x] `FieldErrorDto`를 정의해서, 빈 검증 실패 필드를 `data` 필드에 표현

---
## 🚩 관련 이슈, PR
- #20 

---
## 📖 참고