### PR TITLE
Feat/#30 workspace command v1

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/member/domain/Member.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/domain/Member.java
@@ -7,6 +7,7 @@ import com.uranus.taskmanager.api.common.entity.BaseDateEntity;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -35,7 +36,7 @@ public class Member extends BaseDateEntity {
 	@Column(nullable = false)
 	private String password;
 
-	@OneToMany(mappedBy = "member")
+	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<WorkspaceMember> workspaceMembers = new ArrayList<>();
 
 	@OneToMany(mappedBy = "member")

--- a/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
@@ -48,15 +48,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/v1/workspaces")
 public class WorkspaceController {
 
-	/**
-	 * Todo
-	 *  - 워크스페이스 이름, 설명 수정 PATCH
-	 *  - 워크스페이스 삭제 DELETE
-	 *  - 워크스페이스 비밀번호 설정(만약 없으면 설정, 있으면 수정)
-	 *  - 워크스페이스 상세 정보 조회(워크스페이스 코드를 통해, 해당 워크스페이스의 멤버여야 함) GET
-	 *  - 내가 참여 중인 모든 워크스페이스 조회하기
-	 */
-
 	private final WorkspaceService workspaceService;
 	private final WorkspaceCreateService workspaceCreateService;
 	private final WorkspaceCommandService workspaceCommandService;

--- a/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
@@ -2,9 +2,12 @@ package com.uranus.taskmanager.api.workspace.controller;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -17,13 +20,18 @@ import com.uranus.taskmanager.api.common.ApiResponse;
 import com.uranus.taskmanager.api.workspace.dto.WorkspaceDetail;
 import com.uranus.taskmanager.api.workspace.dto.request.InviteMemberRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.InviteMembersRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceContentUpdateRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceDeleteRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceParticipateRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspacePasswordUpdateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.InviteMemberResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.InviteMembersResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.MyWorkspacesResponse;
+import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceContentUpdateResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceCreateResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceParticipateResponse;
+import com.uranus.taskmanager.api.workspace.service.WorkspaceCommandService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceCreateService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceQueryService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceService;
@@ -48,8 +56,10 @@ public class WorkspaceController {
 	 *  - 워크스페이스 상세 정보 조회(워크스페이스 코드를 통해, 해당 워크스페이스의 멤버여야 함) GET
 	 *  - 내가 참여 중인 모든 워크스페이스 조회하기
 	 */
-	private final WorkspaceCreateService workspaceCreateService;
+
 	private final WorkspaceService workspaceService;
+	private final WorkspaceCreateService workspaceCreateService;
+	private final WorkspaceCommandService workspaceCommandService;
 	private final WorkspaceQueryService workspaceQueryService;
 
 	@LoginRequired
@@ -61,6 +71,36 @@ public class WorkspaceController {
 
 		WorkspaceCreateResponse response = workspaceCreateService.createWorkspace(request, loginMember);
 		return ApiResponse.created("Workspace Created", response);
+	}
+
+	@LoginRequired
+	@RoleRequired(roles = WorkspaceRole.ADMIN)
+	@DeleteMapping("/{code}")
+	public ApiResponse<String> deleteWorkspace(@PathVariable String code,
+		@RequestBody WorkspaceDeleteRequest request) {
+
+		workspaceCommandService.deleteWorkspace(request, code);
+		return ApiResponse.ok("Workspace Deleted", code);
+	}
+
+	@LoginRequired
+	@RoleRequired(roles = WorkspaceRole.ADMIN)
+	@PatchMapping("/{code}")
+	public ApiResponse<WorkspaceContentUpdateResponse> updateWorkspaceContent(@PathVariable String code,
+		@RequestBody @Valid WorkspaceContentUpdateRequest request) {
+
+		WorkspaceContentUpdateResponse response = workspaceCommandService.updateWorkspaceContent(request, code);
+		return ApiResponse.ok("Workspace Title and Description Updated", response);
+	}
+
+	@LoginRequired
+	@RoleRequired(roles = WorkspaceRole.ADMIN)
+	@PutMapping("/{code}/password")
+	public ApiResponse<String> updateWorkspacePassword(@PathVariable String code,
+		@RequestBody @Valid WorkspacePasswordUpdateRequest request) {
+
+		workspaceCommandService.updateWorkspacePassword(request, code);
+		return ApiResponse.okWithNoContent("Workspace Password Updated");
 	}
 
 	@LoginRequired

--- a/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
@@ -7,6 +7,7 @@ import com.uranus.taskmanager.api.common.entity.BaseEntity;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -41,7 +42,7 @@ public class Workspace extends BaseEntity {
 	private String password;
 	private String description;
 
-	@OneToMany(mappedBy = "workspace")
+	@OneToMany(mappedBy = "workspace", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<WorkspaceMember> workspaceMembers = new ArrayList<>();
 
 	@OneToMany(mappedBy = "workspace")
@@ -59,8 +60,15 @@ public class Workspace extends BaseEntity {
 		this.code = code;
 	}
 
-	public void setPassword(String password) {
+	public void updatePassword(String password) {
 		this.password = password;
 	}
 
+	public void updateName(String name) {
+		this.name = name;
+	}
+
+	public void updateDescription(String description) {
+		this.description = description;
+	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/WorkspaceDetail.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/WorkspaceDetail.java
@@ -19,6 +19,8 @@ public class WorkspaceDetail {
 	private String description;
 	private String createdBy;
 	private LocalDateTime createdAt;
+	private String updatedBy;
+	private LocalDateTime updatedAt;
 	private WorkspaceRole role;
 
 	/*
@@ -33,13 +35,15 @@ public class WorkspaceDetail {
 
 	@Builder
 	public WorkspaceDetail(Long id, String code, String name, String description, String createdBy,
-		LocalDateTime createdAt, WorkspaceRole role) {
+		LocalDateTime createdAt, String updatedBy, LocalDateTime updatedAt, WorkspaceRole role) {
 		this.id = id;
 		this.code = code;
 		this.name = name;
 		this.description = description;
 		this.createdBy = createdBy;
 		this.createdAt = createdAt;
+		this.updatedBy = updatedBy;
+		this.updatedAt = updatedAt;
 		this.role = role;
 	}
 
@@ -51,6 +55,8 @@ public class WorkspaceDetail {
 			.description(workspace.getDescription())
 			.createdBy(workspace.getCreatedBy())
 			.createdAt(workspace.getCreatedDate())
+			.updatedBy(workspace.getLastModifiedBy())
+			.updatedAt(workspace.getLastModifiedDate())
 			.role(role)
 			.build();
 	}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/WorkspaceUpdateDetail.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/WorkspaceUpdateDetail.java
@@ -1,0 +1,40 @@
+package com.uranus.taskmanager.api.workspace.dto;
+
+import java.time.LocalDateTime;
+
+import com.uranus.taskmanager.api.workspace.domain.Workspace;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class WorkspaceUpdateDetail {
+
+	private String code;
+	private String name;
+	private String description;
+	private String updatedBy;
+	private LocalDateTime updatedAt;
+
+	@Builder
+	public WorkspaceUpdateDetail(String code, String name, String description, String updatedBy,
+		LocalDateTime updatedAt) {
+		this.code = code;
+		this.name = name;
+		this.description = description;
+		this.updatedBy = updatedBy;
+		this.updatedAt = updatedAt;
+	}
+
+	public static WorkspaceUpdateDetail from(Workspace workspace) {
+		return WorkspaceUpdateDetail.builder()
+			.code(workspace.getCode())
+			.name(workspace.getName())
+			.description(workspace.getDescription())
+			.updatedBy(workspace.getLastModifiedBy())
+			.updatedAt(workspace.getLastModifiedDate())
+			.build();
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/WorkspaceContentUpdateRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/WorkspaceContentUpdateRequest.java
@@ -1,0 +1,34 @@
+package com.uranus.taskmanager.api.workspace.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WorkspaceContentUpdateRequest {
+
+	@Size(min = 2, max = 50, message = "Workspace name must be 2 ~ 50 characters long")
+	private String name;
+	@Size(min = 1, max = 255, message = "Workspace description must be 1 ~ 255 characters long")
+	private String description;
+
+	@Builder
+	public WorkspaceContentUpdateRequest(String name, String description) {
+		this.name = name;
+		this.description = description;
+	}
+
+	public boolean hasName() {
+		return isNotBlank(name);
+	}
+
+	public boolean hasDescription() {
+		return isNotBlank(description);
+	}
+
+	private boolean isNotBlank(String value) {
+		return value != null && !value.trim().isEmpty();
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/WorkspaceCreateRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/WorkspaceCreateRequest.java
@@ -19,7 +19,7 @@ public class WorkspaceCreateRequest {
 	@NotBlank(message = "Workspace name must not be blank")
 	private String name;
 
-	@Size(min = 1, max = 255, message = "Workspace name must be 1 ~ 255 characters long")
+	@Size(min = 1, max = 255, message = "Workspace description must be 1 ~ 255 characters long")
 	@NotBlank(message = "Workspace description must not be blank")
 	private String description;
 

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/WorkspaceDeleteRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/WorkspaceDeleteRequest.java
@@ -1,0 +1,15 @@
+package com.uranus.taskmanager.api.workspace.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WorkspaceDeleteRequest {
+
+	private String password;
+
+	public WorkspaceDeleteRequest(String password) {
+		this.password = password;
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/WorkspacePasswordUpdateRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/WorkspacePasswordUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.uranus.taskmanager.api.workspace.dto.request;
+
+import jakarta.validation.constraints.Pattern;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WorkspacePasswordUpdateRequest {
+
+	private String originalPassword;
+
+	@Pattern(
+		regexp = "^(?!.*[가-힣])(?=.*[0-9])(?=.*[a-zA-Z])(?=\\S+$).{8,30}",
+		message = "The password must be alphanumeric and must be between 4 and 30 characters"
+	)
+	private String updatePassword;
+
+	@Builder
+	public WorkspacePasswordUpdateRequest(String originalPassword, String updatePassword) {
+		this.originalPassword = originalPassword;
+		this.updatePassword = updatePassword;
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/WorkspaceContentUpdateResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/WorkspaceContentUpdateResponse.java
@@ -1,0 +1,27 @@
+package com.uranus.taskmanager.api.workspace.dto.response;
+
+import com.uranus.taskmanager.api.workspace.dto.WorkspaceUpdateDetail;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class WorkspaceContentUpdateResponse {
+	/**
+	 * Todo
+	 * 	- 과연 original을 보여줄 필요가 있을까?
+	 * 	- 그냥 WorkspaceUpdateDetail을 응답의 데이터로 주는 것을 고려해보자
+	 */
+	private WorkspaceUpdateDetail original;
+	private WorkspaceUpdateDetail updatedTo;
+
+	public WorkspaceContentUpdateResponse(WorkspaceUpdateDetail original, WorkspaceUpdateDetail updatedTo) {
+		this.original = original;
+		this.updatedTo = updatedTo;
+	}
+
+	public static WorkspaceContentUpdateResponse from(WorkspaceUpdateDetail original, WorkspaceUpdateDetail updatedTo) {
+		return new WorkspaceContentUpdateResponse(original, updatedTo);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandService.java
@@ -1,0 +1,84 @@
+package com.uranus.taskmanager.api.workspace.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.uranus.taskmanager.api.security.PasswordEncoder;
+import com.uranus.taskmanager.api.workspace.domain.Workspace;
+import com.uranus.taskmanager.api.workspace.dto.WorkspaceUpdateDetail;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceContentUpdateRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceDeleteRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspacePasswordUpdateRequest;
+import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceContentUpdateResponse;
+import com.uranus.taskmanager.api.workspace.exception.InvalidWorkspacePasswordException;
+import com.uranus.taskmanager.api.workspace.exception.WorkspaceNotFoundException;
+import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class WorkspaceCommandService {
+
+	private final WorkspaceRepository workspaceRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	public WorkspaceContentUpdateResponse updateWorkspaceContent(WorkspaceContentUpdateRequest request, String code) {
+		Workspace workspace = findWorkspaceByCode(code);
+		WorkspaceUpdateDetail original = WorkspaceUpdateDetail.from(workspace);
+
+		if (request.hasName()) {
+			workspace.updateName(request.getName());
+		}
+		if (request.hasDescription()) {
+			workspace.updateDescription(request.getDescription());
+		}
+
+		WorkspaceUpdateDetail updatedTo = WorkspaceUpdateDetail.from(workspace);
+		return WorkspaceContentUpdateResponse.from(original, updatedTo);
+	}
+
+	public void updateWorkspacePassword(WorkspacePasswordUpdateRequest request, String code) {
+		Workspace workspace = findWorkspaceByCode(code);
+
+		validatePasswordIfExists(workspace.getPassword(), request.getOriginalPassword());
+
+		String encodedUpdatePassword = encodePasswordIfPresent(request.getUpdatePassword());
+		workspace.updatePassword(encodedUpdatePassword);
+	}
+
+	public void deleteWorkspace(WorkspaceDeleteRequest request, String code) {
+		Workspace workspace = findWorkspaceByCode(code);
+
+		validatePasswordIfExists(workspace.getPassword(), request.getPassword());
+
+		workspaceRepository.delete(workspace);
+	}
+
+	private Workspace findWorkspaceByCode(String workspaceCode) {
+		return workspaceRepository.findByCode(workspaceCode)
+			.orElseThrow(WorkspaceNotFoundException::new);
+	}
+
+	private String encodePasswordIfPresent(String password) {
+		return Optional.ofNullable(password)
+			.map(passwordEncoder::encode)
+			.orElse(null);
+	}
+
+	private void validatePasswordIfExists(String workspacePassword, String inputPassword) {
+		if (workspacePassword == null) {
+			return;
+		}
+		if (passwordDoesNotMatch(workspacePassword, inputPassword)) {
+			throw new InvalidWorkspacePasswordException();
+		}
+	}
+
+	private boolean passwordDoesNotMatch(String workspacePassword, String inputPassword) {
+		return !passwordEncoder.matches(inputPassword, workspacePassword);
+	}
+}

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandServiceTest.java
@@ -1,0 +1,279 @@
+package com.uranus.taskmanager.api.workspace.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.member.repository.MemberRepository;
+import com.uranus.taskmanager.api.security.PasswordEncoder;
+import com.uranus.taskmanager.api.workspace.domain.Workspace;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceContentUpdateRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceDeleteRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspacePasswordUpdateRequest;
+import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceContentUpdateResponse;
+import com.uranus.taskmanager.api.workspace.exception.InvalidWorkspacePasswordException;
+import com.uranus.taskmanager.api.workspace.exception.WorkspaceNotFoundException;
+import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
+import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
+import com.uranus.taskmanager.fixture.repository.MemberRespositoryFixture;
+import com.uranus.taskmanager.fixture.repository.WorkspaceRepositoryFixture;
+
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@SpringBootTest
+public class WorkspaceCommandServiceTest {
+
+	@Autowired
+	private WorkspaceService workspaceService;
+	@Autowired
+	private WorkspaceCommandService workspaceCommandService;
+	@Autowired
+	private WorkspaceRepository workspaceRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private WorkspaceMemberRepository workspaceMemberRepository;
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+	@Autowired
+	private EntityManager entityManager;
+
+	@Autowired
+	private WorkspaceRepositoryFixture workspaceRepositoryFixture;
+	@Autowired
+	private MemberRespositoryFixture memberRespositoryFixture;
+
+	@AfterEach
+	void tearDown() {
+		workspaceMemberRepository.deleteAll();
+		workspaceRepository.deleteAll();
+		memberRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("유효한 워크스페이스 코드와 비밀번호로 워크스페이스를 삭제할 수 있다")
+	void test1() {
+		// given
+		Member member = memberRespositoryFixture.createMember("member1", "member1@test.com", "member1password!");
+		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
+			passwordEncoder.encode("password1234!"));
+		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.ADMIN);
+
+		workspaceRepositoryFixture.createWorkspace("workspace2", "description2", "TEST2222", null);
+
+		// when
+		workspaceCommandService.deleteWorkspace(new WorkspaceDeleteRequest("password1234!"), "TEST1111");
+
+		// then
+		assertThat(workspaceRepository.findByCode("TEST1111")).isEmpty();
+	}
+
+	@Transactional
+	@Test
+	@DisplayName("워크스페이스 삭제 시도 시 비밀번호가 맞지 않으면 예외가 발생한다")
+	void test2() {
+		// given
+		Member member = memberRespositoryFixture.createMember("member1", "member1@test.com", "member1password!");
+		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
+			passwordEncoder.encode("password1234!"));
+		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.ADMIN);
+
+		// when & then
+		assertThatThrownBy(
+			() -> workspaceCommandService.deleteWorkspace(new WorkspaceDeleteRequest("InvalidPassword"), "TEST1111"))
+			.isInstanceOf(InvalidWorkspacePasswordException.class);
+
+	}
+
+	@Transactional
+	@Test
+	@DisplayName("워크스페이스 삭제 시도 시 코드가 유효하지 않으면 예외가 발생한다")
+	void test3() {
+		// given
+		Member member = memberRespositoryFixture.createMember("member1", "member1@test.com", "member1password!");
+		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
+			passwordEncoder.encode("password1234!"));
+		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.ADMIN);
+
+		// when & then
+		assertThatThrownBy(
+			() -> workspaceCommandService.deleteWorkspace(new WorkspaceDeleteRequest("password1234!"), "INVALIDCODE"))
+			.isInstanceOf(WorkspaceNotFoundException.class);
+
+	}
+
+	@Transactional
+	@Test
+	@DisplayName("유효한 워크스페이스 코드로 워크스페이스의 이름과 설명을 수정할 수 있다")
+	void test4() {
+		// given
+		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
+			null);
+
+		WorkspaceContentUpdateRequest request = WorkspaceContentUpdateRequest.builder()
+			.name("Updated Name")
+			.description("Updated Description")
+			.build();
+
+		// when
+		WorkspaceContentUpdateResponse response = workspaceCommandService.updateWorkspaceContent(request, "TEST1111");
+
+		// then
+		assertThat(response.getUpdatedTo().getName()).isEqualTo("Updated Name");
+		assertThat(response.getUpdatedTo().getDescription()).isEqualTo("Updated Description");
+	}
+
+	@Transactional
+	@Test
+	@DisplayName("워크스페이스의 이름만 수정하면 해당 필드만 업데이트된다")
+	void test5() {
+		// given
+		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
+			null);
+
+		WorkspaceContentUpdateRequest request = WorkspaceContentUpdateRequest.builder()
+			.name("Updated Name")
+			.build();
+
+		// when
+		WorkspaceContentUpdateResponse response = workspaceCommandService.updateWorkspaceContent(request, "TEST1111");
+
+		// then
+		assertThat(response.getUpdatedTo().getName()).isEqualTo("Updated Name");
+		assertThat(response.getUpdatedTo().getDescription()).isEqualTo("description1");
+	}
+
+	@Transactional
+	@Test
+	@DisplayName("워크스페이스의 설명만 수정하면 해당 필드만 업데이트된다")
+	void test6() {
+		// given
+		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
+			null);
+
+		WorkspaceContentUpdateRequest request = WorkspaceContentUpdateRequest.builder()
+			.description("Updated Description")
+			.build();
+
+		// when
+		WorkspaceContentUpdateResponse response = workspaceCommandService.updateWorkspaceContent(request, "TEST1111");
+
+		// then
+		assertThat(response.getUpdatedTo().getName()).isEqualTo("workspace1");
+		assertThat(response.getUpdatedTo().getDescription()).isEqualTo("Updated Description");
+	}
+
+	@Transactional
+	@Test
+	@DisplayName("비밀번호 수정 요청의 원본 비밀번호가 유효하면 요청의 수정 비밀번호로 업데이트된다")
+	void test7() {
+		// given
+		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
+			passwordEncoder.encode("password1234!"));
+
+		WorkspacePasswordUpdateRequest request = WorkspacePasswordUpdateRequest.builder()
+			.originalPassword("password1234!")
+			.updatePassword("updated1234!")
+			.build();
+
+		// when
+		workspaceCommandService.updateWorkspacePassword(request, "TEST1111");
+		entityManager.flush();
+
+		// then
+		String updatedPassword = workspaceRepository.findByCode("TEST1111").get().getPassword();
+		assertThat(passwordEncoder.matches("updated1234!", updatedPassword)).isTrue();
+	}
+
+	@Transactional
+	@Test
+	@DisplayName("워크스페이스의 비밀번호가 null이면 비밀번호 수정 요청의 수정 비밀번호로 업데이트된다")
+	void test8() {
+		// given
+		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
+			null);
+
+		WorkspacePasswordUpdateRequest request = WorkspacePasswordUpdateRequest.builder()
+			.updatePassword("updated1234!")
+			.build();
+
+		// when
+		workspaceCommandService.updateWorkspacePassword(request, "TEST1111");
+		entityManager.flush();
+
+		// then
+		String updatedPassword = workspaceRepository.findByCode("TEST1111").get().getPassword();
+		assertThat(passwordEncoder.matches("updated1234!", updatedPassword)).isTrue();
+	}
+
+	@Test
+	@DisplayName("비밀번호 수정 요청의 원본 비밀번호가 유효하지 않으면 예외가 발생한다")
+	void test9() {
+		// given
+		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
+			passwordEncoder.encode("password1234!"));
+
+		WorkspacePasswordUpdateRequest request = WorkspacePasswordUpdateRequest.builder()
+			.originalPassword("invalid1234!")
+			.updatePassword("updated1234!")
+			.build();
+
+		// when
+		assertThatThrownBy(() -> workspaceCommandService.updateWorkspacePassword(request, "TEST1111"))
+			.isInstanceOf(InvalidWorkspacePasswordException.class);
+	}
+
+	@Transactional
+	@Test
+	@DisplayName("비밀번호 수정 요청의 수정 비밀번호를 제공하지 않으면 비밀번호는 null로 업데이트 된다")
+	void test10() {
+		// given
+		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
+			passwordEncoder.encode("password1234!"));
+
+		WorkspacePasswordUpdateRequest request = WorkspacePasswordUpdateRequest.builder()
+			.originalPassword("password1234!")
+			.build();
+
+		// when
+		workspaceCommandService.updateWorkspacePassword(request, "TEST1111");
+		entityManager.flush();
+
+		// then
+		String updatedPassword = workspaceRepository.findByCode("TEST1111").get().getPassword();
+		assertThat(updatedPassword).isNull();
+
+	}
+
+	@Transactional
+	@Test
+	@DisplayName("비밀번호 수정 요청의 수정 비밀번호를 null로 제공하면 비밀번호는 null로 업데이트 된다")
+	void test11() {
+		// given
+		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
+			passwordEncoder.encode("password1234!"));
+
+		WorkspacePasswordUpdateRequest request = WorkspacePasswordUpdateRequest.builder()
+			.originalPassword("password1234!")
+			.updatePassword(null)
+			.build();
+
+		// when
+		workspaceCommandService.updateWorkspacePassword(request, "TEST1111");
+		entityManager.flush();
+
+		// then
+		String updatedPassword = workspaceRepository.findByCode("TEST1111").get().getPassword();
+		assertThat(updatedPassword).isNull();
+
+	}
+}

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceQueryServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceQueryServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspace.dto.WorkspaceDetail;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceParticipateRequest;
@@ -40,6 +42,8 @@ public class WorkspaceQueryServiceTest {
 	private WorkspaceRepository workspaceRepository;
 	@Autowired
 	private WorkspaceMemberRepository workspaceMemberRepository;
+	@Autowired
+	private MemberRepository memberRepository;
 
 	@Autowired
 	private WorkspaceRepositoryFixture workspaceRepositoryFixture;
@@ -56,6 +60,13 @@ public class WorkspaceQueryServiceTest {
 			null);
 		workspaceRepositoryFixture.addMemberToWorkspace(member1, workspace1, WorkspaceRole.ADMIN);
 		workspaceRepositoryFixture.addMemberToWorkspace(member1, workspace2, WorkspaceRole.ADMIN);
+	}
+
+	@AfterEach
+	void tearDown() {
+		workspaceMemberRepository.deleteAll();
+		workspaceRepository.deleteAll();
+		memberRepository.deleteAll();
 	}
 
 	@Transactional


### PR DESCRIPTION
## 🚀 설명
- 워크스페이스 상세 조회 구현
- 참여하는 모든 워크스페이스 조회 구현
- 워크스페이스 삭제 구현
- 워크스페이스 내용 수정 구현
- 워크스페이스 비밀번호 수정 구현
- 테스트 코드 추가

---
## ✅ 변경 사항
- [x] 구현 기능에 대한 컨트롤러, 서비스 코드
- [x] 워크스페이스 도메인에 대해 Query/Command 서비스 분리
- [x] 관련 테스트 코드

---
## 🚩 관련 이슈, PR
- #30 
- #58 

---
## 📖 참고