### PR TITLE
Feat/#30 workspace authorization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,8 @@ jacocoTestReport {
                             "**/*Exception*",
                             "**/*Key*",
                             "**/*Base62Encoder*",
-                            "**/*WorkspaceCodeGenerator*"
+                            "**/*WorkspaceCodeGenerator*",
+                            "**/*Interceptor*"
                     ])
                 })
         )
@@ -91,7 +92,8 @@ jacocoTestReport {
                         "**.*Exception*",
                         "**.*Key*",
                         "**.*Base62Encoder*",
-                        "**.*WorkspaceCodeGenerator*"
+                        "**.*WorkspaceCodeGenerator*",
+                        "**.*Interceptor*"
                 ]
             }
         }

--- a/src/main/java/com/uranus/taskmanager/api/auth/LoginMember.java
+++ b/src/main/java/com/uranus/taskmanager/api/auth/LoginMember.java
@@ -1,0 +1,11 @@
+package com.uranus.taskmanager.api.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginMember {
+}

--- a/src/main/java/com/uranus/taskmanager/api/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/uranus/taskmanager/api/auth/LoginMemberArgumentResolver.java
@@ -1,0 +1,63 @@
+package com.uranus.taskmanager.api.auth;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.auth.exception.UserNotLoggedInException;
+import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.member.repository.MemberRepository;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private final MemberRepository memberRepository;
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		/*
+		 * 컨트롤러 메서드의 파라미터가 LoginMemberDto 타입인지 확인
+		 * 파라미터에 @LoginMember 애노테이션이 붙었는지 확인
+		 */
+		return parameter.getParameterType().equals(LoginMemberDto.class)
+			&& parameter.hasParameterAnnotation(LoginMember.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+
+		/*
+		 * 세션을 가져와서 확인한다
+		 * 세션이 없거나 세션에 LOGIN_MEMBER라는 키로 로그인된 사용자 정보가 없다면 UserNotLoggedInException
+		 */
+		HttpServletRequest request = (HttpServletRequest)webRequest.getNativeRequest();
+		HttpSession session = request.getSession(false);
+		if (session == null || session.getAttribute(SessionKey.LOGIN_MEMBER) == null) {
+			throw new UserNotLoggedInException();
+		}
+
+		/*
+		 * 세션에서 로그인된 사용자의 정보를 가져온다
+		 * loginId를 통해서 Member를 조회한다
+		 */
+		String loginId = (String)session.getAttribute(SessionKey.LOGIN_MEMBER);
+
+		Member member = memberRepository.findByLoginId(loginId)
+			.orElseThrow(RuntimeException::new); // Todo MemberNotFoundException 구현
+
+		/*
+		 * member를 LoginMemberDto로 변환해서 반환한다
+		 */
+		return LoginMemberDto.fromEntity(member);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/auth/controller/AuthenticationController.java
+++ b/src/main/java/com/uranus/taskmanager/api/auth/controller/AuthenticationController.java
@@ -20,15 +20,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1/auth") // Resource를 members가 아닌 auth로 표현하는 것이 좋을까?
+@RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthenticationController {
-	/**
-	 * Todo
-	 * 로그인 - 로그인하면 세션을 생성. 해당 세션ID를 클라에게 전달.
-	 *          서버는 이후 클라가 보낸 쿠키를 사용해 세션ID 식별
-	 * 로그아웃 - 세션 끝내기
-	 */
+
 	private final AuthenticationService authenticationService;
 
 	@PostMapping("/login")

--- a/src/main/java/com/uranus/taskmanager/api/auth/dto/request/LoginMemberDto.java
+++ b/src/main/java/com/uranus/taskmanager/api/auth/dto/request/LoginMemberDto.java
@@ -1,0 +1,29 @@
+package com.uranus.taskmanager.api.auth.dto.request;
+
+import com.uranus.taskmanager.api.member.domain.Member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Todo: 추후에 nickname 추가가 필요하면 추가
+ */
+@Getter
+public class LoginMemberDto {
+
+	private final String loginId;
+	private final String email;
+
+	@Builder
+	public LoginMemberDto(String loginId, String email) {
+		this.loginId = loginId;
+		this.email = email;
+	}
+
+	public static LoginMemberDto fromEntity(Member member) {
+		return LoginMemberDto.builder()
+			.loginId(member.getLoginId())
+			.email(member.getEmail())
+			.build();
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/uranus/taskmanager/api/global/GlobalExceptionHandler.java
@@ -10,9 +10,12 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.uranus.taskmanager.api.auth.exception.AuthenticationException;
 import com.uranus.taskmanager.api.common.ApiResponse;
 import com.uranus.taskmanager.api.common.FieldErrorDto;
-import com.uranus.taskmanager.api.auth.exception.AuthenticationException;
+import com.uranus.taskmanager.api.workspace.exception.WorkspaceException;
+import com.uranus.taskmanager.api.workspacemember.authorization.exception.AuthorizationException;
+import com.uranus.taskmanager.api.workspacemember.exception.WorkspaceMemberException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,7 +36,7 @@ public class GlobalExceptionHandler {
 	@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
 	@ExceptionHandler(RuntimeException.class)
 	public ApiResponse<Void> unexpectedRuntimeException(RuntimeException exception) {
-		log.error("Unexpected RuntimeException :", exception);
+		log.error("Unexpected RuntimeException:", exception);
 
 		return ApiResponse.fail(HttpStatus.INTERNAL_SERVER_ERROR,
 			"A unexpected problem has occured",
@@ -60,13 +63,13 @@ public class GlobalExceptionHandler {
 		List<FieldErrorDto> errors = bindingResult.getFieldErrors().stream()
 			.map(error -> new FieldErrorDto(
 				error.getField(),
-				Objects.toString(error.getRejectedValue(), ""), // null이면 빈 문자열 처리
+				Objects.toString(error.getRejectedValue(), ""),
 				error.getDefaultMessage()
 			))
 			.toList();
 
 		/*
-		 * Todo: 아래 방법을 다시 고려
+		 * Todo: 아래 방법을 고려
 		 */
 		// Map<String, String> fieldErrors = new HashMap<>();
 		//
@@ -88,4 +91,35 @@ public class GlobalExceptionHandler {
 			exception.getMessage(),
 			null); // Todo: AuthenticationException을 상속받은 예외 클래스에 잘못된 필드를 넘기는 것을 고려(이후 data에 넘기기)
 	}
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(WorkspaceException.class)
+	public ApiResponse<?> handleWorkspaceException(WorkspaceException exception) {
+		log.error("Workspace Related Exception: ", exception);
+
+		return ApiResponse.fail(exception.getHttpStatus(),
+			exception.getMessage(),
+			null);
+	}
+
+	@ResponseStatus(HttpStatus.BAD_REQUEST)
+	@ExceptionHandler(WorkspaceMemberException.class)
+	public ApiResponse<?> handleWorkspaceMemberException(WorkspaceMemberException exception) {
+		log.error("WorkspaceMember Related Exception: ", exception);
+
+		return ApiResponse.fail(exception.getHttpStatus(),
+			exception.getMessage(),
+			null);
+	}
+
+	@ResponseStatus(HttpStatus.FORBIDDEN)
+	@ExceptionHandler(AuthorizationException.class)
+	public ApiResponse<?> handleAuthorizationException(AuthorizationException exception) {
+		log.error("Authorization Related Exception: ", exception);
+
+		return ApiResponse.fail(exception.getHttpStatus(),
+			exception.getMessage(),
+			null);
+	}
+
 }

--- a/src/main/java/com/uranus/taskmanager/api/global/config/WebMvcConfig.java
+++ b/src/main/java/com/uranus/taskmanager/api/global/config/WebMvcConfig.java
@@ -9,18 +9,21 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.uranus.taskmanager.api.auth.AuthenticationInterceptor;
 import com.uranus.taskmanager.api.auth.LoginMemberArgumentResolver;
+import com.uranus.taskmanager.api.workspacemember.authorization.AuthorizationInterceptor;
 
 import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
+	private final AuthorizationInterceptor authorizationInterceptor;
 	private final AuthenticationInterceptor authenticationInterceptor;
 	private final LoginMemberArgumentResolver loginMemberArgumentResolver;
 
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(authenticationInterceptor);
+		registry.addInterceptor(authorizationInterceptor);
 	}
 
 	@Override

--- a/src/main/java/com/uranus/taskmanager/api/global/config/WebMvcConfig.java
+++ b/src/main/java/com/uranus/taskmanager/api/global/config/WebMvcConfig.java
@@ -1,10 +1,14 @@
 package com.uranus.taskmanager.api.global.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.uranus.taskmanager.api.auth.AuthenticationInterceptor;
+import com.uranus.taskmanager.api.auth.LoginMemberArgumentResolver;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,9 +16,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
 	private final AuthenticationInterceptor authenticationInterceptor;
+	private final LoginMemberArgumentResolver loginMemberArgumentResolver;
 
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(authenticationInterceptor);
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(loginMemberArgumentResolver);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/member/domain/Member.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/domain/Member.java
@@ -3,7 +3,7 @@ package com.uranus.taskmanager.api.member.domain;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.uranus.taskmanager.api.workspace.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/uranus/taskmanager/api/workspace/config/WorkspaceConfig.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/config/WorkspaceConfig.java
@@ -3,10 +3,12 @@ package com.uranus.taskmanager.api.workspace.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.service.CheckCodeDuplicationService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceCreateService;
 import com.uranus.taskmanager.api.workspace.util.WorkspaceCodeGenerator;
+import com.uranus.taskmanager.api.workspace.workspacemember.repository.WorkspaceMemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 public class WorkspaceConfig {
 
 	private final WorkspaceRepository workspaceRepository;
+	private final MemberRepository memberRepository;
+	private final WorkspaceMemberRepository workspaceMemberRepository;
 	private final WorkspaceCodeGenerator workspaceCodeGenerator;
 
 	/**
@@ -26,6 +30,9 @@ public class WorkspaceConfig {
 	 */
 	@Bean
 	public WorkspaceCreateService workspaceCreateService() {
-		return new CheckCodeDuplicationService(workspaceRepository, workspaceCodeGenerator);
+		return new CheckCodeDuplicationService(workspaceRepository,
+			memberRepository,
+			workspaceMemberRepository,
+			workspaceCodeGenerator);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspace/config/WorkspaceConfig.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/config/WorkspaceConfig.java
@@ -8,7 +8,7 @@ import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.service.CheckCodeDuplicationService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceCreateService;
 import com.uranus.taskmanager.api.workspace.util.WorkspaceCodeGenerator;
-import com.uranus.taskmanager.api.workspace.workspacemember.repository.WorkspaceMemberRepository;
+import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
 
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
@@ -9,7 +9,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.uranus.taskmanager.api.auth.LoginMember;
 import com.uranus.taskmanager.api.auth.LoginRequired;
+import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.common.ApiResponse;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
@@ -47,8 +49,10 @@ public class WorkspaceController {
 	@LoginRequired
 	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping
-	public ApiResponse<WorkspaceResponse> createWorkspace(@RequestBody @Valid WorkspaceCreateRequest request) {
-		WorkspaceResponse response = workspaceCreateService.createWorkspace(request);
+	public ApiResponse<WorkspaceResponse> createWorkspace(
+		@LoginMember LoginMemberDto loginMember,
+		@RequestBody @Valid WorkspaceCreateRequest request) {
+		WorkspaceResponse response = workspaceCreateService.createWorkspace(request, loginMember);
 		return ApiResponse.created("Workspace Created", response);
 	}
 

--- a/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
@@ -17,6 +17,8 @@ import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceCreateService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceService;
+import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspacemember.authorization.RoleRequired;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -56,9 +58,20 @@ public class WorkspaceController {
 		return ApiResponse.created("Workspace Created", response);
 	}
 
-	@GetMapping("/{workspaceId}")
-	public ApiResponse<WorkspaceResponse> getWorkspace(@PathVariable String workspaceId) {
-		WorkspaceResponse response = workspaceService.get(workspaceId);
+	@GetMapping("/{workspaceCode}")
+	public ApiResponse<WorkspaceResponse> getWorkspace(@PathVariable String workspaceCode) {
+		WorkspaceResponse response = workspaceService.get(workspaceCode);
 		return ApiResponse.ok("Workspace Found", response);
+	}
+
+	/**
+	 * RoleRequired 적용 예시
+	 */
+	@LoginRequired
+	@RoleRequired(roles = {WorkspaceRole.ADMIN})
+	@PostMapping("/{workspaceCode}/admin-only")
+	public ApiResponse<LoginMemberDto> adminOnlyApi(@LoginMember LoginMemberDto loginMember,
+		@PathVariable String workspaceCode) {
+		return ApiResponse.ok("This is an admin-only API", loginMember);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
@@ -3,7 +3,7 @@ package com.uranus.taskmanager.api.workspace.domain;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.uranus.taskmanager.api.workspace.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/uranus/taskmanager/api/workspace/exception/WorkspaceNotFoundException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/exception/WorkspaceNotFoundException.java
@@ -2,11 +2,9 @@ package com.uranus.taskmanager.api.workspace.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.workspace.exception.WorkspaceException;
-
 public class WorkspaceNotFoundException extends WorkspaceException {
 
-	private static final String MESSAGE = "Workspace was not found for given code.";
+	private static final String MESSAGE = "Workspace was not found for the given code";
 	private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
 
 	public WorkspaceNotFoundException() {

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
@@ -11,9 +11,9 @@ import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.util.WorkspaceCodeGenerator;
-import com.uranus.taskmanager.api.workspace.workspacemember.WorkspaceRole;
-import com.uranus.taskmanager.api.workspace.workspacemember.domain.WorkspaceMember;
-import com.uranus.taskmanager.api.workspace.workspacemember.repository.WorkspaceMemberRepository;
+import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
@@ -3,11 +3,17 @@ package com.uranus.taskmanager.api.workspace.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.util.WorkspaceCodeGenerator;
+import com.uranus.taskmanager.api.workspace.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspace.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspace.workspacemember.repository.WorkspaceMemberRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,26 +29,53 @@ public class CheckCodeDuplicationService implements WorkspaceCreateService {
 	private static final int MAX_RETRIES = 5;
 
 	private final WorkspaceRepository workspaceRepository;
+	private final MemberRepository memberRepository;
+	private final WorkspaceMemberRepository workspaceMemberRepository;
 	private final WorkspaceCodeGenerator workspaceCodeGenerator;
 
 	/**
 	 * Todo: createWorkspace() 가독성 좋은 코드로 리팩토링
+	 * <p>
+	 * 코드 과정
+	 * <p>
+	 * 1. ArgumentResolver를 통해 세션의 Member 정보를 컨트롤러로 넘긴다(LoginMemberDto라는 형태로)
+	 * 	- Todo: 과연 Member 엔티티를 반환하지 않고 DTO 형태로 컨트롤러로 넘기는게 과연 잘한걸까?
+	 * 	- Todo: OSIV 관련 문제 찾아보기
+	 * 2. 컨트롤러에서 넘어온 생성 request, 세션에 저장된 로그인 정보 loginMember을 사용한다
+	 * 3. loginMember의 loginId를 사용해 Member 엔티티를 찾는다
+	 * 	- Todo: 컨트롤러에서 loginId만 받아와도 되는거 아닌가?
+	 * 4. 기존 워크스페이스 코드 생성과 워크스페이스 저장 과정
+	 * 5. WorkspaceMember도 같이 생성한다(addWorkspaceMember라는 편의 메서드를 통해서)
+	 * 	- 워크스페이스를 생성한 멤버는 해당 워크스페이스에서 기본적으로 ADMIN 권한을 가진다
+	 * 	- 별칭(nickname)은 기본적으로 email로 설정된다
+	 * 6. WorkspaceMember를 저장한다
 	 */
 	@Override
 	@Transactional
-	public WorkspaceResponse createWorkspace(WorkspaceCreateRequest request) {
+	public WorkspaceResponse createWorkspace(WorkspaceCreateRequest request, LoginMemberDto loginMember) {
+
+		Member member = memberRepository.findByLoginId(loginMember.getLoginId())
+			.orElseThrow(() -> new RuntimeException("Member not found")); // Todo: MemberNotFoundException 구현
+
 		for (int count = 0; count < MAX_RETRIES; count++) {
 			String workspaceCode = workspaceCodeGenerator.generateWorkspaceCode();
 			if (workspaceCodeIsNotDuplicate(workspaceCode)) {
 				log.info("[workspaceCodeIsNotDuplicate] workspaceCode = {}", workspaceCode);
 				request.setWorkspaceCode(workspaceCode);
 				Workspace workspace = workspaceRepository.save(request.toEntity());
+
+				WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace,
+					WorkspaceRole.ADMIN,
+					member.getEmail());
+
+				workspaceMemberRepository.save(workspaceMember);
+
 				return WorkspaceResponse.fromEntity(workspace);
 			}
 			log.info("[Workspace Code Collision] Retrying... attempt {}", count + 1);
 		}
 		throw new RuntimeException(
-			"Failed to solve workspace code collision"); // Todo: WorkspaceCode 재생성 반복 후에도 실패하는 경우 예외 처리
+			"Failed to solve workspace code collision"); // Todo: WorkspaceCodeCollisionHandleException 구현
 	}
 
 	public boolean workspaceCodeIsNotDuplicate(String workspaceCode) {

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/HandleDatabaseExceptionService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/HandleDatabaseExceptionService.java
@@ -13,9 +13,9 @@ import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.util.WorkspaceCodeGenerator;
-import com.uranus.taskmanager.api.workspace.workspacemember.WorkspaceRole;
-import com.uranus.taskmanager.api.workspace.workspacemember.domain.WorkspaceMember;
-import com.uranus.taskmanager.api.workspace.workspacemember.repository.WorkspaceMemberRepository;
+import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/HandleDatabaseExceptionService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/HandleDatabaseExceptionService.java
@@ -5,11 +5,17 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.util.WorkspaceCodeGenerator;
+import com.uranus.taskmanager.api.workspace.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspace.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspace.workspacemember.repository.WorkspaceMemberRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +30,8 @@ public class HandleDatabaseExceptionService implements WorkspaceCreateService {
 	private static final int MAX_RETRIES = 5;
 
 	private final WorkspaceRepository workspaceRepository;
+	private final MemberRepository memberRepository;
+	private final WorkspaceMemberRepository workspaceMemberRepository;
 	private final WorkspaceCodeGenerator workspaceCodeGenerator;
 
 	/**
@@ -31,7 +39,10 @@ public class HandleDatabaseExceptionService implements WorkspaceCreateService {
 	 */
 	@Override
 	@Transactional
-	public WorkspaceResponse createWorkspace(WorkspaceCreateRequest request) {
+	public WorkspaceResponse createWorkspace(WorkspaceCreateRequest request, LoginMemberDto loginMember) {
+
+		Member member = memberRepository.findByLoginId(loginMember.getLoginId())
+			.orElseThrow(() -> new RuntimeException("Member not found")); // Todo: MemberNotFoundException 구현
 
 		for (int count = 0; count < MAX_RETRIES; count++) {
 			try {
@@ -43,6 +54,13 @@ public class HandleDatabaseExceptionService implements WorkspaceCreateService {
 				request.setWorkspaceCode(workspaceCode);
 
 				Workspace workspace = workspaceRepository.saveWithNewTransaction(request.toEntity());
+
+				WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace,
+					WorkspaceRole.ADMIN,
+					member.getEmail());
+
+				workspaceMemberRepository.save(workspaceMember);
+
 				return WorkspaceResponse.fromEntity(workspace);
 			} catch (DataIntegrityViolationException | ConstraintViolationException e) {
 				/*
@@ -53,6 +71,6 @@ public class HandleDatabaseExceptionService implements WorkspaceCreateService {
 			}
 		}
 		throw new RuntimeException(
-			"Failed to solve workspace code collision"); // Todo: WorkspaceCode 재생성 반복 후에도 실패하는 경우 예외 처리
+			"Failed to solve workspace code collision"); // Todo: WorkspaceCodeCollisionHandleException 구현
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateService.java
@@ -1,8 +1,9 @@
 package com.uranus.taskmanager.api.workspace.service;
 
+import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
 
 public interface WorkspaceCreateService {
-	public WorkspaceResponse createWorkspace(WorkspaceCreateRequest request);
+	public WorkspaceResponse createWorkspace(WorkspaceCreateRequest request, LoginMemberDto loginMember);
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspace/workspacemember/WorkspaceRole.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/workspacemember/WorkspaceRole.java
@@ -1,7 +1,0 @@
-package com.uranus.taskmanager.api.workspace.workspacemember;
-
-public enum WorkspaceRole {
-	ADMIN,
-	USER,
-	READER
-}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/workspacemember/domain/WorkspaceMember.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/workspacemember/domain/WorkspaceMember.java
@@ -43,16 +43,22 @@ public class WorkspaceMember {
 	private String nickname;
 
 	@Builder
-	public WorkspaceMember(Member member, Workspace workspace) {
+	public WorkspaceMember(Member member, Workspace workspace, WorkspaceRole role, String nickname) {
 		this.member = member;
 		this.workspace = workspace;
+		this.role = role;
+		this.nickname = nickname;
 	}
 
-	public static WorkspaceMember createWorkspaceMember(Member member, Workspace workspace) {
+	public static WorkspaceMember addWorkspaceMember(Member member, Workspace workspace, WorkspaceRole role,
+		String nickname) {
 		WorkspaceMember workspaceMember = WorkspaceMember.builder()
 			.member(member)
 			.workspace(workspace)
+			.role(role)
+			.nickname(nickname)
 			.build();
+
 		member.getWorkspaceMembers().add(workspaceMember);
 		workspace.getWorkspaceMembers().add(workspaceMember);
 		return workspaceMember;

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/WorkspaceRole.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/WorkspaceRole.java
@@ -1,0 +1,7 @@
+package com.uranus.taskmanager.api.workspacemember;
+
+public enum WorkspaceRole {
+	ADMIN,
+	USER,
+	READER
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/AuthorizationInterceptor.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/AuthorizationInterceptor.java
@@ -1,0 +1,115 @@
+package com.uranus.taskmanager.api.workspacemember.authorization;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.uranus.taskmanager.api.auth.SessionKey;
+import com.uranus.taskmanager.api.auth.exception.UserNotLoggedInException;
+import com.uranus.taskmanager.api.workspace.domain.Workspace;
+import com.uranus.taskmanager.api.workspace.exception.WorkspaceNotFoundException;
+import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
+import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspacemember.authorization.exception.InsufficientWorkspaceRoleException;
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspacemember.exception.MemberNotInWorkspaceException;
+import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthorizationInterceptor implements HandlerInterceptor {
+
+	/**
+	 * Todo: 상수 정리
+	 */
+	private static final String WORKSPACE_PREFIX = "/api/v1/workspaces/";
+	private static final int WORKSPACE_PREFIX_LENGTH = WORKSPACE_PREFIX.length();
+
+	private final WorkspaceRepository workspaceRepository;
+	private final WorkspaceMemberRepository workspaceMemberRepository;
+
+	/**
+	 * Todo: preHandle() 가독성 좋은 코드로 리팩토링
+	 */
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		if (handler instanceof HandlerMethod handlerMethod) {
+			RoleRequired roleRequired = handlerMethod.getMethodAnnotation(RoleRequired.class);
+
+			if (roleRequired != null) {
+				// 로그인된 사용자 정보 가져오기 (ArgumentResolver 사용 가능)
+				HttpSession session = request.getSession(false);
+				if (session == null || session.getAttribute(SessionKey.LOGIN_MEMBER) == null) {
+					throw new UserNotLoggedInException();
+				}
+
+				// 로그인된 멤버의 ID 가져오기
+				String loginId = (String)session.getAttribute(SessionKey.LOGIN_MEMBER);
+				log.info("loginId from session = {}", loginId);
+
+				// 요청 URL에서 workspaceCode 추출
+				String uri = request.getRequestURI();
+				String workspaceCode = extractWorkspaceCodeFromUri(uri);
+				log.info("extracted workspaceCode = {}", workspaceCode);
+
+				// workspaceCode를 통해 워크스페이스 찾기
+				Workspace workspace = workspaceRepository.findByWorkspaceCode(workspaceCode)
+					.orElseThrow(WorkspaceNotFoundException::new);
+
+				// 해당 워크스페이스에 대한 사용자의 역할 가져오기
+				WorkspaceMember workspaceMember = workspaceMemberRepository.findByMemberLoginIdAndWorkspaceId(loginId,
+						workspace.getId())
+					.orElseThrow(MemberNotInWorkspaceException::new);
+
+				if (isAccessDenied(workspaceMember.getRole(), roleRequired.roles())) {
+					throw new InsufficientWorkspaceRoleException();
+				}
+			}
+		}
+		return true; // 권한 검사 통과 시 요청 진행
+	}
+
+	/**
+	 * Todo: 리팩터링 필요
+	 * 권한 수준: ADMIN > USER > READER
+	 * 권한에 정수 value를 부여해서 부등호 형식으로 비교하도록 수정해보자
+	 */
+	private boolean isAccessDenied(WorkspaceRole userRole, WorkspaceRole[] requiredRoles) {
+		// 접근 권한이 없을 경우 true 반환
+		for (WorkspaceRole requiredRole : requiredRoles) {
+			if (userRole == WorkspaceRole.ADMIN) {
+				return false; // ADMIN은 모든 권한 허용
+			}
+			if (userRole == WorkspaceRole.USER && (requiredRole == WorkspaceRole.USER
+				|| requiredRole == WorkspaceRole.READER)) {
+				return false; // USER는 USER와 READER API 접근 허용
+			}
+			if (userRole == WorkspaceRole.READER && requiredRole == WorkspaceRole.READER) {
+				return false; // READER는 READER API만 접근 허용
+			}
+		}
+		return true; // 권한이 일치하지 않으면 접근 불가
+	}
+
+	/**
+	 * Todo: 더 좋은 방식이 있는지 찾아보기
+	 * API 설계에 따라 로직이 변할 수 있을 것 같음
+	 */
+	private String extractWorkspaceCodeFromUri(String uri) {
+		// prefix가 URI에 있는지 확인
+		int startIndex = uri.indexOf(WORKSPACE_PREFIX);
+		if (startIndex != -1) {
+			// startIndex + WORKSPACE_PREFIX_LENGTH부터 시작하여 8자리를 잘라내기
+			return uri.substring(startIndex + WORKSPACE_PREFIX_LENGTH, startIndex + WORKSPACE_PREFIX_LENGTH + 8);
+		}
+
+		return ""; // 유효하지 않은 경우 빈 문자열 반환
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/RoleRequired.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/RoleRequired.java
@@ -1,0 +1,14 @@
+package com.uranus.taskmanager.api.workspacemember.authorization;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RoleRequired {
+	WorkspaceRole[] roles(); // 요구되는 권한을 배열로 받는다
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/exception/AuthorizationException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/exception/AuthorizationException.java
@@ -1,0 +1,16 @@
+package com.uranus.taskmanager.api.workspacemember.authorization.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.common.CommonException;
+
+public abstract class AuthorizationException extends CommonException {
+
+	public AuthorizationException(String message, HttpStatus httpStatus) {
+		super(message, httpStatus);
+	}
+
+	public AuthorizationException(String message, HttpStatus httpStatus, Throwable cause) {
+		super(message, httpStatus, cause);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/exception/InsufficientWorkspaceRoleException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/exception/InsufficientWorkspaceRoleException.java
@@ -1,0 +1,21 @@
+package com.uranus.taskmanager.api.workspacemember.authorization.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Todo: 예외를 던질때 필요한 권한을 같이 넘겨서 권한 별로 매세지를 다르게 설정한다
+ * 예시: ADMIN privileges are needed to access this resource
+ */
+public class InsufficientWorkspaceRoleException extends AuthorizationException {
+	private static final String MESSAGE = "Access denied. Please check your permissions.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
+
+	public InsufficientWorkspaceRoleException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public InsufficientWorkspaceRoleException(Throwable cause) {
+		super(MESSAGE, HTTP_STATUS, cause);
+	}
+
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/domain/WorkspaceMember.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/domain/WorkspaceMember.java
@@ -1,8 +1,8 @@
-package com.uranus.taskmanager.api.workspace.workspacemember.domain;
+package com.uranus.taskmanager.api.workspacemember.domain;
 
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
-import com.uranus.taskmanager.api.workspace.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/MemberNotInWorkspaceException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/MemberNotInWorkspaceException.java
@@ -1,0 +1,16 @@
+package com.uranus.taskmanager.api.workspacemember.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class MemberNotInWorkspaceException extends WorkspaceMemberException {
+	private static final String MESSAGE = "Member was not found in the given workspace";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
+
+	public MemberNotInWorkspaceException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public MemberNotInWorkspaceException(Throwable cause) {
+		super(MESSAGE, HTTP_STATUS, cause);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/WorkspaceMemberException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/WorkspaceMemberException.java
@@ -1,0 +1,16 @@
+package com.uranus.taskmanager.api.workspacemember.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.common.CommonException;
+
+public abstract class WorkspaceMemberException extends CommonException {
+
+	public WorkspaceMemberException(String message, HttpStatus httpStatus) {
+		super(message, httpStatus);
+	}
+
+	public WorkspaceMemberException(String message, HttpStatus httpStatus, Throwable cause) {
+		super(message, httpStatus, cause);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/repository/WorkspaceMemberRepository.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/repository/WorkspaceMemberRepository.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.api.workspace.workspacemember.repository;
+package com.uranus.taskmanager.api.workspacemember.repository;
 
 import java.util.List;
 
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
-import com.uranus.taskmanager.api.workspace.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 
 public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember, Long> {
 	List<WorkspaceMember> findByWorkspaceId(Long workspaceId);

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/repository/WorkspaceMemberRepository.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/repository/WorkspaceMemberRepository.java
@@ -1,6 +1,7 @@
 package com.uranus.taskmanager.api.workspacemember.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,6 +11,8 @@ import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 
 public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember, Long> {
 	List<WorkspaceMember> findByWorkspaceId(Long workspaceId);
+
+	Optional<WorkspaceMember> findByMemberLoginIdAndWorkspaceId(String loginId, Long workspaceId);
 
 	boolean existsByMemberAndWorkspace(Member member, Workspace workspace);
 }

--- a/src/test/java/com/uranus/taskmanager/api/auth/controller/AuthenticationControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/auth/controller/AuthenticationControllerTest.java
@@ -22,6 +22,8 @@ import com.uranus.taskmanager.api.auth.dto.response.LoginResponse;
 import com.uranus.taskmanager.api.auth.exception.UserNotLoggedInException;
 import com.uranus.taskmanager.api.auth.service.AuthenticationService;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
+import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
+import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
 
 @WebMvcTest(AuthenticationController.class)
 class AuthenticationControllerTest {
@@ -35,6 +37,10 @@ class AuthenticationControllerTest {
 	private AuthenticationService authenticationService;
 	@MockBean
 	private MemberRepository memberRepository;
+	@MockBean
+	private WorkspaceRepository workspaceRepository;
+	@MockBean
+	private WorkspaceMemberRepository workspaceMemberRepository;
 
 	@Test
 	@DisplayName("로그인에 성공하면 200 OK를 기대하고, 세션에 로그인ID가 저장된다")
@@ -104,14 +110,10 @@ class AuthenticationControllerTest {
 	@Test
 	@DisplayName("로그인 하지 않은 상태에서 로그아웃 시도 시 UserNotLoggedInException 발생")
 	void test4() throws Exception {
-		// given
-
-		// when & then
 		mockMvc.perform(post("/api/v1/auth/logout"))
 			.andExpect(status().isUnauthorized())
 			.andExpect(result -> assertThat(result.getResolvedException()).isInstanceOf(UserNotLoggedInException.class))
 			.andDo(print());
-
 	}
 
 }

--- a/src/test/java/com/uranus/taskmanager/api/auth/controller/AuthenticationControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/auth/controller/AuthenticationControllerTest.java
@@ -21,6 +21,7 @@ import com.uranus.taskmanager.api.auth.dto.request.LoginRequest;
 import com.uranus.taskmanager.api.auth.dto.response.LoginResponse;
 import com.uranus.taskmanager.api.auth.exception.UserNotLoggedInException;
 import com.uranus.taskmanager.api.auth.service.AuthenticationService;
+import com.uranus.taskmanager.api.member.repository.MemberRepository;
 
 @WebMvcTest(AuthenticationController.class)
 class AuthenticationControllerTest {
@@ -32,6 +33,8 @@ class AuthenticationControllerTest {
 	private ObjectMapper objectMapper;
 	@MockBean
 	private AuthenticationService authenticationService;
+	@MockBean
+	private MemberRepository memberRepository;
 
 	@Test
 	@DisplayName("로그인에 성공하면 200 OK를 기대하고, 세션에 로그인ID가 저장된다")

--- a/src/test/java/com/uranus/taskmanager/api/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/member/controller/MemberControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.uranus.taskmanager.api.member.dto.request.SignupRequest;
+import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.member.service.MemberService;
 
 import lombok.extern.slf4j.Slf4j;
@@ -31,11 +32,13 @@ import lombok.extern.slf4j.Slf4j;
 class MemberControllerTest {
 	@Autowired
 	private MockMvc mockMvc;
-
 	@Autowired
 	private ObjectMapper objectMapper;
+	
 	@MockBean
 	private MemberService memberService;
+	@MockBean
+	private MemberRepository memberRepository;
 
 	@Test
 	@DisplayName("회원 가입에 검증을 통과하면 CREATED를 기대한다")

--- a/src/test/java/com/uranus/taskmanager/api/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/member/controller/MemberControllerTest.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.uranus.taskmanager.api.member.dto.request.SignupRequest;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.member.service.MemberService;
+import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
+import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,11 +36,15 @@ class MemberControllerTest {
 	private MockMvc mockMvc;
 	@Autowired
 	private ObjectMapper objectMapper;
-	
+
 	@MockBean
 	private MemberService memberService;
 	@MockBean
 	private MemberRepository memberRepository;
+	@MockBean
+	private WorkspaceRepository workspaceRepository;
+	@MockBean
+	private WorkspaceMemberRepository workspaceMemberRepository;
 
 	@Test
 	@DisplayName("회원 가입에 검증을 통과하면 CREATED를 기대한다")

--- a/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
@@ -24,6 +24,8 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.uranus.taskmanager.api.auth.SessionKey;
+import com.uranus.taskmanager.api.global.config.WebMvcConfig;
+import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
 import com.uranus.taskmanager.api.workspace.service.CheckCodeDuplicationService;
@@ -44,6 +46,10 @@ class WorkspaceControllerTest {
 	private WorkspaceService workspaceService;
 	@MockBean
 	private CheckCodeDuplicationService workspaceCreateService;
+	@MockBean
+	private MemberRepository memberRepository;
+	@MockBean
+	private WebMvcConfig webMvcConfig;
 
 	@Test
 	@DisplayName("워크스페이스 생성: 검증을 통과하면 CREATED를 기대한다")

--- a/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
@@ -28,8 +28,10 @@ import com.uranus.taskmanager.api.global.config.WebMvcConfig;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
+import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.service.CheckCodeDuplicationService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceService;
+import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -48,6 +50,10 @@ class WorkspaceControllerTest {
 	private CheckCodeDuplicationService workspaceCreateService;
 	@MockBean
 	private MemberRepository memberRepository;
+	@MockBean
+	private WorkspaceRepository workspaceRepository;
+	@MockBean
+	private WorkspaceMemberRepository workspaceMemberRepository;
 	@MockBean
 	private WebMvcConfig webMvcConfig;
 

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTest.java
@@ -1,0 +1,203 @@
+package com.uranus.taskmanager.api.workspace.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.member.repository.MemberRepository;
+import com.uranus.taskmanager.api.workspace.domain.Workspace;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
+import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
+import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
+import com.uranus.taskmanager.api.workspace.util.WorkspaceCodeGenerator;
+import com.uranus.taskmanager.api.workspace.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspace.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspace.workspacemember.repository.WorkspaceMemberRepository;
+import com.uranus.taskmanager.fixture.MockFixture;
+
+@ExtendWith(MockitoExtension.class)
+class WorkspaceCreateServiceTest {
+
+	@InjectMocks
+	private CheckCodeDuplicationService workspaceCreateService;
+
+	@Mock
+	private WorkspaceCodeGenerator workspaceCodeGenerator;
+	@Mock
+	private WorkspaceRepository workspaceRepository;
+	@Mock
+	private MemberRepository memberRepository;
+	@Mock
+	private WorkspaceMemberRepository workspaceMemberRepository;
+
+	MockFixture mockFixture;
+
+	@BeforeEach
+	public void setup() {
+		mockFixture = new MockFixture();
+	}
+
+	@Test
+	@DisplayName("워크스페이스 생성에는 생성 요청과 로그인 멤버를 필요로 한다")
+	void test1() {
+		// given
+		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
+			.name("test name")
+			.description("test description")
+			.build();
+
+		Workspace mockWorkspace = mockFixture.mockWorkspace("testcode");
+		Member mockMember = mockFixture.mockMember("user123", "test@test.com");
+		LoginMemberDto mockLoginMember = mockFixture.mockLoginMember("user123", "test@test.com");
+
+		when(memberRepository.findByLoginId(mockLoginMember.getLoginId())).thenReturn(Optional.of(mockMember));
+		when(workspaceRepository.save(any(Workspace.class))).thenReturn(mockWorkspace);
+
+		// when
+		WorkspaceResponse response = workspaceCreateService.createWorkspace(request, mockLoginMember);
+
+		// then
+		assertThat(response).isNotNull();
+		verify(memberRepository, times(1)).findByLoginId("user123");
+	}
+
+	@Test
+	@DisplayName("워크스페이스 생성을 성공하면 WorkspaceResponse를 반환한다")
+	void test2() {
+		// given
+		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
+			.name("test name")
+			.description("test description")
+			.build();
+
+		Workspace mockWorkspace = mockFixture.mockWorkspace("testcode");
+		Member mockMember = mockFixture.mockMember("user123", "test@test.com");
+		LoginMemberDto mockLoginMember = mockFixture.mockLoginMember("user123", "test@test.com");
+
+		when(memberRepository.findByLoginId(mockLoginMember.getLoginId())).thenReturn(Optional.of(mockMember));
+		when(workspaceRepository.save(any(Workspace.class))).thenReturn(mockWorkspace);
+
+		// when
+		WorkspaceResponse response = workspaceCreateService.createWorkspace(request, mockLoginMember);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.getName()).isEqualTo("test name");
+		assertThat(response.getDescription()).isEqualTo("test description");
+		assertThat(response.getWorkspaceCode()).isEqualTo("testcode");
+		verify(workspaceRepository, times(1)).save(any(Workspace.class));
+	}
+
+	@Test
+	@DisplayName("워크스페이스 코드가 중복될 때 최대 재시도 횟수(5회)를 소진하면 예외가 발생한다")
+	void test3() {
+		// given
+		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
+			.name("test name")
+			.description("test description")
+			.build();
+
+		Member mockMember = mockFixture.mockMember("user123", "test@test.com");
+		LoginMemberDto mockLoginMember = mockFixture.mockLoginMember("user123", "test@test.com");
+		when(memberRepository.findByLoginId(mockLoginMember.getLoginId())).thenReturn(Optional.of(mockMember));
+
+		when(workspaceCodeGenerator.generateWorkspaceCode())
+			.thenReturn("WORK123", "WORK124", "WORK125", "WORK126", "WORK127");
+		when(workspaceRepository.existsByWorkspaceCode(anyString())).thenReturn(true);
+
+		// when & then
+		assertThatThrownBy(() -> workspaceCreateService.createWorkspace(request, mockLoginMember))
+			.isInstanceOf(RuntimeException.class)  // Todo: WorkspaceCodeCollisionHandleException 구현 후 수정
+			.hasMessageContaining("Failed to solve workspace code collision");
+	}
+
+	@Test
+	@DisplayName("워크스페이스 생성 시 WorkspaceMember도 생성되고 저장된다")
+	void test4() {
+		// given
+		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
+			.name("test name")
+			.description("test description")
+			.build();
+
+		Workspace mockWorkspace = mockFixture.mockWorkspace("testcode");
+		Member mockMember = mockFixture.mockMember("user123", "test@test.com");
+		LoginMemberDto mockLoginMember = mockFixture.mockLoginMember("user123", "test@test.com");
+		WorkspaceMember mockWorkspaceMember = mockFixture.mockAdminWorkspaceMember(mockMember, mockWorkspace);
+		when(memberRepository.findByLoginId(mockLoginMember.getLoginId())).thenReturn(Optional.of(mockMember));
+		when(workspaceRepository.save(any(Workspace.class))).thenReturn(mockWorkspace);
+		when(workspaceMemberRepository.save(any(WorkspaceMember.class))).thenReturn(mockWorkspaceMember);
+
+		// when
+		workspaceCreateService.createWorkspace(request, mockLoginMember);
+
+		// then
+		verify(workspaceMemberRepository, times(1)).save(any(WorkspaceMember.class));
+	}
+
+	@Test
+	@DisplayName("워크스페이스 생성 시 WorkspaceMember의 별칭은 생성자의 이메일로 설정된다")
+	void test5() {
+		// given
+		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
+			.name("test name")
+			.description("test description")
+			.build();
+
+		Workspace mockWorkspace = mockFixture.mockWorkspace("testcode");
+		Member mockMember = mockFixture.mockMember("user123", "test@test.com");
+		LoginMemberDto mockLoginMember = mockFixture.mockLoginMember("user123", "test@test.com");
+		WorkspaceMember mockWorkspaceMember = mockFixture.mockAdminWorkspaceMember(mockMember, mockWorkspace);
+
+		when(memberRepository.findByLoginId(mockLoginMember.getLoginId())).thenReturn(Optional.of(mockMember));
+		when(workspaceRepository.save(any(Workspace.class))).thenReturn(mockWorkspace);
+		when(workspaceMemberRepository.save(any(WorkspaceMember.class))).thenReturn(mockWorkspaceMember);
+
+		// when
+		workspaceCreateService.createWorkspace(request, mockLoginMember);
+
+		// then
+		verify(workspaceMemberRepository, times(1)).save(argThat(workspaceMember ->
+			workspaceMember.getNickname().equals("test@test.com")
+		));
+	}
+
+	@Test
+	@DisplayName("워크스페이스 생성 시 WorkspaceMember의 권한은 ADMIN으로 설정된다")
+	void test6() {
+		// given
+		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
+			.name("test name")
+			.description("test description")
+			.build();
+
+		Workspace mockWorkspace = mockFixture.mockWorkspace("testcode");
+		Member mockMember = mockFixture.mockMember("user123", "test@test.com");
+		LoginMemberDto mockLoginMember = mockFixture.mockLoginMember("user123", "test@test.com");
+		WorkspaceMember mockWorkspaceMember = mockFixture.mockAdminWorkspaceMember(mockMember, mockWorkspace);
+
+		when(memberRepository.findByLoginId(mockLoginMember.getLoginId())).thenReturn(Optional.of(mockMember));
+		when(workspaceRepository.save(any(Workspace.class))).thenReturn(mockWorkspace);
+		when(workspaceMemberRepository.save(any(WorkspaceMember.class))).thenReturn(mockWorkspaceMember);
+
+		// when
+		workspaceCreateService.createWorkspace(request, mockLoginMember);
+
+		// then
+		verify(workspaceMemberRepository, times(1)).save(argThat(workspaceMember ->
+			workspaceMember.getRole().equals(WorkspaceRole.ADMIN)
+		));
+	}
+}

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTest.java
@@ -22,9 +22,9 @@ import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.util.WorkspaceCodeGenerator;
-import com.uranus.taskmanager.api.workspace.workspacemember.WorkspaceRole;
-import com.uranus.taskmanager.api.workspace.workspacemember.domain.WorkspaceMember;
-import com.uranus.taskmanager.api.workspace.workspacemember.repository.WorkspaceMemberRepository;
+import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
 import com.uranus.taskmanager.fixture.MockFixture;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceServiceTest.java
@@ -1,7 +1,6 @@
 package com.uranus.taskmanager.api.workspace.service;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.util.Optional;
@@ -15,10 +14,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
-import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
-import com.uranus.taskmanager.api.workspace.util.WorkspaceCodeGenerator;
 
 @ExtendWith(MockitoExtension.class)
 class WorkspaceServiceTest {
@@ -26,39 +23,13 @@ class WorkspaceServiceTest {
 	@InjectMocks
 	private WorkspaceService workspaceService;
 
-	@InjectMocks
-	private CheckCodeDuplicationService workspaceCreateService;
-
-	@Mock
-	private WorkspaceCodeGenerator workspaceCodeGenerator;
 	@Mock
 	private WorkspaceRepository workspaceRepository;
 
 	@Test
-	@DisplayName("워크스페이스 생성 요청 시 새로운 워크스페이스가 생성되고 workspaceCode가 설정된 후, WorkspaceResponse를 반환한다")
-	void test1() {
-		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
-			.name("Test Workspace")
-			.description("Test Description")
-			.build();
-		Workspace mockWorkspace = Workspace.builder()
-			.name("Test Workspace")
-			.description("Test Description")
-			.build();
-
-		when(workspaceRepository.save(any(Workspace.class))).thenReturn(mockWorkspace);
-		WorkspaceResponse response = workspaceCreateService.createWorkspace(request);
-
-		assertThat(response).isNotNull();
-		assertThat(response.getName()).isEqualTo("Test Workspace");
-		verify(workspaceRepository, times(1)).save(any(Workspace.class));
-
-	}
-
-	@Test
 	@DisplayName("유효한 workspaceCode로 워크스페이스를 조회하면, 워크스페이스를 반환한다.")
 	void test2() {
-		String workspaceCode = UUID.randomUUID().toString();
+		String workspaceCode = "testcode";
 		Workspace mockWorkspace = Workspace.builder()
 			.workspaceCode(workspaceCode)
 			.name("Test Workspace")

--- a/src/test/java/com/uranus/taskmanager/basetest/BaseIntegrationTest.java
+++ b/src/test/java/com/uranus/taskmanager/basetest/BaseIntegrationTest.java
@@ -9,6 +9,7 @@ import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.member.service.MemberService;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.service.CheckCodeDuplicationService;
+import com.uranus.taskmanager.api.workspace.workspacemember.repository.WorkspaceMemberRepository;
 import com.uranus.taskmanager.fixture.RestAssuredAuthenticationFixture;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -25,6 +26,8 @@ public abstract class BaseIntegrationTest {
 	protected WorkspaceRepository workspaceRepository;
 	@Autowired
 	protected MemberRepository memberRepository;
+	@Autowired
+	protected WorkspaceMemberRepository workspaceMemberRepository;
 	@Autowired
 	protected RestAssuredAuthenticationFixture restAssuredAuthenticationFixture;
 }

--- a/src/test/java/com/uranus/taskmanager/basetest/BaseIntegrationTest.java
+++ b/src/test/java/com/uranus/taskmanager/basetest/BaseIntegrationTest.java
@@ -9,7 +9,7 @@ import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.member.service.MemberService;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.service.CheckCodeDuplicationService;
-import com.uranus.taskmanager.api.workspace.workspacemember.repository.WorkspaceMemberRepository;
+import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
 import com.uranus.taskmanager.fixture.RestAssuredAuthenticationFixture;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)

--- a/src/test/java/com/uranus/taskmanager/fixture/MockFixture.java
+++ b/src/test/java/com/uranus/taskmanager/fixture/MockFixture.java
@@ -3,8 +3,8 @@ package com.uranus.taskmanager.fixture;
 import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
-import com.uranus.taskmanager.api.workspace.workspacemember.WorkspaceRole;
-import com.uranus.taskmanager.api.workspace.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 
 public class MockFixture {
 

--- a/src/test/java/com/uranus/taskmanager/fixture/MockFixture.java
+++ b/src/test/java/com/uranus/taskmanager/fixture/MockFixture.java
@@ -1,0 +1,38 @@
+package com.uranus.taskmanager.fixture;
+
+import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.workspace.domain.Workspace;
+import com.uranus.taskmanager.api.workspace.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspace.workspacemember.domain.WorkspaceMember;
+
+public class MockFixture {
+
+	public Workspace mockWorkspace(String workspaceCode) {
+		return Workspace.builder()
+			.workspaceCode(workspaceCode)
+			.name("test name")
+			.description("test description")
+			.build();
+	}
+
+	public Member mockMember(String loginId, String email) {
+		return Member.builder()
+			.loginId(loginId)
+			.email(email)
+			.password("test1234!")
+			.build();
+	}
+
+	public WorkspaceMember mockAdminWorkspaceMember(Member mockMember, Workspace mockWorkspace) {
+		return WorkspaceMember.addWorkspaceMember(mockMember, mockWorkspace, WorkspaceRole.ADMIN,
+			mockMember.getEmail());
+	}
+
+	public LoginMemberDto mockLoginMember(String loginId, String email) {
+		return LoginMemberDto.builder()
+			.loginId(loginId)
+			.email(email)
+			.build();
+	}
+}

--- a/src/test/java/com/uranus/taskmanager/integrationtest/WorkspaceControllerIntegrationTest.java
+++ b/src/test/java/com/uranus/taskmanager/integrationtest/WorkspaceControllerIntegrationTest.java
@@ -15,11 +15,23 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
-class WorkspaceCreateIntegrationTest extends BaseIntegrationTest {
+class WorkspaceControllerIntegrationTest extends BaseIntegrationTest {
 
+	/**
+	 * Todo: Workspace와 WorkspaceMember 엔티티 간의 외래 키 제약 조건으로 인한 문제 발생
+	 * Workspace 엔티티를 삭제하려고 할 때, 해당 Workspace와 연결된 WorkspaceMember 엔티티 레코드가 존재하기 때문에
+	 * 참조 무결성 위반 문제가 발생한다
+	 * 쉽게 말해서, WorkspaceMember 테이블에서 Workspace에 대한 외래 키 제약 조건이 설정되어 있어서,
+	 * 해당 Workspace를 먼저 삭제하려면 해당 외래 키로 참조하는 모든 WorkspaceMember 레코드를 먼저 삭제해야 한다
+	 * <p>
+	 * 해결 1: workspaceMemberRepository.deleteAll()을 제일 먼저 수행한다
+	 * 해결 2: CascadeType.REMOVE을 사용한다
+	 * - 예시: Workspace 엔티티에서 연관관계 매핑과 관련해서 cascade = CascadeType.ALL, orphanRemoval = true을 사용한다
+	 */
 	@BeforeEach
 	public void setup() {
 		RestAssured.port = port;
+		workspaceMemberRepository.deleteAll();
 		workspaceRepository.deleteAll();
 		memberRepository.deleteAll();
 	}
@@ -48,7 +60,6 @@ class WorkspaceCreateIntegrationTest extends BaseIntegrationTest {
 			.body("data.description", equalTo("Test Description"))
 			.body("data.workspaceCode", notNullValue())
 			.extract().response();
-
 	}
 
 	@Test


### PR DESCRIPTION
## 🚀 설명
- `ArgumentResolver`를 사용해서 로그인 정보를 읽어와서 `WorkspaceMember`를 추가하는 로직 추가
- 인터셉터를 사용해서 커스텀 애노테이션인 `@RoleRequired`를 통해 필요한 권한을 명시하고 검증하는 로직 추가
- 

---
## ✅ 변경 사항
- [x] `LoginMemberArgumentResolver` 추가
- [x] `RoleRequired` 추가
- [x] `AuthorizationInterceptor` 추가
- [x] 필요한 예외 추가

---
## 🚩 관련 이슈, PR
- #38 
- #30 

---
## 📖 참고