### PR TITLE
Feat/#31 auditing

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/authentication/exception/AuthenticationException.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/exception/AuthenticationException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.authentication.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.CommonException;
+import com.uranus.taskmanager.api.common.exception.CommonException;
 
 public abstract class AuthenticationException extends CommonException {
 

--- a/src/main/java/com/uranus/taskmanager/api/common/entity/BaseDateEntity.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/entity/BaseDateEntity.java
@@ -1,0 +1,24 @@
+package com.uranus.taskmanager.api.common.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseDateEntity {
+
+	@CreatedDate
+	@Column(updatable = false)
+	private LocalDateTime createdDate;
+	@LastModifiedDate
+	private LocalDateTime lastModifiedDate;
+}

--- a/src/main/java/com/uranus/taskmanager/api/common/entity/BaseEntity.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/entity/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.uranus.taskmanager.api.common.entity;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity extends BaseDateEntity {
+
+	@CreatedBy
+	@Column(updatable = false)
+	private String createdBy;
+	@LastModifiedBy
+	private String lastModifiedBy;
+}

--- a/src/main/java/com/uranus/taskmanager/api/common/exception/CommonException.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/exception/CommonException.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.api.common;
+package com.uranus.taskmanager.api.common.exception;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/uranus/taskmanager/api/global/audit/SessionAuditorAware.java
+++ b/src/main/java/com/uranus/taskmanager/api/global/audit/SessionAuditorAware.java
@@ -1,0 +1,23 @@
+package com.uranus.taskmanager.api.global.audit;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+import com.uranus.taskmanager.api.authentication.SessionKey;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SessionAuditorAware implements AuditorAware<String> {
+	private final HttpSession session;
+
+	@Override
+	public Optional<String> getCurrentAuditor() {
+		String loginId = (String)session.getAttribute(SessionKey.LOGIN_MEMBER);
+		return Optional.ofNullable(loginId);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/uranus/taskmanager/api/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.uranus.taskmanager.api.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/uranus/taskmanager/api/invitation/domain/Invitation.java
+++ b/src/main/java/com/uranus/taskmanager/api/invitation/domain/Invitation.java
@@ -1,5 +1,6 @@
 package com.uranus.taskmanager.api.invitation.domain;
 
+import com.uranus.taskmanager.api.common.entity.BaseEntity;
 import com.uranus.taskmanager.api.invitation.InvitationStatus;
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
@@ -22,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Invitation {
+public class Invitation extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/uranus/taskmanager/api/invitation/exception/InvitationException.java
+++ b/src/main/java/com/uranus/taskmanager/api/invitation/exception/InvitationException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.invitation.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.CommonException;
+import com.uranus.taskmanager.api.common.exception.CommonException;
 
 public class InvitationException extends CommonException {
 

--- a/src/main/java/com/uranus/taskmanager/api/member/domain/Member.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/domain/Member.java
@@ -3,6 +3,7 @@ package com.uranus.taskmanager.api.member.domain;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.uranus.taskmanager.api.common.entity.BaseDateEntity;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseDateEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/uranus/taskmanager/api/member/exception/MemberException.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/exception/MemberException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.member.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.CommonException;
+import com.uranus.taskmanager.api.common.exception.CommonException;
 
 public abstract class MemberException extends CommonException {
 

--- a/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
@@ -3,6 +3,7 @@ package com.uranus.taskmanager.api.workspace.domain;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.uranus.taskmanager.api.common.entity.BaseEntity;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 
@@ -20,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Workspace {
+public class Workspace extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/uranus/taskmanager/api/workspace/exception/WorkspaceException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/exception/WorkspaceException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspace.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.CommonException;
+import com.uranus.taskmanager.api.common.exception.CommonException;
 
 public abstract class WorkspaceException extends CommonException {
 	public WorkspaceException(String message, HttpStatus httpStatus) {

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
-import com.uranus.taskmanager.api.common.CommonException;
+import com.uranus.taskmanager.api.common.exception.CommonException;
 import com.uranus.taskmanager.api.invitation.InvitationStatus;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
 import com.uranus.taskmanager.api.invitation.exception.InvitationAlreadyExistsException;

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/exception/AuthorizationException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/exception/AuthorizationException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspacemember.authorization.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.CommonException;
+import com.uranus.taskmanager.api.common.exception.CommonException;
 
 public abstract class AuthorizationException extends CommonException {
 

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/WorkspaceMemberException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/WorkspaceMemberException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspacemember.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.CommonException;
+import com.uranus.taskmanager.api.common.exception.CommonException;
 
 public abstract class WorkspaceMemberException extends CommonException {
 

--- a/src/test/java/com/uranus/taskmanager/basetest/BaseApiIntegrationTest.java
+++ b/src/test/java/com/uranus/taskmanager/basetest/BaseApiIntegrationTest.java
@@ -1,0 +1,42 @@
+package com.uranus.taskmanager.basetest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import com.uranus.taskmanager.api.authentication.service.AuthenticationService;
+import com.uranus.taskmanager.api.invitation.repository.InvitationRepository;
+import com.uranus.taskmanager.api.invitation.service.InvitationService;
+import com.uranus.taskmanager.api.member.repository.MemberRepository;
+import com.uranus.taskmanager.api.member.service.MemberService;
+import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
+import com.uranus.taskmanager.api.workspace.service.CheckCodeDuplicationService;
+import com.uranus.taskmanager.api.workspace.service.WorkspaceService;
+import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class BaseApiIntegrationTest {
+	@LocalServerPort
+	protected int port;
+
+	@Autowired
+	protected WorkspaceService workspaceService;
+	@Autowired
+	protected CheckCodeDuplicationService workspaceCreateService;
+	@Autowired
+	protected AuthenticationService authenticationService;
+	@Autowired
+	protected MemberService memberService;
+	@Autowired
+	protected InvitationService invitationService;
+
+	@Autowired
+	protected WorkspaceRepository workspaceRepository;
+	@Autowired
+	protected MemberRepository memberRepository;
+	@Autowired
+	protected WorkspaceMemberRepository workspaceMemberRepository;
+	@Autowired
+	protected InvitationRepository invitationRepository;
+
+}

--- a/src/test/java/com/uranus/taskmanager/basetest/BaseServiceIntegrationTest.java
+++ b/src/test/java/com/uranus/taskmanager/basetest/BaseServiceIntegrationTest.java
@@ -2,20 +2,22 @@ package com.uranus.taskmanager.basetest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 
 import com.uranus.taskmanager.api.authentication.service.AuthenticationService;
+import com.uranus.taskmanager.api.invitation.repository.InvitationRepository;
+import com.uranus.taskmanager.api.invitation.service.InvitationService;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.member.service.MemberService;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.service.CheckCodeDuplicationService;
+import com.uranus.taskmanager.api.workspace.service.WorkspaceService;
 import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
-import com.uranus.taskmanager.fixture.RestAssuredAuthenticationFixture;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public abstract class BaseIntegrationTest {
-	@LocalServerPort
-	protected int port;
+@SpringBootTest
+public class BaseServiceIntegrationTest {
+
+	@Autowired
+	protected WorkspaceService workspaceService;
 	@Autowired
 	protected CheckCodeDuplicationService workspaceCreateService;
 	@Autowired
@@ -23,11 +25,14 @@ public abstract class BaseIntegrationTest {
 	@Autowired
 	protected MemberService memberService;
 	@Autowired
+	protected InvitationService invitationService;
+
+	@Autowired
 	protected WorkspaceRepository workspaceRepository;
 	@Autowired
 	protected MemberRepository memberRepository;
 	@Autowired
 	protected WorkspaceMemberRepository workspaceMemberRepository;
 	@Autowired
-	protected RestAssuredAuthenticationFixture restAssuredAuthenticationFixture;
+	protected InvitationRepository invitationRepository;
 }

--- a/src/test/java/com/uranus/taskmanager/fixture/controller/RestAssuredApiFixture.java
+++ b/src/test/java/com/uranus/taskmanager/fixture/controller/RestAssuredApiFixture.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.fixture;
+package com.uranus.taskmanager.fixture.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -11,7 +11,7 @@ import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
 @Component
-public class RestAssuredAuthenticationFixture {
+public class RestAssuredApiFixture {
 
 	public void signup(String loginId, String email, String password) {
 		SignupRequest signupRequest = SignupRequest.builder()
@@ -33,6 +33,24 @@ public class RestAssuredAuthenticationFixture {
 	public String loginWithId(String loginId, String password) {
 		LoginRequest loginRequest = LoginRequest.builder()
 			.loginId(loginId)
+			.password(password)
+			.build();
+
+		Response response = RestAssured.given()
+			.contentType(ContentType.JSON)
+			.body(loginRequest)
+			.when()
+			.post("/api/v1/auth/login")
+			.then()
+			.statusCode(HttpStatus.OK.value())
+			.extract().response();
+
+		return response.cookie("JSESSIONID");
+	}
+
+	public String loginWithEmail(String email, String password) {
+		LoginRequest loginRequest = LoginRequest.builder()
+			.email(email)
 			.password(password)
 			.build();
 

--- a/src/test/java/com/uranus/taskmanager/fixture/service/LoginFixture.java
+++ b/src/test/java/com/uranus/taskmanager/fixture/service/LoginFixture.java
@@ -1,0 +1,25 @@
+package com.uranus.taskmanager.fixture.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.uranus.taskmanager.api.authentication.dto.request.LoginRequest;
+import com.uranus.taskmanager.api.authentication.service.AuthenticationService;
+
+@Component
+public class LoginFixture {
+
+	@Autowired
+	private AuthenticationService authenticationService;
+
+	public void loginWithId(String loginId, String password) {
+		LoginRequest loginRequest = LoginRequest.builder()
+			.loginId(loginId)
+			.password(password)
+			.build();
+
+		authenticationService.login(loginRequest);
+	}
+
+	// Todo: 로그아웃 픽스쳐
+}

--- a/src/test/java/com/uranus/taskmanager/fixture/service/SignupFixture.java
+++ b/src/test/java/com/uranus/taskmanager/fixture/service/SignupFixture.java
@@ -1,0 +1,26 @@
+package com.uranus.taskmanager.fixture.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.uranus.taskmanager.api.member.dto.request.SignupRequest;
+import com.uranus.taskmanager.api.member.service.MemberService;
+
+@Component
+public class SignupFixture {
+
+	@Autowired
+	private MemberService memberService;
+
+	public void signup(String loginId, String email, String password) {
+		SignupRequest signupRequest = SignupRequest.builder()
+			.loginId(loginId)
+			.email(email)
+			.password(password)
+			.build();
+
+		memberService.signup(signupRequest);
+	}
+
+	// Todo: 탈퇴 관련 픽스쳐
+}

--- a/src/test/java/com/uranus/taskmanager/integrationtest/AuditApiIntegrationTest.java
+++ b/src/test/java/com/uranus/taskmanager/integrationtest/AuditApiIntegrationTest.java
@@ -1,0 +1,108 @@
+package com.uranus.taskmanager.integrationtest;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.workspace.domain.Workspace;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
+import com.uranus.taskmanager.basetest.BaseApiIntegrationTest;
+import com.uranus.taskmanager.fixture.controller.RestAssuredApiFixture;
+import com.uranus.taskmanager.util.DatabaseCleaner;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+public class AuditApiIntegrationTest extends BaseApiIntegrationTest {
+	@Autowired
+	private AuditorAware<String> auditorAware;
+	@Autowired
+	private RestAssuredApiFixture restAssuredApiFixture;
+	@Autowired
+	private DatabaseCleaner databaseCleaner;
+
+	@BeforeEach
+	public void setUp() {
+		RestAssured.port = port;
+		databaseCleaner.execute();
+	}
+
+	@Test
+	@DisplayName("워크스페이스가 생성될 시 생성자(로그인 정보의 로그인ID)가 기록된다")
+	public void test1() {
+		// given
+		String loginId = "user123";
+		String email = "user123@test.com";
+		String password = "password123!";
+
+		restAssuredApiFixture.signup(loginId, email, password);
+		String sessionCookie = restAssuredApiFixture.loginWithId(loginId, password);
+
+		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
+			.name("Test Workspace")
+			.description("Test Description")
+			.build();
+
+		// when
+		RestAssured.given()
+			.contentType(ContentType.JSON)
+			.cookie("JSESSIONID", sessionCookie)
+			.body(request)
+			.when()
+			.post("/api/v1/workspaces")
+			.then()
+			.statusCode(HttpStatus.CREATED.value())
+			.extract().response();
+
+		Optional<Workspace> optionalWorkspace = workspaceRepository.findById(1L);
+		// then
+		assertThat(optionalWorkspace).isPresent();
+		Workspace workspace = optionalWorkspace.get();
+		assertThat(workspace.getCreatedBy()).isEqualTo(loginId);
+	}
+
+	@Test
+	@DisplayName("워크스페이스가 생성될 시 생성일이 기록된다")
+	public void test2() {
+		// given
+		String loginId = "user123";
+		String email = "user123@test.com";
+		String password = "password123!";
+
+		restAssuredApiFixture.signup(loginId, email, password);
+		String sessionCookie = restAssuredApiFixture.loginWithId(loginId, password);
+
+		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
+			.name("Test Workspace")
+			.description("Test Description")
+			.build();
+
+		// when
+		RestAssured.given()
+			.contentType(ContentType.JSON)
+			.cookie("JSESSIONID", sessionCookie)
+			.body(request)
+			.when()
+			.post("/api/v1/workspaces")
+			.then()
+			.statusCode(HttpStatus.CREATED.value())
+			.extract().response();
+
+		Optional<Workspace> optionalWorkspace = workspaceRepository.findById(1L);
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime oneSecondAgo = now.minusSeconds(1);
+
+		// then
+		assertThat(optionalWorkspace).isPresent();
+		assertThat(optionalWorkspace.get().getCreatedDate()).isBefore(now);
+		assertThat(optionalWorkspace.get().getCreatedDate()).isAfter(oneSecondAgo);
+	}
+}

--- a/src/test/java/com/uranus/taskmanager/integrationtest/WorkspaceControllerApiIntegrationTest.java
+++ b/src/test/java/com/uranus/taskmanager/integrationtest/WorkspaceControllerApiIntegrationTest.java
@@ -6,16 +6,21 @@ import static org.hamcrest.Matchers.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
-import com.uranus.taskmanager.basetest.BaseIntegrationTest;
+import com.uranus.taskmanager.basetest.BaseApiIntegrationTest;
+import com.uranus.taskmanager.fixture.controller.RestAssuredApiFixture;
+import com.uranus.taskmanager.util.DatabaseCleaner;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
-class WorkspaceControllerIntegrationTest extends BaseIntegrationTest {
+@Transactional
+class WorkspaceControllerApiIntegrationTest extends BaseApiIntegrationTest {
 
 	/**
 	 * Todo: Workspace와 WorkspaceMember 엔티티 간의 외래 키 제약 조건으로 인한 문제 발생
@@ -28,20 +33,23 @@ class WorkspaceControllerIntegrationTest extends BaseIntegrationTest {
 	 * 해결 2: CascadeType.REMOVE을 사용한다
 	 * - 예시: Workspace 엔티티에서 연관관계 매핑과 관련해서 cascade = CascadeType.ALL, orphanRemoval = true을 사용한다
 	 */
+	@Autowired
+	private RestAssuredApiFixture restAssuredApiFixture;
+	@Autowired
+	private DatabaseCleaner databaseCleaner;
+
 	@BeforeEach
 	public void setup() {
 		RestAssured.port = port;
-		workspaceMemberRepository.deleteAll();
-		workspaceRepository.deleteAll();
-		memberRepository.deleteAll();
+		databaseCleaner.execute();
 	}
 
 	@Test
 	@DisplayName("워크스페이스를 생성하면 응답의 데이터에 워크스페이스의 이름, 설명, 코드가 존재해야 한다")
 	public void test1() throws Exception {
 
-		restAssuredAuthenticationFixture.signup("user123", "user123@gmail.com", "test1234!");
-		String sessionCookie = restAssuredAuthenticationFixture.loginWithId("user123", "test1234!");
+		restAssuredApiFixture.signup("user123", "user123@gmail.com", "test1234!");
+		String sessionCookie = restAssuredApiFixture.loginWithId("user123", "test1234!");
 
 		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
 			.name("Test Workspace")
@@ -66,8 +74,8 @@ class WorkspaceControllerIntegrationTest extends BaseIntegrationTest {
 	@DisplayName("하나의 워크스페이스를 생성하면 DB에 하나의 워크스페이스만 존재해야 한다")
 	public void test2() throws Exception {
 
-		restAssuredAuthenticationFixture.signup("user123", "user123@gmail.com", "test1234!");
-		String sessionCookie = restAssuredAuthenticationFixture.loginWithId("user123", "test1234!");
+		restAssuredApiFixture.signup("user123", "user123@gmail.com", "test1234!");
+		String sessionCookie = restAssuredApiFixture.loginWithId("user123", "test1234!");
 
 		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
 			.name("Test Workspace")

--- a/src/test/java/com/uranus/taskmanager/util/DatabaseCleaner.java
+++ b/src/test/java/com/uranus/taskmanager/util/DatabaseCleaner.java
@@ -1,0 +1,82 @@
+package com.uranus.taskmanager.util;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.Session;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DatabaseCleaner {
+
+	private final EntityManager entityManager;
+
+	private List<String> tableNames;
+
+	@PostConstruct
+	public void extractTableNames() {
+		Session session = entityManager.unwrap(Session.class);
+		tableNames = new ArrayList<>();
+
+		session.doWork(connection -> {
+			ResultSet rs = connection.getMetaData()
+				.getTables(null, "PUBLIC", null, new String[] {"TABLE"});
+
+			while (rs.next()) {
+				tableNames.add(rs.getString("TABLE_NAME"));
+			}
+			// log.info("tableNames = {}", tableNames);
+		});
+	}
+
+	private List<String> getIdColumnNamesForTable(String tableName) {
+		List<String> idColumns = new ArrayList<>();
+
+		Session session = entityManager.unwrap(Session.class);
+
+		session.doWork(connection -> {
+			try (ResultSet rs = connection.getMetaData().getColumns(null, null, tableName, null)) {
+				while (rs.next()) {
+					String columnName = rs.getString("COLUMN_NAME");
+					if (columnName.equalsIgnoreCase("ID") || columnName.equalsIgnoreCase(tableName + "_ID")) {
+						idColumns.add(columnName);
+					}
+				}
+			} catch (SQLException e) {
+				log.error("Error while retrieving ID column names for table: {}", tableName, e);
+			}
+		});
+
+		return idColumns;
+	}
+
+	@Transactional
+	public void execute() {
+		entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+		for (String tableName : tableNames) {
+			// log.info("TRUNCATE TABLE {}", tableName);
+			entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+
+			List<String> idColumnNames = getIdColumnNamesForTable(tableName);
+			for (String idColumnName : idColumnNames) {
+				// log.info("ALTER TABLE {} ALTER COLUMN {} RESTART WITH 1", tableName, idColumnName);
+				entityManager.createNativeQuery(
+						"ALTER TABLE " + tableName + " ALTER COLUMN " + idColumnName + " RESTART WITH 1")
+					.executeUpdate();
+			}
+		}
+
+		entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+	}
+}


### PR DESCRIPTION
## 🚀 설명
- `Audit` 기능 적용
- `AuditorAware`를 구현해서 세션의 로그인 정보를 사용하도록 함
- #54 를 해결하기 위해서 `DatabaseCleaner` 구현
- 테스트 픽스처 추가/수정
- `BaseIntegrationTest` 분리

---
## ✅ 변경 사항
- [x] `BaseEntity` 추가
- [x] `BaseTimeEntity` 추가
- [x] `BaseEntity` 적용
- [x] `SessionAuditorAware` 추가
- [x] `JpaAuditingConfig` 추가
- [x] `BaseIntegrationTest` 분리
- [x] `DatabaseCleaner` 추가
- [x] Audit 기능 테스트 추가

---
## 🚩 관련 이슈, PR
- #54 해결
- #31 

---
## 📖 참고