### PR TITLE
Feat/#40 workspace participation v2

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/auth/AuthenticationInterceptor.java
+++ b/src/main/java/com/uranus/taskmanager/api/auth/AuthenticationInterceptor.java
@@ -9,13 +9,16 @@ import com.uranus.taskmanager.api.auth.exception.UserNotLoggedInException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 public class AuthenticationInterceptor implements HandlerInterceptor {
 
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
 		if (handler instanceof HandlerMethod method) {
+			log.info("[AuthenticationInterceptor Invoked]");
 			LoginRequired loginRequired = method.getMethodAnnotation(LoginRequired.class);
 			if (loginRequired != null) {
 				HttpSession session = request.getSession(false);

--- a/src/main/java/com/uranus/taskmanager/api/auth/exception/InvalidLoginPasswordException.java
+++ b/src/main/java/com/uranus/taskmanager/api/auth/exception/InvalidLoginPasswordException.java
@@ -2,11 +2,9 @@ package com.uranus.taskmanager.api.auth.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.auth.exception.AuthenticationException;
-
 public class InvalidLoginPasswordException extends AuthenticationException {
 
-	private static final String MESSAGE = "Please provide a valid login pasword.";
+	private static final String MESSAGE = "The given login password is invalid";
 	private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
 
 	public InvalidLoginPasswordException() {

--- a/src/main/java/com/uranus/taskmanager/api/workspace/config/WorkspaceConfig.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/config/WorkspaceConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
+import com.uranus.taskmanager.api.security.PasswordEncoder;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.service.CheckCodeDuplicationService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceCreateService;
@@ -23,6 +24,7 @@ public class WorkspaceConfig {
 	private final MemberRepository memberRepository;
 	private final WorkspaceMemberRepository workspaceMemberRepository;
 	private final WorkspaceCodeGenerator workspaceCodeGenerator;
+	private final PasswordEncoder passwordEncoder;
 
 	/**
 	 * HandleDatabaseExceptionService: DB에서 올라오는 ConstraintViolation을 잡아서 핸들링(워크스페이스 코드 재생성)
@@ -33,6 +35,7 @@ public class WorkspaceConfig {
 		return new CheckCodeDuplicationService(workspaceRepository,
 			memberRepository,
 			workspaceMemberRepository,
-			workspaceCodeGenerator);
+			workspaceCodeGenerator,
+			passwordEncoder);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
@@ -16,8 +16,10 @@ import com.uranus.taskmanager.api.common.ApiResponse;
 import com.uranus.taskmanager.api.workspace.dto.request.InviteMemberRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.InviteMembersRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceParticipateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.InviteMemberResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.InviteMembersResponse;
+import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceParticipateResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceCreateService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceService;
@@ -35,11 +37,6 @@ import lombok.extern.slf4j.Slf4j;
 public class WorkspaceController {
 
 	/**
-	 * Todo 1
-	 * 워크스페이스 관련 모든 작업은 기본적으로 @LoginRequired 필요
-	 * 워크스페이스 내의 권한 자격을 나타내는 @Role 구현
-	 * 특정 워크스페이스의 이름, 설명 수정은 @Role({"ADMIN"})
-	 * 특정 워크스페이스의 삭제는 @Role({"ADMIN"})
 	 * Todo 2
 	 * 워크스페이스 생성(비밀번호 설정 추가)
 	 * 워크스페이스 이름, 설명 수정
@@ -97,6 +94,18 @@ public class WorkspaceController {
 
 		InviteMembersResponse response = workspaceService.inviteMembers(code, request, loginMember);
 		return ApiResponse.ok("Members Invited", response);
+	}
+
+	@LoginRequired
+	@PostMapping("/{code}")
+	public ApiResponse<WorkspaceParticipateResponse> participateWorkspace(
+		@PathVariable String code,
+		@LoginMember LoginMemberDto loginMember,
+		@RequestBody @Valid WorkspaceParticipateRequest request
+	) {
+
+		WorkspaceParticipateResponse response = workspaceService.participateWorkspace(code, request, loginMember);
+		return ApiResponse.ok("Joined Workspace", response);
 	}
 
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/WorkspaceCreateRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/WorkspaceCreateRequest.java
@@ -25,12 +25,16 @@ public class WorkspaceCreateRequest {
 	@Pattern(regexp = "^(?!.*[가-힣])(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,30}",
 		message = "The password must be alphanumeric"
 			+ " including at least one special character and must be between 8 and 30 characters")
-	private final String password;
+	private String password;
 
 	private String code;
 
 	public void setCode(String code) {
 		this.code = code;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
 	}
 
 	public Workspace toEntity() {

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/WorkspaceParticipateRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/WorkspaceParticipateRequest.java
@@ -1,0 +1,21 @@
+package com.uranus.taskmanager.api.workspace.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class WorkspaceParticipateRequest {
+	/*
+	 * Todo:
+	 * 	- 비밀번호 필드(Optional)
+	 * 	- 패턴 검증만 해도 될듯
+	 */
+
+	private String password;
+
+	public WorkspaceParticipateRequest() {
+	}
+
+	public WorkspaceParticipateRequest(String password) {
+		this.password = password;
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/WorkspaceParticipateResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/WorkspaceParticipateResponse.java
@@ -1,0 +1,57 @@
+package com.uranus.taskmanager.api.workspace.dto.response;
+
+import com.uranus.taskmanager.api.workspace.domain.Workspace;
+import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class WorkspaceParticipateResponse {
+
+	/*
+	 * Todo:
+	 *  - 참여한 워크스페이스의 상세 정보
+	 *  - 이름
+	 *  - 설명
+	 *  - 코드
+	 *  - 인원(Box 사용) - 인원 계산을 서비스 vs 엔티티에서?
+	 *  - 인원 계산에 캐시 적용 찾아보기(변동 시점에만 갱신하기)
+	 *  - 현재 내 별칭
+	 *  - 현재 내 권한
+	 *  - fromEntity(): Workspace, WorkspaceMember -> WorkspaceParticipateResponse
+	 */
+	private final String name;
+	private final String description;
+	private final String code;
+	private final int headcount;
+	private final String nickname;
+	private final WorkspaceRole myRole;
+	private final boolean isAlreadyMember;
+
+	@Builder
+	public WorkspaceParticipateResponse(String name, String description, String code, int headcount, String nickname,
+		WorkspaceRole myRole, boolean isAlreadyMember) {
+		this.name = name;
+		this.description = description;
+		this.code = code;
+		this.headcount = headcount;
+		this.nickname = nickname;
+		this.myRole = myRole;
+		this.isAlreadyMember = isAlreadyMember;
+	}
+
+	public static WorkspaceParticipateResponse from(Workspace workspace, WorkspaceMember workspaceMember,
+		int headcount, boolean isAlreadyMember) {
+		return WorkspaceParticipateResponse.builder()
+			.name(workspace.getName())
+			.description(workspace.getDescription())
+			.code(workspace.getCode())
+			.headcount(headcount)
+			.nickname(workspaceMember.getNickname())
+			.myRole(workspaceMember.getRole())
+			.isAlreadyMember(isAlreadyMember)
+			.build();
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/exception/InvalidWorkspacePasswordException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/exception/InvalidWorkspacePasswordException.java
@@ -1,0 +1,18 @@
+package com.uranus.taskmanager.api.workspace.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.auth.exception.AuthenticationException;
+
+public class InvalidWorkspacePasswordException extends AuthenticationException {
+	private static final String MESSAGE = "The given workspace password is invalid";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
+
+	public InvalidWorkspacePasswordException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public InvalidWorkspacePasswordException(Throwable cause) {
+		super(MESSAGE, HTTP_STATUS, cause);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
@@ -7,6 +7,7 @@ import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.member.exception.MemberNotFoundException;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
+import com.uranus.taskmanager.api.security.PasswordEncoder;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
@@ -33,6 +34,7 @@ public class CheckCodeDuplicationService implements WorkspaceCreateService {
 	private final MemberRepository memberRepository;
 	private final WorkspaceMemberRepository workspaceMemberRepository;
 	private final WorkspaceCodeGenerator workspaceCodeGenerator;
+	private final PasswordEncoder passwordEncoder;
 
 	/**
 	 * Todo: createWorkspace() 가독성 좋은 코드로 리팩토링
@@ -65,9 +67,21 @@ public class CheckCodeDuplicationService implements WorkspaceCreateService {
 			String code = workspaceCodeGenerator.generateWorkspaceCode();
 			if (workspaceCodeIsNotDuplicate(code)) {
 				log.info("[workspaceCodeIsNotDuplicate] code = {}", code);
+
+				// 요청 DTO 객체에 생성된 code 설정
 				request.setCode(code);
+
+				// 요청 DTO 객체에 비밀번호를 꺼내고 암호화하고 설정
+				// Todo: null 대신 Optional을 사용, Optional은 바로 해소하도록 로직 작성
+				if (request.getPassword() != null) {
+					String encodedPassword = passwordEncoder.encode(request.getPassword());
+					request.setPassword(encodedPassword);
+				}
+
+				// 요청 DTO를 사용해서 워크스페이스 엔티티로 만들고 저장
 				Workspace workspace = workspaceRepository.save(request.toEntity());
 
+				// 워크스페이스 멤버 생성 및 저장
 				WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace,
 					WorkspaceRole.ADMIN,
 					member.getEmail());

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/repository/WorkspaceMemberRepository.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/repository/WorkspaceMemberRepository.java
@@ -16,5 +16,7 @@ public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember
 
 	Optional<WorkspaceMember> findByMemberLoginIdAndWorkspaceCode(String loginId, String workspaceCode);
 
+	int countByWorkspaceId(Long workspaceId);
+
 	boolean existsByMemberAndWorkspace(Member member, Workspace workspace);
 }

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.uranus.taskmanager.api.auth.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
+import com.uranus.taskmanager.api.security.PasswordEncoder;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
@@ -41,6 +42,8 @@ class WorkspaceCreateServiceTest {
 	private MemberRepository memberRepository;
 	@Mock
 	private WorkspaceMemberRepository workspaceMemberRepository;
+	@Mock
+	private PasswordEncoder passwordEncoder;
 
 	TestFixture testFixture;
 

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceServiceTest.java
@@ -22,12 +22,16 @@ import com.uranus.taskmanager.api.invitation.repository.InvitationRepository;
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.member.exception.MemberNotFoundException;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
+import com.uranus.taskmanager.api.security.PasswordEncoder;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspace.dto.request.InviteMemberRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.InviteMembersRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceParticipateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.InviteMemberResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.InviteMembersResponse;
+import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceParticipateResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceResponse;
+import com.uranus.taskmanager.api.workspace.exception.InvalidWorkspacePasswordException;
 import com.uranus.taskmanager.api.workspace.exception.WorkspaceNotFoundException;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
@@ -52,6 +56,8 @@ class WorkspaceServiceTest {
 	private WorkspaceMemberRepository workspaceMemberRepository;
 	@Mock
 	private InvitationRepository invitationRepository;
+	@Mock
+	private PasswordEncoder passwordEncoder;
 
 	TestFixture testFixture;
 
@@ -70,8 +76,7 @@ class WorkspaceServiceTest {
 			.description("Test Description")
 			.build();
 
-		when(workspaceRepository.findByCode(workspaceCode))
-			.thenReturn(Optional.of(workspace));
+		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
 
 		WorkspaceResponse response = workspaceService.get(workspaceCode);
 
@@ -85,11 +90,9 @@ class WorkspaceServiceTest {
 	void test3() {
 		String workspaceCode = "INVALIDCODE";
 
-		when(workspaceRepository.findByCode(workspaceCode))
-			.thenReturn(Optional.empty());
+		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.empty());
 
-		assertThatThrownBy(() -> workspaceService.get(workspaceCode))
-			.isInstanceOf(WorkspaceNotFoundException.class);
+		assertThatThrownBy(() -> workspaceService.get(workspaceCode)).isInstanceOf(WorkspaceNotFoundException.class);
 
 		verify(workspaceRepository, times(1)).findByCode(workspaceCode);
 	}
@@ -113,11 +116,9 @@ class WorkspaceServiceTest {
 		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(invitedLoginId);
 		String identifier = inviteMemberRequest.getMemberIdentifier();
 
-		when(workspaceRepository.findByCode(workspaceCode))
-			.thenReturn(Optional.of(workspace));
+		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
 
-		when(memberRepository.findByLoginIdOrEmail(identifier, identifier))
-			.thenReturn(Optional.of(invitedMember));
+		when(memberRepository.findByLoginIdOrEmail(identifier, identifier)).thenReturn(Optional.of(invitedMember));
 
 		// when
 		InviteMemberResponse inviteMemberResponse = workspaceService.inviteMember(workspaceCode, inviteMemberRequest,
@@ -142,13 +143,12 @@ class WorkspaceServiceTest {
 
 		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(invitedLoginId);
 
-		when(workspaceRepository.findByCode(workspaceCode))
-			.thenReturn(Optional.empty());
+		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.empty());
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest, loginMember)).isInstanceOf(
-			WorkspaceNotFoundException.class);
+			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest, loginMember))
+			.isInstanceOf(WorkspaceNotFoundException.class);
 
 	}
 
@@ -168,16 +168,14 @@ class WorkspaceServiceTest {
 		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(invitedLoginId);
 		String identifier = inviteMemberRequest.getMemberIdentifier();
 
-		when(workspaceRepository.findByCode(workspaceCode))
-			.thenReturn(Optional.of(workspace));
+		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
 
-		when(memberRepository.findByLoginIdOrEmail(identifier, identifier))
-			.thenReturn(Optional.empty());
+		when(memberRepository.findByLoginIdOrEmail(identifier, identifier)).thenReturn(Optional.empty());
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest, loginMember)).isInstanceOf(
-			MemberNotFoundException.class);
+			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest, loginMember))
+			.isInstanceOf(MemberNotFoundException.class);
 	}
 
 	@Test
@@ -200,11 +198,9 @@ class WorkspaceServiceTest {
 		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(invitedLoginId);
 		String identifier = inviteMemberRequest.getMemberIdentifier();
 
-		when(workspaceRepository.findByCode(workspaceCode))
-			.thenReturn(Optional.of(workspace));
+		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
 
-		when(memberRepository.findByLoginIdOrEmail(identifier, identifier))
-			.thenReturn(Optional.of(invitedMember));
+		when(memberRepository.findByLoginIdOrEmail(identifier, identifier)).thenReturn(Optional.of(invitedMember));
 
 		when(invitationRepository.findByWorkspaceAndMember(workspace, invitedMember)).thenReturn(
 			Optional.of(invitation));
@@ -235,19 +231,17 @@ class WorkspaceServiceTest {
 		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(invitedLoginId);
 		String identifier = inviteMemberRequest.getMemberIdentifier();
 
-		when(workspaceRepository.findByCode(workspaceCode))
-			.thenReturn(Optional.of(workspace));
+		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
 
-		when(memberRepository.findByLoginIdOrEmail(identifier, identifier))
-			.thenReturn(Optional.of(invitedMember));
+		when(memberRepository.findByLoginIdOrEmail(identifier, identifier)).thenReturn(Optional.of(invitedMember));
 
-		when(workspaceMemberRepository.findByMemberLoginIdAndWorkspaceCode(invitedLoginId, workspaceCode))
-			.thenReturn(Optional.of(workspaceMember));
+		when(workspaceMemberRepository.findByMemberLoginIdAndWorkspaceCode(invitedLoginId, workspaceCode)).thenReturn(
+			Optional.of(workspaceMember));
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest, loginMember)).isInstanceOf(
-			MemberAlreadyParticipatingException.class);
+			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest, loginMember))
+			.isInstanceOf(MemberAlreadyParticipatingException.class);
 	}
 
 	@Test
@@ -273,26 +267,111 @@ class WorkspaceServiceTest {
 		// Mock Member
 		Member member1 = testFixture.createMember(member1Id, member1Email);
 		Member member2 = testFixture.createMember(member2Id, member2Email);
-		when(memberRepository.findByLoginIdOrEmail(member1Id, member1Id))
-			.thenReturn(Optional.of(member1));
-		when(memberRepository.findByLoginIdOrEmail(member2Id, member2Id))
-			.thenReturn(Optional.of(member2));
+		when(memberRepository.findByLoginIdOrEmail(member1Id, member1Id)).thenReturn(Optional.of(member1));
+		when(memberRepository.findByLoginIdOrEmail(member2Id, member2Id)).thenReturn(Optional.of(member2));
 
 		// Mock Invitation
 		Invitation invitation1 = testFixture.createPendingInvitation(workspace, member1);
 		Invitation invitation2 = testFixture.createPendingInvitation(workspace, member2);
-		when(invitationRepository.save(any(Invitation.class)))
-			.thenReturn(invitation1).thenReturn(invitation2);
+		when(invitationRepository.save(any(Invitation.class))).thenReturn(invitation1).thenReturn(invitation2);
 
-		// then
+		// when
 		InviteMembersResponse response = workspaceService.inviteMembers(workspaceCode, inviteMembersRequest,
 			loginMember);
 
 		log.info("response = {}", response);
 
+		// then
 		assertThat(response.getInvitedMembers().size()).isEqualTo(2);
 		assertThat(response.getFailedInvitedMembers()).isEmpty();
 
 	}
 
+	@Test
+	@DisplayName("워크스페이스 참여가 성공하는 경우 참여 응답 DTO를 데이터로 제공하고, 참여 플래그는 False이다")
+	void test10() {
+		// given
+		String workspaceCode = "TESTCODE";
+		String loginId = "user123";
+		String email = "user123@test.com";
+		String workspacePassword = "workspace1234!";
+
+		Workspace workspace = testFixture.createWorkspaceWithPassword(workspaceCode, workspacePassword);
+		Member member = testFixture.createMember(loginId, email);
+		LoginMemberDto loginMember = testFixture.createLoginMemberDto(loginId, email);
+		WorkspaceParticipateRequest request = new WorkspaceParticipateRequest(workspace.getPassword());
+
+		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
+		when(memberRepository.findByLoginId(loginMember.getLoginId())).thenReturn(Optional.of(member));
+		when(workspaceMemberRepository.countByWorkspaceId(workspace.getId())).thenReturn(3);
+		when(workspaceMemberRepository.findByMemberLoginIdAndWorkspaceCode(loginMember.getLoginId(), workspaceCode))
+			.thenReturn(Optional.empty());
+		when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
+
+		// when
+		WorkspaceParticipateResponse response = workspaceService.participateWorkspace(workspaceCode, request,
+			loginMember);
+
+		// then
+		assertThat(response.isAlreadyMember()).isFalse();
+		assertThat(response.getCode()).isEqualTo(workspaceCode);
+		assertThat(response.getHeadcount()).isEqualTo(3);
+	}
+
+	@Test
+	@DisplayName("워크스페이스 참여 시 이미 참여하고 있는 경우 정상 응답을 하되, 참여 플래그는 True이다")
+	void test11() {
+		// given
+		String workspaceCode = "TESTCODE";
+		String loginId = "user123";
+		String email = "user123@test.com";
+		String workspacePassword = "workspace1234!";
+
+		Workspace workspace = testFixture.createWorkspaceWithPassword(workspaceCode, workspacePassword);
+		Member member = testFixture.createMember(loginId, email);
+		LoginMemberDto loginMember = testFixture.createLoginMemberDto(loginId, email);
+		WorkspaceMember workspaceMember = testFixture.createUserWorkspaceMember(member, workspace);
+		WorkspaceParticipateRequest request = new WorkspaceParticipateRequest(workspace.getPassword());
+
+		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
+		when(memberRepository.findByLoginId(loginMember.getLoginId())).thenReturn(Optional.of(member));
+		when(workspaceMemberRepository.countByWorkspaceId(workspace.getId())).thenReturn(3);
+		when(workspaceMemberRepository.findByMemberLoginIdAndWorkspaceCode(loginMember.getLoginId(), workspaceCode))
+			.thenReturn(Optional.of(workspaceMember));
+
+		// when
+		WorkspaceParticipateResponse response = workspaceService.participateWorkspace(workspaceCode, request,
+			loginMember);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.isAlreadyMember()).isTrue();
+		assertThat(response.getCode()).isEqualTo(workspaceCode);
+		assertThat(response.getHeadcount()).isEqualTo(3);
+	}
+
+	@Test
+	@DisplayName("워크스페이스 참여 시 비밀번호가 일치하지 않는 경우 예외가 발생한다")
+	void test12() {
+		// given
+		String workspaceCode = "TESTCODE";
+		String loginId = "user123";
+		String email = "user123@test.com";
+		String workspacePassword = "workspace1234!";
+		String invalidPassword = "invalid1234!";
+
+		Workspace workspace = testFixture.createWorkspaceWithPassword(workspaceCode, workspacePassword);
+		Member member = testFixture.createMember(loginId, email);
+		LoginMemberDto loginMember = testFixture.createLoginMemberDto(loginId, email);
+		WorkspaceParticipateRequest request = new WorkspaceParticipateRequest(invalidPassword);
+
+		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
+		when(memberRepository.findByLoginId(loginMember.getLoginId())).thenReturn(Optional.of(member));
+		when(workspaceMemberRepository.findByMemberLoginIdAndWorkspaceCode(loginMember.getLoginId(), workspaceCode))
+			.thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> workspaceService.participateWorkspace(workspaceCode, request,
+			loginMember)).isInstanceOf(InvalidWorkspacePasswordException.class);
+	}
 }

--- a/src/test/java/com/uranus/taskmanager/config/TestWebConfig.java
+++ b/src/test/java/com/uranus/taskmanager/config/TestWebConfig.java
@@ -1,0 +1,35 @@
+package com.uranus.taskmanager.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.uranus.taskmanager.api.auth.AuthenticationInterceptor;
+import com.uranus.taskmanager.api.auth.LoginMemberArgumentResolver;
+import com.uranus.taskmanager.api.workspacemember.authorization.AuthorizationInterceptor;
+
+import lombok.RequiredArgsConstructor;
+
+@Profile("TestWebConfig")
+@Configuration
+@RequiredArgsConstructor
+public class TestWebConfig implements WebMvcConfigurer {
+	private final AuthorizationInterceptor authorizationInterceptor;
+	private final AuthenticationInterceptor authenticationInterceptor;
+	private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(authenticationInterceptor);
+		registry.addInterceptor(authorizationInterceptor);
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(loginMemberArgumentResolver);
+	}
+}

--- a/src/test/java/com/uranus/taskmanager/fixture/TestFixture.java
+++ b/src/test/java/com/uranus/taskmanager/fixture/TestFixture.java
@@ -45,6 +45,24 @@ public class TestFixture {
 			.code(code)
 			.name("test name")
 			.description("test description")
+			.password("workspace1234!")
+			.build();
+	}
+
+	public Workspace createWorkspaceWithPassword(String code, String password) {
+		return Workspace.builder()
+			.code(code)
+			.name("test name")
+			.description("test description")
+			.password(password)
+			.build();
+	}
+
+	public Workspace createWorkspaceWithoutPassword(String code) {
+		return Workspace.builder()
+			.code(code)
+			.name("test name")
+			.description("test description")
 			.build();
 	}
 


### PR DESCRIPTION
## 🚀 설명
- 참여 요청/응답 DTO 추가
- 워크스페이스 생성 시 비밀번호 암호화
- 워크스페이스의 코드를 사용한 참여 기능
- 워크스페이스에 비밀번호가 있는 경우, 요청에서 제공한 비밀번호 대조
- 테스트 픽스쳐 추가(워크스페이스 생성 관련)
- `WebMvcConfigurer`를 구현하는 `TestWebConfig` 추가

---
## ✅ 변경 사항
- [x] 워크스페이스 참여 기능 구현
- [x] 워크스페이스 비밀번호 암호화
- [x] `WebMvcConfigurer`를 구현하는 `TestWebConfig` 추가(프로필로 적용)
- [x] 워크스페이스 참여 테스트 코드 추가

---
## 🚩 관련 이슈, PR
- #48 
- #40 

---
## 📖 참고