### PR TITLE
Feat/#30 workspace headcount

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/invitation/service/InvitationService.java
+++ b/src/main/java/com/uranus/taskmanager/api/invitation/service/InvitationService.java
@@ -10,6 +10,8 @@ import com.uranus.taskmanager.api.invitation.dto.response.InvitationAcceptRespon
 import com.uranus.taskmanager.api.invitation.exception.InvalidInvitationStatusException;
 import com.uranus.taskmanager.api.invitation.exception.InvitationNotFoundException;
 import com.uranus.taskmanager.api.invitation.repository.InvitationRepository;
+import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
@@ -51,10 +53,21 @@ public class InvitationService {
 		return invitation;
 	}
 
+	/*
+	 * Todo
+	 *  - 워크스페이스에 낙관적락 적용 시 예외 잡고 재시도 로직 추가 필요
+	 *  - 이 메서드에 try-catch vs acceptInvitation에서 try-catch를 할지 고민
+	 */
 	private WorkspaceMember addMemberToWorkspace(Invitation invitation) {
-		WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(invitation.getMember(),
-			invitation.getWorkspace(), WorkspaceRole.USER, invitation.getMember().getEmail());
+		Workspace workspace = invitation.getWorkspace();
+		Member member = invitation.getMember();
+		WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member,
+			workspace, WorkspaceRole.USER, member.getEmail());
+
+		workspace.increaseMemberCount();
+
 		workspaceMemberRepository.save(workspaceMember);
+
 		return workspaceMember;
 	}
 

--- a/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
@@ -117,10 +117,9 @@ public class WorkspaceController {
 	@PostMapping("/{code}/invite")
 	public ApiResponse<InviteMemberResponse> inviteMember(
 		@PathVariable String code,
-		@LoginMember LoginMemberDto loginMember,
 		@RequestBody @Valid InviteMemberRequest request) {
 
-		InviteMemberResponse response = workspaceService.inviteMember(code, request, loginMember);
+		InviteMemberResponse response = workspaceService.inviteMember(code, request);
 		return ApiResponse.ok("Member Invited", response);
 	}
 
@@ -129,10 +128,9 @@ public class WorkspaceController {
 	@PostMapping("/{code}/invites")
 	public ApiResponse<InviteMembersResponse> inviteMembers(
 		@PathVariable String code,
-		@LoginMember LoginMemberDto loginMember,
 		@RequestBody @Valid InviteMembersRequest request) {
 
-		InviteMembersResponse response = workspaceService.inviteMembers(code, request, loginMember);
+		InviteMembersResponse response = workspaceService.inviteMembers(code, request);
 		return ApiResponse.ok("Members Invited", response);
 	}
 

--- a/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
@@ -23,10 +23,15 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Workspace extends BaseEntity {
+
+	// @Version
+	// private Long version;
+
 	/**
 	 * Todo
-	 *  - 인원(headcount) 필드 추가 고려(현재 서비스에서 headcount 계산해서 DTO로 넘기는 중)
-	 *  - headcount에 캐시 적용 고려
+	 *  - memberCount에 캐시 적용 고려
+	 *  - 낙관적락 적용 고려
+	 *  -> memberCount 증가/감소가 들어가는 로직은 전부 예외를 잡고 재수행 로직을 적용해야 한다
 	 */
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,9 +43,13 @@ public class Workspace extends BaseEntity {
 
 	@Column(nullable = false)
 	private String name;
+	@Column(nullable = false)
+	private String description;
 
 	private String password;
-	private String description;
+
+	@Column(nullable = false)
+	private int memberCount;
 
 	@OneToMany(mappedBy = "workspace", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<WorkspaceMember> workspaceMembers = new ArrayList<>();
@@ -71,4 +80,15 @@ public class Workspace extends BaseEntity {
 	public void updateDescription(String description) {
 		this.description = description;
 	}
+
+	public void increaseMemberCount() {
+		this.memberCount++;
+	}
+
+	public void decreaseMemberCount() {
+		if (this.memberCount > 0) {
+			this.memberCount--;
+		}
+	}
+
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
@@ -49,7 +49,7 @@ public class Workspace extends BaseEntity {
 	private String password;
 
 	@Column(nullable = false)
-	private int memberCount;
+	private int memberCount = 1;
 
 	@OneToMany(mappedBy = "workspace", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<WorkspaceMember> workspaceMembers = new ArrayList<>();

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/WorkspaceDetail.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/WorkspaceDetail.java
@@ -13,33 +13,31 @@ import lombok.ToString;
 @Getter
 public class WorkspaceDetail {
 
+	/**
+	 * Todo
+	 *  - role 제거: role이 필요한 응답 DTO는 role 필드를 추가해서 사용하자
+	 *  - WorkspaceDetail은 멤버에 상관없이 단순히 해당 워크스페이스에서 사용하는 일반 정보만을 나타내도록 하자
+	 */
+
 	private Long id;
 	private String code;
 	private String name;
 	private String description;
+	private int memberCount;
 	private String createdBy;
 	private LocalDateTime createdAt;
 	private String updatedBy;
 	private LocalDateTime updatedAt;
 	private WorkspaceRole role;
 
-	/*
-	 * Todo
-	 *  - Workspace에 headcount 필드 추가
-	 *  - Workspace에 increaseHeadcount(), decreaseHeadcount() 추가
-	 *  - WorkspaceMember에 removeWorkspaceMember() 추가
-	 *  - headcount 필드 추가에 따라 WorkspaceService의 participateWorkspace()를 수정한다
-	 *  - 이후 WorkspaceDetail의 headcount 사용
-	 */
-	// private int headcount;
-
 	@Builder
-	public WorkspaceDetail(Long id, String code, String name, String description, String createdBy,
+	public WorkspaceDetail(Long id, String code, String name, String description, int memberCount, String createdBy,
 		LocalDateTime createdAt, String updatedBy, LocalDateTime updatedAt, WorkspaceRole role) {
 		this.id = id;
 		this.code = code;
 		this.name = name;
 		this.description = description;
+		this.memberCount = memberCount;
 		this.createdBy = createdBy;
 		this.createdAt = createdAt;
 		this.updatedBy = updatedBy;
@@ -53,6 +51,7 @@ public class WorkspaceDetail {
 			.code(workspace.getCode())
 			.name(workspace.getName())
 			.description(workspace.getDescription())
+			.memberCount(workspace.getMemberCount())
 			.createdBy(workspace.getCreatedBy())
 			.createdAt(workspace.getCreatedDate())
 			.updatedBy(workspace.getLastModifiedBy())

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/WorkspaceParticipateResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/WorkspaceParticipateResponse.java
@@ -12,27 +12,27 @@ import lombok.ToString;
 @Getter
 public class WorkspaceParticipateResponse {
 
+	/**
+	 * Todo
+	 *  - WorkspaceDetail에 role 정보가 빠짐
+	 *  - role 필드를 추가 -> 서비스 코드 수정
+	 */
 	private WorkspaceDetail workspaceDetail;
-	// Todo: Workspace에 headcount 필드 추가 -> WorkspaceDetail에 headcount 추가
-	//  -> WorkspaceParticipateResponse의 headcount 제거
-	private int headcount;
 	private String nickname;
 	private boolean isAlreadyMember;
 
 	@Builder
-	public WorkspaceParticipateResponse(WorkspaceDetail workspaceDetail, int headcount, String nickname,
+	public WorkspaceParticipateResponse(WorkspaceDetail workspaceDetail, String nickname,
 		boolean isAlreadyMember) {
 		this.workspaceDetail = workspaceDetail;
-		this.headcount = headcount;
 		this.nickname = nickname;
 		this.isAlreadyMember = isAlreadyMember;
 	}
 
 	public static WorkspaceParticipateResponse from(Workspace workspace, WorkspaceMember workspaceMember,
-		int headcount, boolean isAlreadyMember) {
+		boolean isAlreadyMember) {
 		return WorkspaceParticipateResponse.builder()
 			.workspaceDetail(WorkspaceDetail.from(workspace, workspaceMember.getRole()))
-			.headcount(headcount)
 			.nickname(workspaceMember.getNickname())
 			.isAlreadyMember(isAlreadyMember)
 			.build();

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandService.java
@@ -18,7 +18,6 @@ import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 
 import lombok.RequiredArgsConstructor;
 
-@Transactional
 @RequiredArgsConstructor
 @Service
 public class WorkspaceCommandService {
@@ -26,6 +25,7 @@ public class WorkspaceCommandService {
 	private final WorkspaceRepository workspaceRepository;
 	private final PasswordEncoder passwordEncoder;
 
+	@Transactional
 	public WorkspaceContentUpdateResponse updateWorkspaceContent(WorkspaceContentUpdateRequest request, String code) {
 		Workspace workspace = findWorkspaceByCode(code);
 		WorkspaceUpdateDetail original = WorkspaceUpdateDetail.from(workspace);
@@ -41,6 +41,7 @@ public class WorkspaceCommandService {
 		return WorkspaceContentUpdateResponse.from(original, updatedTo);
 	}
 
+	@Transactional
 	public void updateWorkspacePassword(WorkspacePasswordUpdateRequest request, String code) {
 		Workspace workspace = findWorkspaceByCode(code);
 
@@ -50,6 +51,7 @@ public class WorkspaceCommandService {
 		workspace.updatePassword(encodedUpdatePassword);
 	}
 
+	@Transactional
 	public void deleteWorkspace(WorkspaceDeleteRequest request, String code) {
 		Workspace workspace = findWorkspaceByCode(code);
 

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceQueryService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceQueryService.java
@@ -19,7 +19,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class WorkspaceQueryService {
@@ -27,6 +26,7 @@ public class WorkspaceQueryService {
 	private final WorkspaceMemberRepository workspaceMemberRepository;
 	private final WorkspaceRepository workspaceRepository;
 
+	@Transactional(readOnly = true)
 	public WorkspaceDetail getWorkspaceDetail(String workspaceCode, LoginMemberDto loginMember) {
 
 		Workspace workspace = findWorkspaceByCode(workspaceCode);
@@ -37,10 +37,11 @@ public class WorkspaceQueryService {
 		return WorkspaceDetail.from(workspace, workspaceMember.getRole());
 	}
 
+	@Transactional(readOnly = true)
 	public MyWorkspacesResponse getMyWorkspaces(LoginMemberDto loginMember, Pageable pageable) {
 
 		String loginId = loginMember.getLoginId();
-		
+
 		Page<WorkspaceDetail> workspaceDetails = workspaceMemberRepository.findByMemberLoginId(loginId, pageable)
 			.map(workspaceMember -> WorkspaceDetail.from(
 				workspaceMember.getWorkspace(),

--- a/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
@@ -381,8 +381,7 @@ class WorkspaceControllerTest {
 
 		InviteMemberResponse inviteMemberResponse = InviteMemberResponse.from(invitation);
 
-		when(workspaceService.inviteMember(eq(workspaceCode), ArgumentMatchers.any(InviteMemberRequest.class),
-			ArgumentMatchers.any(LoginMemberDto.class)))
+		when(workspaceService.inviteMember(eq(workspaceCode), ArgumentMatchers.any(InviteMemberRequest.class)))
 			.thenReturn(inviteMemberResponse);
 
 		// when & then
@@ -413,8 +412,7 @@ class WorkspaceControllerTest {
 
 		InviteMembersResponse inviteMembersResponse = new InviteMembersResponse(successfulResponses, failedResponses);
 
-		when(workspaceService.inviteMembers(eq(workspaceCode), ArgumentMatchers.any(InviteMembersRequest.class),
-			ArgumentMatchers.any(LoginMemberDto.class)))
+		when(workspaceService.inviteMembers(eq(workspaceCode), ArgumentMatchers.any(InviteMembersRequest.class)))
 			.thenReturn(inviteMembersResponse);
 
 		// then
@@ -458,8 +456,7 @@ class WorkspaceControllerTest {
 			.build();
 
 		// when
-		when(workspaceService.inviteMembers(eq(workspaceCode), ArgumentMatchers.any(InviteMembersRequest.class),
-			ArgumentMatchers.any(LoginMemberDto.class)))
+		when(workspaceService.inviteMembers(eq(workspaceCode), ArgumentMatchers.any(InviteMembersRequest.class)))
 			.thenReturn(inviteMembersResponse);
 
 		// then
@@ -489,7 +486,7 @@ class WorkspaceControllerTest {
 		WorkspaceParticipateRequest request = new WorkspaceParticipateRequest(workspace.getPassword());
 		String requestBody = objectMapper.writeValueAsString(request);
 
-		WorkspaceParticipateResponse response = WorkspaceParticipateResponse.from(workspace, workspaceMember, 1, false);
+		WorkspaceParticipateResponse response = WorkspaceParticipateResponse.from(workspace, workspaceMember, false);
 
 		when(workspaceService.participateWorkspace(eq(workspaceCode),
 			ArgumentMatchers.any(WorkspaceParticipateRequest.class),
@@ -501,7 +498,6 @@ class WorkspaceControllerTest {
 				.content(requestBody))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.message").value("Joined Workspace"))
-			.andExpect(jsonPath("$.data.headcount").value(1))
 			.andExpect(jsonPath("$.data.alreadyMember").value(false))
 			.andDo(print());
 

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceServiceTest.java
@@ -136,14 +136,11 @@ class WorkspaceServiceTest {
 	void test8() {
 		// given
 		String workspaceCode = "TESTCODE";
-		String loginId = "user123";
-		String email = "user123@test.com";
 
 		String invitedLoginId = "inviteduser123";
 		String invitedEmail = "inviteduser123@test.com";
 
 		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
-		LoginMemberDto loginMember = loginMemberDtoFixture.createLoginMemberDto(loginId, email);
 
 		Member invitedMember = memberEntityFixture.createMember(invitedLoginId, invitedEmail);
 
@@ -155,8 +152,7 @@ class WorkspaceServiceTest {
 		when(memberRepository.findByLoginIdOrEmail(identifier, identifier)).thenReturn(Optional.of(invitedMember));
 
 		// when
-		InviteMemberResponse inviteMemberResponse = workspaceService.inviteMember(workspaceCode, inviteMemberRequest,
-			loginMember);
+		InviteMemberResponse inviteMemberResponse = workspaceService.inviteMember(workspaceCode, inviteMemberRequest);
 
 		// then
 		assertThat(inviteMemberResponse.getStatus()).isEqualTo(InvitationStatus.PENDING);
@@ -168,12 +164,8 @@ class WorkspaceServiceTest {
 	void test4() {
 		// given
 		String workspaceCode = "INVALIDCODE";
-		String loginId = "user123";
-		String email = "user123@test.com";
 
 		String invitedLoginId = "inviteduser123";
-
-		LoginMemberDto loginMember = loginMemberDtoFixture.createLoginMemberDto(loginId, email);
 
 		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(invitedLoginId);
 
@@ -181,7 +173,7 @@ class WorkspaceServiceTest {
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest, loginMember))
+			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest))
 			.isInstanceOf(WorkspaceNotFoundException.class);
 
 	}
@@ -191,13 +183,10 @@ class WorkspaceServiceTest {
 	void test5() {
 		// given
 		String workspaceCode = "TESTCODE";
-		String loginId = "user123";
-		String email = "user123@test.com";
 
 		String invitedLoginId = "inviteduser123";
 
 		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
-		LoginMemberDto loginMember = loginMemberDtoFixture.createLoginMemberDto(loginId, email);
 
 		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(invitedLoginId);
 		String identifier = inviteMemberRequest.getMemberIdentifier();
@@ -208,7 +197,7 @@ class WorkspaceServiceTest {
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest, loginMember))
+			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest))
 			.isInstanceOf(MemberNotFoundException.class);
 	}
 
@@ -217,14 +206,11 @@ class WorkspaceServiceTest {
 	void test6() {
 		// given
 		String workspaceCode = "TESTCODE";
-		String loginId = "user123";
-		String email = "user123@test.com";
 
 		String invitedLoginId = "inviteduser123";
 		String invitedEmail = "inviteduser123@test.com";
 
 		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
-		LoginMemberDto loginMember = loginMemberDtoFixture.createLoginMemberDto(loginId, email);
 
 		Member invitedMember = memberEntityFixture.createMember(invitedLoginId, invitedEmail);
 		Invitation invitation = invitationEntityFixture.createPendingInvitation(workspace, invitedMember);
@@ -236,13 +222,13 @@ class WorkspaceServiceTest {
 
 		when(memberRepository.findByLoginIdOrEmail(identifier, identifier)).thenReturn(Optional.of(invitedMember));
 
-		when(invitationRepository.findByWorkspaceAndMember(workspace, invitedMember)).thenReturn(
-			Optional.of(invitation));
+		when(invitationRepository.findByWorkspaceAndMember(workspace, invitedMember))
+			.thenReturn(Optional.of(invitation));
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest, loginMember)).isInstanceOf(
-			InvitationAlreadyExistsException.class);
+			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest))
+			.isInstanceOf(InvitationAlreadyExistsException.class);
 	}
 
 	@Test
@@ -250,14 +236,11 @@ class WorkspaceServiceTest {
 	void test7() {
 		// given
 		String workspaceCode = "TESTCODE";
-		String loginId = "user123";
-		String email = "user123@test.com";
 
 		String invitedLoginId = "inviteduser123";
 		String invitedEmail = "inviteduser123@test.com";
 
 		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
-		LoginMemberDto loginMember = loginMemberDtoFixture.createLoginMemberDto(loginId, email);
 
 		Member invitedMember = memberEntityFixture.createMember(invitedLoginId, invitedEmail);
 		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createUserWorkspaceMember(invitedMember,
@@ -275,7 +258,7 @@ class WorkspaceServiceTest {
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest, loginMember))
+			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest))
 			.isInstanceOf(MemberAlreadyParticipatingException.class);
 	}
 
@@ -291,9 +274,6 @@ class WorkspaceServiceTest {
 
 		List<String> memberIdentifiers = List.of(member1Id, member2Id);
 		InviteMembersRequest inviteMembersRequest = new InviteMembersRequest(memberIdentifiers);
-
-		// Mock LoginMemberDto
-		LoginMemberDto loginMember = loginMemberDtoFixture.createLoginMemberDto("inviter", "inviter@test.com");
 
 		// Mock Workspace
 		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
@@ -311,8 +291,7 @@ class WorkspaceServiceTest {
 		when(invitationRepository.save(any(Invitation.class))).thenReturn(invitation1).thenReturn(invitation2);
 
 		// when
-		InviteMembersResponse response = workspaceService.inviteMembers(workspaceCode, inviteMembersRequest,
-			loginMember);
+		InviteMembersResponse response = workspaceService.inviteMembers(workspaceCode, inviteMembersRequest);
 
 		log.info("response = {}", response);
 
@@ -338,7 +317,6 @@ class WorkspaceServiceTest {
 
 		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
 		when(memberRepository.findByLoginId(loginMember.getLoginId())).thenReturn(Optional.of(member));
-		when(workspaceMemberRepository.countByWorkspaceId(workspace.getId())).thenReturn(3);
 		when(workspaceMemberRepository.findByMemberLoginIdAndWorkspaceCode(loginMember.getLoginId(), workspaceCode))
 			.thenReturn(Optional.empty());
 		when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
@@ -350,7 +328,6 @@ class WorkspaceServiceTest {
 		// then
 		assertThat(response.isAlreadyMember()).isFalse();
 		assertThat(response.getWorkspaceDetail().getCode()).isEqualTo(workspaceCode);
-		assertThat(response.getHeadcount()).isEqualTo(3);
 	}
 
 	@Test
@@ -370,7 +347,6 @@ class WorkspaceServiceTest {
 
 		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
 		when(memberRepository.findByLoginId(loginMember.getLoginId())).thenReturn(Optional.of(member));
-		when(workspaceMemberRepository.countByWorkspaceId(workspace.getId())).thenReturn(3);
 		when(workspaceMemberRepository.findByMemberLoginIdAndWorkspaceCode(loginMember.getLoginId(), workspaceCode))
 			.thenReturn(Optional.of(workspaceMember));
 
@@ -382,7 +358,6 @@ class WorkspaceServiceTest {
 		assertThat(response).isNotNull();
 		assertThat(response.isAlreadyMember()).isTrue();
 		assertThat(response.getWorkspaceDetail().getCode()).isEqualTo(workspaceCode);
-		assertThat(response.getHeadcount()).isEqualTo(3);
 	}
 
 	@Test


### PR DESCRIPTION
## 🚀 설명
- `memberCount` 필드를 `Workspace` 엔티티에 추가
- 인원수 증가/감소 메서드 `Workspace`에 추가
- `memberCount`에 대한 동시성 문제(Lost Update) 문제를 해결하기 위해 추후에 낙관적 락 적용 고려 

---
## ✅ 변경 사항
- [x] `memberCount` 추가
- [x] `memberCount` 적용
- [x] 트랜잭션 애노테이션을 클래스 레벨에서 메서드 레벨로 이동(가독성을 위해)

---
## 🚩 관련 이슈, PR
- #66 
- #65 

---
## 📖 참고