### PR TITLE
Refactor: to, from으로 메서드명 변경

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/authentication/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/LoginMemberArgumentResolver.java
@@ -59,6 +59,6 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
 		/*
 		 * member를 LoginMemberDto로 변환해서 반환한다
 		 */
-		return LoginMemberDto.fromEntity(member);
+		return LoginMemberDto.from(member);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/authentication/dto/request/LoginMemberDto.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/dto/request/LoginMemberDto.java
@@ -17,7 +17,7 @@ public class LoginMemberDto {
 		this.email = email;
 	}
 
-	public static LoginMemberDto fromEntity(Member member) {
+	public static LoginMemberDto from(Member member) {
 		return LoginMemberDto.builder()
 			.loginId(member.getLoginId())
 			.email(member.getEmail())

--- a/src/main/java/com/uranus/taskmanager/api/authentication/dto/request/LoginRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/dto/request/LoginRequest.java
@@ -17,7 +17,7 @@ public class LoginRequest {
 	@NotBlank(message = "Password must not be blank")
 	private String password;
 
-	public Member toEntity() {
+	public Member to() {
 		return Member.builder()
 			.email(email)
 			.password(password)

--- a/src/main/java/com/uranus/taskmanager/api/authentication/dto/response/LoginResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/dto/response/LoginResponse.java
@@ -12,7 +12,7 @@ public class LoginResponse {
 	private final String loginId;
 	private final String email;
 
-	public static LoginResponse fromEntity(Member member) {
+	public static LoginResponse from(Member member) {
 		return LoginResponse.builder()
 			.loginId(member.getLoginId())
 			.email(member.getEmail())

--- a/src/main/java/com/uranus/taskmanager/api/authentication/service/AuthenticationService.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/service/AuthenticationService.java
@@ -29,6 +29,6 @@ public class AuthenticationService {
 		if (!passwordEncoder.matches(loginRequest.getPassword(), member.getPassword())) {
 			throw new InvalidLoginPasswordException();
 		}
-		return LoginResponse.fromEntity(member);
+		return LoginResponse.from(member);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/invitation/dto/response/InvitationAcceptResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/invitation/dto/response/InvitationAcceptResponse.java
@@ -32,7 +32,7 @@ public class InvitationAcceptResponse {
 		this.headcount = headcount;
 	}
 
-	public static InvitationAcceptResponse fromEntity(Invitation invitation, WorkspaceMember workspaceMember) {
+	public static InvitationAcceptResponse from(Invitation invitation, WorkspaceMember workspaceMember) {
 		return InvitationAcceptResponse.builder()
 			.workspaceCode(invitation.getWorkspace().getCode())
 			.workspaceName(invitation.getWorkspace().getName())

--- a/src/main/java/com/uranus/taskmanager/api/invitation/service/InvitationService.java
+++ b/src/main/java/com/uranus/taskmanager/api/invitation/service/InvitationService.java
@@ -47,7 +47,7 @@ public class InvitationService {
 			invitation.getWorkspace(), WorkspaceRole.USER, invitation.getMember().getEmail());
 		workspaceMemberRepository.save(workspaceMember);
 
-		return InvitationAcceptResponse.fromEntity(invitation, workspaceMember);
+		return InvitationAcceptResponse.from(invitation, workspaceMember);
 	}
 
 	@Transactional

--- a/src/main/java/com/uranus/taskmanager/api/member/dto/response/SignupResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/dto/response/SignupResponse.java
@@ -12,7 +12,7 @@ public class SignupResponse {
 	private final String loginId;
 	private final String email;
 
-	public static SignupResponse fromEntity(Member member) {
+	public static SignupResponse from(Member member) {
 		return SignupResponse.builder()
 			.loginId(member.getLoginId())
 			.email(member.getEmail())

--- a/src/main/java/com/uranus/taskmanager/api/member/service/MemberService.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/service/MemberService.java
@@ -33,7 +33,7 @@ public class MemberService {
 			.email(signupRequest.getEmail())
 			.password(encodedPassword)
 			.build();
-		return SignupResponse.fromEntity(memberRepository.save(member));
+		return SignupResponse.from(memberRepository.save(member));
 	}
 
 	public void checkLoginIdDuplicate(String loginId) {

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/WorkspaceCreateRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/WorkspaceCreateRequest.java
@@ -37,7 +37,7 @@ public class WorkspaceCreateRequest {
 		this.password = password;
 	}
 
-	public Workspace toEntity() {
+	public Workspace to() {
 		return Workspace.builder()
 			.name(name)
 			.description(description)

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/InviteMemberResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/InviteMemberResponse.java
@@ -36,12 +36,12 @@ public class InviteMemberResponse {
 		this.invitedMember = invitedMember;
 	}
 
-	public static InviteMemberResponse fromEntity(Invitation invitation) {
+	public static InviteMemberResponse from(Invitation invitation) {
 		return InviteMemberResponse.builder()
 			.code(invitation.getWorkspace().getCode())
 			// .loginId(invitation.getMember().getLoginId())
 			// .email(invitation.getMember().getEmail())
-			.invitedMember(InvitedMember.fromEntity(invitation))
+			.invitedMember(InvitedMember.from(invitation))
 			.status(invitation.getStatus())
 			.build();
 	}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/InvitedMember.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/InvitedMember.java
@@ -16,7 +16,7 @@ public class InvitedMember {
 		this.email = email;
 	}
 
-	public static InvitedMember fromEntity(Invitation invitation) {
+	public static InvitedMember from(Invitation invitation) {
 		return InvitedMember.builder()
 			.email(invitation.getMember().getEmail())
 			.loginId(invitation.getMember().getLoginId())

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/WorkspaceResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/WorkspaceResponse.java
@@ -15,7 +15,7 @@ public class WorkspaceResponse {
 	private final String name;
 	private final String description;
 
-	public static WorkspaceResponse fromEntity(Workspace workspace) {
+	public static WorkspaceResponse from(Workspace workspace) {
 		return WorkspaceResponse.builder()
 			.name(workspace.getName())
 			.description(workspace.getDescription())

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
@@ -79,7 +79,7 @@ public class CheckCodeDuplicationService implements WorkspaceCreateService {
 				}
 
 				// 요청 DTO를 사용해서 워크스페이스 엔티티로 만들고 저장
-				Workspace workspace = workspaceRepository.save(request.toEntity());
+				Workspace workspace = workspaceRepository.save(request.to());
 
 				// 워크스페이스 멤버 생성 및 저장
 				WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace,
@@ -88,7 +88,7 @@ public class CheckCodeDuplicationService implements WorkspaceCreateService {
 
 				workspaceMemberRepository.save(workspaceMember);
 
-				return WorkspaceResponse.fromEntity(workspace);
+				return WorkspaceResponse.from(workspace);
 			}
 			log.info("[Workspace Code Collision] Retrying... attempt {}", count + 1);
 		}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/HandleDatabaseExceptionService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/HandleDatabaseExceptionService.java
@@ -66,7 +66,7 @@ public class HandleDatabaseExceptionService implements WorkspaceCreateService {
 				}
 
 				// 요청 DTO를 사용해서 워크스페이스 엔티티로 만들고 저장
-				Workspace workspace = workspaceRepository.saveWithNewTransaction(request.toEntity());
+				Workspace workspace = workspaceRepository.saveWithNewTransaction(request.to());
 
 				// 워크스페이스 멤버 생성 및 저장
 				WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace,
@@ -75,7 +75,7 @@ public class HandleDatabaseExceptionService implements WorkspaceCreateService {
 
 				workspaceMemberRepository.save(workspaceMember);
 
-				return WorkspaceResponse.fromEntity(workspace);
+				return WorkspaceResponse.from(workspace);
 			} catch (DataIntegrityViolationException | ConstraintViolationException e) {
 				/*
 				 * Todo: 로그 정리

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceService.java
@@ -61,7 +61,7 @@ public class WorkspaceService {
 
 		Workspace workspace = workspaceRepository.findByCode(workspaceCode)
 			.orElseThrow(WorkspaceNotFoundException::new);
-		return WorkspaceResponse.fromEntity(workspace);
+		return WorkspaceResponse.from(workspace);
 	}
 
 	// Todo: 로직, 가독성 리팩토링
@@ -108,7 +108,7 @@ public class WorkspaceService {
 			.build();
 		invitationRepository.save(invitation);
 
-		return InviteMemberResponse.fromEntity(invitation);
+		return InviteMemberResponse.from(invitation);
 	}
 
 	@Transactional

--- a/src/test/java/com/uranus/taskmanager/api/invitation/controller/InvitationControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/invitation/controller/InvitationControllerTest.java
@@ -80,7 +80,7 @@ class InvitationControllerTest {
 		Member member = testFixture.createMember(loginId, email);
 		Invitation invitation = testFixture.createPendingInvitation(workspace, member);
 
-		InvitationAcceptResponse acceptResponse = InvitationAcceptResponse.fromEntity(invitation,
+		InvitationAcceptResponse acceptResponse = InvitationAcceptResponse.from(invitation,
 			WorkspaceMember.addWorkspaceMember(member, workspace, WorkspaceRole.USER,
 				member.getEmail()));
 

--- a/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
@@ -220,7 +220,7 @@ class WorkspaceControllerTest {
 		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(invitedLoginId);
 		String requestBody = objectMapper.writeValueAsString(inviteMemberRequest);
 
-		InviteMemberResponse inviteMemberResponse = InviteMemberResponse.fromEntity(invitation);
+		InviteMemberResponse inviteMemberResponse = InviteMemberResponse.from(invitation);
 
 		// Todo: any()를 사용하지 않고 eq() 또는 객체 그대로 사용하는 경우 inviteMemberResponse가 null로 찍히는 문제 발생.
 		//  정확한 객체에 대한 검증을 수행할 해결방법 찾아보기.


### PR DESCRIPTION
## 🚀 설명
- `toEntity()` -> `to()`
- `fromEntity()` -> `from()`

---
## ✅ 변경 사항
- [x] `toEntity()` -> `to()`
- [x] `fromEntity()` -> `from()`

---
## 🚩 관련 이슈, PR
- #47 

---
## 📖 참고