### PR TITLE
Refactor/#22 builder id exclude

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/domain/member/Member.java
+++ b/src/main/java/com/uranus/taskmanager/api/domain/member/Member.java
@@ -36,14 +36,9 @@ public class Member {
 
 	@OneToMany(mappedBy = "member")
 	private List<WorkspaceMember> workspaceMembers = new ArrayList<>();
-
-	/**
-	 * Todo
-	 * @param id - 빌더에 id 필드 제외를 고려하자(테스트를 위해 리플렉션을 사용)
-	 */
+	
 	@Builder
-	public Member(Long id, String loginId, String email, String password) {
-		this.id = id;
+	public Member(String loginId, String email, String password) {
 		this.loginId = loginId;
 		this.email = email;
 		this.password = password;

--- a/src/main/java/com/uranus/taskmanager/api/domain/workspace/Workspace.java
+++ b/src/main/java/com/uranus/taskmanager/api/domain/workspace/Workspace.java
@@ -36,14 +36,9 @@ public class Workspace {
 
 	@OneToMany(mappedBy = "workspace")
 	private List<WorkspaceMember> workspaceMembers = new ArrayList<>();
-
-	/**
-	 * Todo
-	 * @param id - 빌더에 id 필드 제외를 고려하자(테스트를 위해 리플렉션을 사용)
-	 */
+	
 	@Builder
-	public Workspace(Long id, String workspaceCode, String name, String description) {
-		this.id = id;
+	public Workspace(String workspaceCode, String name, String description) {
 		this.workspaceCode = workspaceCode;
 		this.name = name;
 		this.description = description;

--- a/src/main/java/com/uranus/taskmanager/api/response/WorkspaceResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/response/WorkspaceResponse.java
@@ -10,15 +10,13 @@ import lombok.ToString;
 @ToString
 @Builder
 public class WorkspaceResponse {
-
-	private final Long id;
+	
 	private final String workspaceCode;
 	private final String name;
 	private final String description;
 
 	public static WorkspaceResponse fromEntity(Workspace workspace) {
 		return WorkspaceResponse.builder()
-			.id(workspace.getId())
 			.name(workspace.getName())
 			.description(workspace.getDescription())
 			.workspaceCode(workspace.getWorkspaceCode())

--- a/src/test/java/com/uranus/taskmanager/api/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/controller/WorkspaceControllerTest.java
@@ -127,7 +127,6 @@ class WorkspaceControllerTest {
 	public void test4() throws Exception {
 		String workspaceCode = UUID.randomUUID().toString();
 		WorkspaceResponse workspaceResponse = WorkspaceResponse.builder()
-			.id(1L)
 			.name("Test workspace")
 			.description("Test description")
 			.workspaceCode(workspaceCode)
@@ -143,7 +142,6 @@ class WorkspaceControllerTest {
 	public void test5() throws Exception {
 		String workspaceCode = UUID.randomUUID().toString();
 		WorkspaceResponse workspaceResponse = WorkspaceResponse.builder()
-			.id(1L)
 			.name("Test workspace")
 			.description("Test description")
 			.workspaceCode(workspaceCode)
@@ -152,7 +150,6 @@ class WorkspaceControllerTest {
 
 		mockMvc.perform(get("/api/v1/workspaces/{workspaceCode}", workspaceCode))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.id").value(1L))
 			.andExpect(jsonPath("$.data.workspaceCode").value(workspaceCode))
 			.andExpect(jsonPath("$.data.name").value("Test workspace"))
 			.andExpect(jsonPath("$.data.description").value("Test description"));

--- a/src/test/java/com/uranus/taskmanager/api/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/service/WorkspaceServiceTest.java
@@ -36,7 +36,6 @@ class WorkspaceServiceTest {
 			.description("Test Description")
 			.build();
 		Workspace mockWorkspace = Workspace.builder()
-			.id(1L)
 			.name("Test Workspace")
 			.description("Test Description")
 			.build();
@@ -45,7 +44,7 @@ class WorkspaceServiceTest {
 		WorkspaceResponse response = workspaceService.create(request);
 
 		assertThat(response).isNotNull();
-		assertThat(response.getId()).isEqualTo(1L);
+		assertThat(response.getName()).isEqualTo("Test Workspace");
 		verify(workspaceRepository, times(1)).save(any(Workspace.class));
 
 	}
@@ -55,7 +54,6 @@ class WorkspaceServiceTest {
 	void test2() {
 		String workspaceCode = UUID.randomUUID().toString();
 		Workspace mockWorkspace = Workspace.builder()
-			.id(1L)
 			.workspaceCode(workspaceCode)
 			.name("Test Workspace")
 			.description("Test Description")
@@ -67,7 +65,6 @@ class WorkspaceServiceTest {
 		WorkspaceResponse response = workspaceService.get(workspaceCode);
 
 		assertThat(response).isNotNull();
-		assertThat(response.getId()).isEqualTo(1L);
 		assertThat(response.getWorkspaceCode()).isEqualTo(workspaceCode);
 		verify(workspaceRepository, times(1)).findByWorkspaceCode(workspaceCode);
 	}


### PR DESCRIPTION
## 🚀 설명
- 엔티티의 빌더에 `id` 필드는 사용하지 않도록 제외한다

---
## ✅ 변경 사항
- [x] 빌더의 `id` 필드 제외

---
## 🚩 관련 이슈, PR
- #22 

---
## 📖 참고