### PR TITLE
Feat: GlobalExceptionHandler에서 EntityResponse 사용

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/uranus/taskmanager/api/global/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -21,6 +22,11 @@ import com.uranus.taskmanager.api.workspacemember.exception.WorkspaceMemberExcep
 
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Todo: 중복, 가독성 리팩토링
+ * 	- 커스텀 비즈니스 예외에 대한 핸들링은 로그 처리를 제외하고는 중복된다.
+ * 	- 아예 CommonException을 잡고, 로그 처리만 예외 별로 다르게 처리되도록 구현?
+ */
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -50,17 +56,7 @@ public class GlobalExceptionHandler {
 	public ApiResponse<List<FieldErrorDto>> handleValidationException(MethodArgumentNotValidException exception) {
 		log.error("Field Validation Failed: ", exception);
 
-		/*
-		 * Todo: data안에 검증을 실패한 필드를 다음 처럼 표현하는 것이 과연 좋은가?
-		 * "data": {
-		 *    {
-		 *      "field" : "***",
-		 * 		"rejectedValue" : "***",
-		 * 		"message" : "***"
-		 *    },
-		 * 	  ...
-		 * }
-		 */
+		// Todo: 가독성을 위해 리팩토링(메서드 추출)
 		BindingResult bindingResult = exception.getBindingResult();
 		List<FieldErrorDto> errors = bindingResult.getFieldErrors().stream()
 			.map(error -> new FieldErrorDto(
@@ -70,78 +66,58 @@ public class GlobalExceptionHandler {
 			))
 			.toList();
 
-		/*
-		 * Todo: 아래 방법을 고려
-		 */
-		// Map<String, String> fieldErrors = new HashMap<>();
-		//
-		// for (FieldError fieldError : bindingResult.getFieldErrors()) {
-		// 	fieldErrors.put(fieldError.getField(), fieldError.getDefaultMessage());
-		// }
-
 		return ApiResponse.fail(HttpStatus.BAD_REQUEST,
 			"One or more fields have validation errors",
 			errors);
 	}
 
-	@ResponseStatus(HttpStatus.UNAUTHORIZED)
 	@ExceptionHandler(AuthenticationException.class)
-	public ApiResponse<?> handleAuthenticationException(AuthenticationException exception) {
+	public ResponseEntity<ApiResponse<?>> handleAuthenticationException(AuthenticationException exception) {
 		log.error("Authentication Related Exception: ", exception);
 
-		return ApiResponse.fail(exception.getHttpStatus(),
-			exception.getMessage(),
-			null); // Todo: AuthenticationException을 상속받은 예외 클래스에 잘못된 필드를 넘기는 것을 고려(이후 data에 넘기기)
+		return ResponseEntity.status(exception.getHttpStatus())
+			.body(ApiResponse.fail(exception.getHttpStatus(), exception.getMessage(), null));
+		// Todo: AuthenticationException을 상속받은 예외 클래스에 잘못된 필드를 넘기는 것을 고려(ApiResponse의 data에 넘기기)
 	}
 
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(MemberException.class)
-	public ApiResponse<?> handleMemberException(MemberException exception) {
+	public ResponseEntity<ApiResponse<?>> handleMemberException(MemberException exception) {
 		log.error("Member Related Exception: ", exception);
 
-		return ApiResponse.fail(exception.getHttpStatus(),
-			exception.getMessage(),
-			null);
+		return ResponseEntity.status(exception.getHttpStatus())
+			.body(ApiResponse.fail(exception.getHttpStatus(), exception.getMessage(), null));
 	}
 
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(WorkspaceException.class)
-	public ApiResponse<?> handleWorkspaceException(WorkspaceException exception) {
+	public ResponseEntity<ApiResponse<?>> handleWorkspaceException(WorkspaceException exception) {
 		log.error("Workspace Related Exception: ", exception);
 
-		return ApiResponse.fail(exception.getHttpStatus(),
-			exception.getMessage(),
-			null);
+		return ResponseEntity.status(exception.getHttpStatus())
+			.body(ApiResponse.fail(exception.getHttpStatus(), exception.getMessage(), null));
 	}
 
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(WorkspaceMemberException.class)
-	public ApiResponse<?> handleWorkspaceMemberException(WorkspaceMemberException exception) {
+	public ResponseEntity<ApiResponse<?>> handleWorkspaceMemberException(WorkspaceMemberException exception) {
 		log.error("WorkspaceMember Related Exception: ", exception);
 
-		return ApiResponse.fail(exception.getHttpStatus(),
-			exception.getMessage(),
-			null);
+		return ResponseEntity.status(exception.getHttpStatus())
+			.body(ApiResponse.fail(exception.getHttpStatus(), exception.getMessage(), null));
 	}
 
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
 	@ExceptionHandler(InvitationException.class)
-	public ApiResponse<?> handleInvitationException(InvitationException exception) {
+	public ResponseEntity<ApiResponse<?>> handleInvitationException(InvitationException exception) {
 		log.error("Invitation Related Exception: ", exception);
 
-		return ApiResponse.fail(exception.getHttpStatus(),
-			exception.getMessage(),
-			null);
+		return ResponseEntity.status(exception.getHttpStatus())
+			.body(ApiResponse.fail(exception.getHttpStatus(), exception.getMessage(), null));
 	}
 
-	@ResponseStatus(HttpStatus.FORBIDDEN)
 	@ExceptionHandler(AuthorizationException.class)
-	public ApiResponse<?> handleAuthorizationException(AuthorizationException exception) {
+	public ResponseEntity<ApiResponse<?>> handleAuthorizationException(AuthorizationException exception) {
 		log.error("Authorization Related Exception: ", exception);
 
-		return ApiResponse.fail(exception.getHttpStatus(),
-			exception.getMessage(),
-			null);
+		return ResponseEntity.status(exception.getHttpStatus())
+			.body(ApiResponse.fail(exception.getHttpStatus(), exception.getMessage(), null));
 	}
 
 	/*
@@ -149,6 +125,6 @@ public class GlobalExceptionHandler {
 	 *  - 기존에는 도메인 별 상위 예외를 만들어서 처리했는데, 응답 상태 헤더의 섬세한 조작이 어렵다
 	 *  - 해결 1: 도메인 별 상위 예외 말고, 응답 상태에 따른 상위 예외를 만들어서 처리
 	 *  - 해결 2: @ResponseStatus 대신 ResponseEntity 사용
-	 *  일단 도메인 상위 예외를 상속 받아서 사용하고, 이후 ResponseEntity를 사용하도록 리팩토링 해보자
+	 *  - 일단 도메인 상위 예외를 상속 받아서 사용하고, 이후 ResponseEntity를 사용하도록 리팩토링 해보자
 	 */
 }

--- a/src/test/java/com/uranus/taskmanager/api/invitation/controller/InvitationControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/invitation/controller/InvitationControllerTest.java
@@ -114,8 +114,7 @@ class InvitationControllerTest {
 		mockMvc.perform(post("/api/v1/invitations/{workspaceCode}/accept", workspaceCode)
 				.session(session)
 				.contentType(MediaType.APPLICATION_JSON))
-			// Todo: 추후 ResponseEntity를 적용하면 응답 상태 헤더는 해당 예외에서 상태를 꺼내서 사용한다 (400 -> 404로 변경)
-			.andExpect(status().isBadRequest())
+			.andExpect(status().isNotFound())
 			.andExpect(jsonPath("$.message").value("Invitation was not found for the given code"))
 			.andDo(print());
 	}

--- a/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
@@ -320,13 +320,13 @@ class WorkspaceControllerTest {
 	@Test
 	@DisplayName("해당 워크스페이스에서 ADMIN 권한이 있는 멤버는 초대 API 호출이 가능하다")
 	void test7() throws Exception {
-		// Todo: 인터셉터를 적용하기 위해서
+		// Todo: AuthorizationInterceptor를 적용하고 테스트, 다른 테스트로 분리
 	}
 
 	@Test
 	@DisplayName("해당 워크스페이스에서 ADMIN 권한이 없는 멤버가 초대를 시도하면 예외가 발생한다")
 	void test8() throws Exception {
-		// Todo
+		// Todo: AuthorizationInterceptor를 적용하고 테스트, 다른 테스트로 분리
 	}
 
 	@Test


### PR DESCRIPTION
## 🚀 설명
- 기존 일부 예외에 핸들링에서 @ResponseStatus 대신 EntityResponse를 적용했다
- `EntityResponse<ApiResponse<?>>`를 반환
- `status`를 예외에서 꺼내서 사용하는 방식을 사용한다
---
## ✅ 변경 사항
- [x] 전역 예외 처리에서 일부 핸들링에서 `EntityResponse` 적용
- [x] 깨진 테스트 코드 수정

---
## 🚩 관련 이슈, PR
- #41 

---
## 📖 참고