### PR TITLE
Feat/#30 workspace member kick

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ jacocoTestReport {
                 files(classDirectories.files.collect {
                     fileTree(dir: it, excludes: [
                             "com.uranus/taskmanager/api/**/domain/**",
+                            "com.uranus/taskmanager/api/**/dto/**",
                             "**/*Application*",
                             "**/*Request*",
                             "**/*Response*",
@@ -85,6 +86,7 @@ jacocoTestReport {
 
                 excludes = [
                         "com.uranus.taskmanager.api.**.domain.**",
+                        "com.uranus.taskmanager.api.**.dto.**",
                         "**.*Application*",
                         "**.*Request*",
                         "**.*Response*",

--- a/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceAccessController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceAccessController.java
@@ -1,5 +1,6 @@
 package com.uranus.taskmanager.api.workspace.controller;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -12,9 +13,11 @@ import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.common.ApiResponse;
 import com.uranus.taskmanager.api.workspace.dto.request.InviteMemberRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.InviteMembersRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.KickWorkspaceMemberRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceParticipateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.InviteMemberResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.InviteMembersResponse;
+import com.uranus.taskmanager.api.workspace.dto.response.KickWorkspaceMemberResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceParticipateResponse;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceAccessService;
 import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
@@ -64,5 +67,17 @@ public class WorkspaceAccessController {
 
 		WorkspaceParticipateResponse response = workspaceAccessService.joinWorkspace(code, request, loginMember);
 		return ApiResponse.ok("Joined Workspace", response);
+	}
+
+	@LoginRequired
+	@RoleRequired(roles = {WorkspaceRole.ADMIN})
+	@DeleteMapping("/{code}/kick")
+	public ApiResponse<KickWorkspaceMemberResponse> kickWorkspaceMember(
+		@PathVariable String code,
+		@RequestBody @Valid KickWorkspaceMemberRequest request
+	) {
+
+		KickWorkspaceMemberResponse response = workspaceAccessService.kickWorkspaceMember(code, request);
+		return ApiResponse.ok("Member was kicked from this Workspace", response);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceAccessController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceAccessController.java
@@ -1,0 +1,68 @@
+package com.uranus.taskmanager.api.workspace.controller;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.uranus.taskmanager.api.authentication.LoginMember;
+import com.uranus.taskmanager.api.authentication.LoginRequired;
+import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
+import com.uranus.taskmanager.api.common.ApiResponse;
+import com.uranus.taskmanager.api.workspace.dto.request.InviteMemberRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.InviteMembersRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceParticipateRequest;
+import com.uranus.taskmanager.api.workspace.dto.response.InviteMemberResponse;
+import com.uranus.taskmanager.api.workspace.dto.response.InviteMembersResponse;
+import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceParticipateResponse;
+import com.uranus.taskmanager.api.workspace.service.WorkspaceAccessService;
+import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspacemember.authorization.RoleRequired;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/workspaces")
+public class WorkspaceAccessController {
+
+	private final WorkspaceAccessService workspaceAccessService;
+
+	@LoginRequired
+	@RoleRequired(roles = {WorkspaceRole.ADMIN})
+	@PostMapping("/{code}/invite")
+	public ApiResponse<InviteMemberResponse> inviteMember(
+		@PathVariable String code,
+		@RequestBody @Valid InviteMemberRequest request) {
+
+		InviteMemberResponse response = workspaceAccessService.inviteMember(code, request);
+		return ApiResponse.ok("Member Invited", response);
+	}
+
+	@LoginRequired
+	@RoleRequired(roles = {WorkspaceRole.ADMIN})
+	@PostMapping("/{code}/invites")
+	public ApiResponse<InviteMembersResponse> inviteMembers(
+		@PathVariable String code,
+		@RequestBody @Valid InviteMembersRequest request) {
+
+		InviteMembersResponse response = workspaceAccessService.inviteMembers(code, request);
+		return ApiResponse.ok("Members Invited", response);
+	}
+
+	@LoginRequired
+	@PostMapping("/{code}")
+	public ApiResponse<WorkspaceParticipateResponse> joinWorkspace(
+		@PathVariable String code,
+		@LoginMember LoginMemberDto loginMember,
+		@RequestBody @Valid WorkspaceParticipateRequest request
+	) {
+
+		WorkspaceParticipateResponse response = workspaceAccessService.joinWorkspace(code, request, loginMember);
+		return ApiResponse.ok("Joined Workspace", response);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
@@ -18,23 +18,16 @@ import com.uranus.taskmanager.api.authentication.LoginRequired;
 import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.common.ApiResponse;
 import com.uranus.taskmanager.api.workspace.dto.WorkspaceDetail;
-import com.uranus.taskmanager.api.workspace.dto.request.InviteMemberRequest;
-import com.uranus.taskmanager.api.workspace.dto.request.InviteMembersRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceContentUpdateRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceDeleteRequest;
-import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceParticipateRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspacePasswordUpdateRequest;
-import com.uranus.taskmanager.api.workspace.dto.response.InviteMemberResponse;
-import com.uranus.taskmanager.api.workspace.dto.response.InviteMembersResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.MyWorkspacesResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceContentUpdateResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceCreateResponse;
-import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceParticipateResponse;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceCommandService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceCreateService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceQueryService;
-import com.uranus.taskmanager.api.workspace.service.WorkspaceService;
 import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
 import com.uranus.taskmanager.api.workspacemember.authorization.RoleRequired;
 
@@ -48,7 +41,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/v1/workspaces")
 public class WorkspaceController {
 
-	private final WorkspaceService workspaceService;
 	private final WorkspaceCreateService workspaceCreateService;
 	private final WorkspaceCommandService workspaceCommandService;
 	private final WorkspaceQueryService workspaceQueryService;
@@ -111,44 +103,4 @@ public class WorkspaceController {
 		MyWorkspacesResponse response = workspaceQueryService.getMyWorkspaces(loginMember, pageable);
 		return ApiResponse.ok("Currently joined Workspaces Found", response);
 	}
-
-	@LoginRequired
-	@RoleRequired(roles = {WorkspaceRole.ADMIN})
-	@PostMapping("/{code}/invite")
-	public ApiResponse<InviteMemberResponse> inviteMember(
-		@PathVariable String code,
-		@RequestBody @Valid InviteMemberRequest request) {
-
-		InviteMemberResponse response = workspaceService.inviteMember(code, request);
-		return ApiResponse.ok("Member Invited", response);
-	}
-
-	@LoginRequired
-	@RoleRequired(roles = {WorkspaceRole.ADMIN})
-	@PostMapping("/{code}/invites")
-	public ApiResponse<InviteMembersResponse> inviteMembers(
-		@PathVariable String code,
-		@RequestBody @Valid InviteMembersRequest request) {
-
-		InviteMembersResponse response = workspaceService.inviteMembers(code, request);
-		return ApiResponse.ok("Members Invited", response);
-	}
-
-	/*
-	 * Todo
-	 *  - participate -> join으로 명칭 변경
-	 *  - MemberAlreadyParticipationException -> AlreadyJoinedWorkspaceException 명칭 변경
-	 */
-	@LoginRequired
-	@PostMapping("/{code}")
-	public ApiResponse<WorkspaceParticipateResponse> participateWorkspace(
-		@PathVariable String code,
-		@LoginMember LoginMemberDto loginMember,
-		@RequestBody @Valid WorkspaceParticipateRequest request
-	) {
-
-		WorkspaceParticipateResponse response = workspaceService.participateWorkspace(code, request, loginMember);
-		return ApiResponse.ok("Joined Workspace", response);
-	}
-
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/KickWorkspaceMemberRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/request/KickWorkspaceMemberRequest.java
@@ -1,0 +1,15 @@
+package com.uranus.taskmanager.api.workspace.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KickWorkspaceMemberRequest {
+
+	private String memberIdentifier;
+
+	public KickWorkspaceMemberRequest(String memberIdentifier) {
+		this.memberIdentifier = memberIdentifier;
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/FailedInvitedMember.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/FailedInvitedMember.java
@@ -1,8 +1,12 @@
 package com.uranus.taskmanager.api.workspace.dto.response;
 
+import java.util.Objects;
+
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
+@ToString
 @Getter
 public class FailedInvitedMember {
 	private final String identifier;
@@ -12,5 +16,20 @@ public class FailedInvitedMember {
 	public FailedInvitedMember(String identifier, String error) {
 		this.identifier = identifier;
 		this.error = error;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		FailedInvitedMember that = (FailedInvitedMember)o;
+		return Objects.equals(identifier, that.identifier) && Objects.equals(error, that.error);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(identifier, error);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/InvitedMember.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/InvitedMember.java
@@ -1,10 +1,14 @@
 package com.uranus.taskmanager.api.workspace.dto.response;
 
+import java.util.Objects;
+
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
+@ToString
 @Getter
 public class InvitedMember {
 	private final String loginId;
@@ -21,5 +25,20 @@ public class InvitedMember {
 			.email(invitation.getMember().getEmail())
 			.loginId(invitation.getMember().getLoginId())
 			.build();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		InvitedMember that = (InvitedMember)o;
+		return Objects.equals(loginId, that.loginId) && Objects.equals(email, that.email);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(loginId, email);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/KickWorkspaceMemberResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/dto/response/KickWorkspaceMemberResponse.java
@@ -1,0 +1,40 @@
+package com.uranus.taskmanager.api.workspace.dto.response;
+
+import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class KickWorkspaceMemberResponse {
+
+	/*
+	 * Todo
+	 *  - WorkspaceMemberDetail을 만들어서 사용하기
+	 *  - 해당 DTO에 다음 필드 넣기
+	 *  - id
+	 *  - nickname
+	 *  - role
+	 */
+	private String memberIdentifier;
+	private String nickname;
+	private WorkspaceRole role;
+
+	@Builder
+	public KickWorkspaceMemberResponse(String memberIdentifier, String nickname, WorkspaceRole role) {
+		this.memberIdentifier = memberIdentifier;
+		this.nickname = nickname;
+		this.role = role;
+	}
+
+	public static KickWorkspaceMemberResponse from(String memberIdentifier, WorkspaceMember workspaceMember) {
+		return KickWorkspaceMemberResponse.builder()
+			.memberIdentifier(memberIdentifier)
+			.nickname(workspaceMember.getNickname())
+			.role(workspaceMember.getRole())
+			.build();
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceAccessService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceAccessService.java
@@ -20,11 +20,13 @@ import com.uranus.taskmanager.api.security.PasswordEncoder;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspace.dto.request.InviteMemberRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.InviteMembersRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.KickWorkspaceMemberRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceParticipateRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.FailedInvitedMember;
 import com.uranus.taskmanager.api.workspace.dto.response.InviteMemberResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.InviteMembersResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.InvitedMember;
+import com.uranus.taskmanager.api.workspace.dto.response.KickWorkspaceMemberResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceParticipateResponse;
 import com.uranus.taskmanager.api.workspace.exception.InvalidWorkspacePasswordException;
 import com.uranus.taskmanager.api.workspace.exception.WorkspaceNotFoundException;
@@ -32,6 +34,7 @@ import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 import com.uranus.taskmanager.api.workspacemember.exception.AlreadyJoinedWorkspaceException;
+import com.uranus.taskmanager.api.workspacemember.exception.MemberNotInWorkspaceException;
 import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -51,12 +54,12 @@ public class WorkspaceAccessService {
 	private final PasswordEncoder passwordEncoder;
 
 	@Transactional
-	public InviteMemberResponse inviteMember(String workspaceCode, InviteMemberRequest request) {
+	public InviteMemberResponse inviteMember(String code, InviteMemberRequest request) {
 
-		Workspace workspace = findWorkspaceByCode(workspaceCode);
+		Workspace workspace = findWorkspaceByCode(code);
 		Member invitedMember = findMemberByIdentifier(request.getMemberIdentifier());
 
-		checkIfMemberAlreadyJoined(workspaceCode, invitedMember);
+		checkIfMemberAlreadyJoined(code, invitedMember);
 		checkIfPendingInvitationExists(workspace, invitedMember);
 
 		Invitation invitation = savePendingInvitation(workspace, invitedMember);
@@ -64,24 +67,30 @@ public class WorkspaceAccessService {
 		return InviteMemberResponse.from(invitation);
 	}
 
+	/**
+	 * Todo
+	 *  - InvitedMember, FailedInvitedMember가 일치하지 않는 문제 때문에 equals & hashCode를 구현했다
+	 *  - 추후에 중복 멤버 또는 identifier를 거르기 위해서 Set을 사용할 예정
+	 *  - InvitedMember, FailedInvitedMember로 분리하지 않고 하나의 클래스를 만들어서 통합하기
+	 */
 	@Transactional
-	public InviteMembersResponse inviteMembers(String workspaceCode, InviteMembersRequest request) {
+	public InviteMembersResponse inviteMembers(String code, InviteMembersRequest request) {
 		// Todo: 일급 컬렉션으로 리팩토링하는 것을 고려. 관련 처리 로직을 해당 일급 컬렉션 클래스에서 정의
 		List<InvitedMember> invitedMembers = new ArrayList<>();
 		List<FailedInvitedMember> failedInvitedMembers = new ArrayList<>();
 
-		Workspace workspace = findWorkspaceByCode(workspaceCode);
+		Workspace workspace = findWorkspaceByCode(code);
 
 		for (String identifier : request.getMemberIdentifiers()) {
 			try {
 				Member invitedMember = findMemberByIdentifier(identifier);
 
-				checkIfMemberAlreadyJoined(workspaceCode, invitedMember);
+				checkIfMemberAlreadyJoined(code, invitedMember);
 				checkIfPendingInvitationExists(workspace, invitedMember);
 
 				savePendingInvitation(workspace, invitedMember);
 				addInvitedMember(invitedMembers, invitedMember);
-			} catch (Exception e) {
+			} catch (AlreadyJoinedWorkspaceException | InvitationAlreadyExistsException e) {
 				String errorMessage = getErrorMessageFromException(e);
 				addFailedInvitedMember(identifier, failedInvitedMembers, errorMessage);
 			}
@@ -94,19 +103,19 @@ public class WorkspaceAccessService {
 	 * 참여할 워크스페이스의 코드와 참여 요청의 패스워드(null 허용)를 사용해서
 	 * 참여를 요청한 로그인 멤버를 해당 워크스페이스에 참여시킨다.
 	 *
-	 * @param workspaceCode
+	 * @param code
 	 * @param request
 	 * @param loginMember
 	 * @return - 워크스페이스 참여 응답을 위한 DTO
 	 */
 	@Transactional
-	public WorkspaceParticipateResponse joinWorkspace(String workspaceCode, WorkspaceParticipateRequest request,
+	public WorkspaceParticipateResponse joinWorkspace(String code, WorkspaceParticipateRequest request,
 		LoginMemberDto loginMember) {
 
-		Workspace workspace = findWorkspaceByCode(workspaceCode);
+		Workspace workspace = findWorkspaceByCode(code);
 		Member member = findMemberByLoginId(loginMember);
 
-		Optional<WorkspaceMember> optionalWorkspaceMember = findExistingWorkspaceMember(workspaceCode, loginMember);
+		Optional<WorkspaceMember> optionalWorkspaceMember = findExistingWorkspaceMember(code, loginMember);
 		if (optionalWorkspaceMember.isPresent()) {
 			return WorkspaceParticipateResponse.from(workspace, optionalWorkspaceMember.get(), true);
 		}
@@ -123,6 +132,24 @@ public class WorkspaceAccessService {
 		workspaceMemberRepository.save(workspaceMember);
 
 		return WorkspaceParticipateResponse.from(workspace, workspaceMember, false);
+	}
+
+	@Transactional
+	public KickWorkspaceMemberResponse kickWorkspaceMember(String code, KickWorkspaceMemberRequest request) {
+
+		Workspace workspace = findWorkspaceByCode(code);
+
+		String identifier = request.getMemberIdentifier();
+		Member member = memberRepository.findByLoginIdOrEmail(identifier, identifier)
+			.orElseThrow(MemberNotFoundException::new);
+
+		WorkspaceMember workspaceMember = workspaceMemberRepository.findByMemberIdAndWorkspaceCode(member.getId(), code)
+			.orElseThrow(MemberNotInWorkspaceException::new);
+
+		workspaceMemberRepository.delete(workspaceMember);
+		workspace.decreaseMemberCount();
+
+		return KickWorkspaceMemberResponse.from(identifier, workspaceMember);
 	}
 
 	private Workspace findWorkspaceByCode(String workspaceCode) {

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/AlreadyJoinedWorkspaceException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/AlreadyJoinedWorkspaceException.java
@@ -4,15 +4,15 @@ import org.springframework.http.HttpStatus;
 
 import com.uranus.taskmanager.api.common.exception.WorkspaceMemberException;
 
-public class MemberAlreadyParticipatingException extends WorkspaceMemberException {
-	private static final String MESSAGE = "Current login member is already participating in this Workspace";
+public class AlreadyJoinedWorkspaceException extends WorkspaceMemberException {
+	private static final String MESSAGE = "Member already joined this Workspace";
 	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
 
-	public MemberAlreadyParticipatingException() {
+	public AlreadyJoinedWorkspaceException() {
 		super(MESSAGE, HTTP_STATUS);
 	}
 
-	public MemberAlreadyParticipatingException(Throwable cause) {
+	public AlreadyJoinedWorkspaceException(Throwable cause) {
 		super(MESSAGE, HTTP_STATUS, cause);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/MemberNotInWorkspaceException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/MemberNotInWorkspaceException.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import com.uranus.taskmanager.api.common.exception.WorkspaceMemberException;
 
 public class MemberNotInWorkspaceException extends WorkspaceMemberException {
-	private static final String MESSAGE = "Member was not found in the given workspace";
+	private static final String MESSAGE = "Member was not found in this workspace";
 	private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
 
 	public MemberNotInWorkspaceException() {

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/repository/WorkspaceMemberRepository.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/repository/WorkspaceMemberRepository.java
@@ -15,10 +15,12 @@ public interface WorkspaceMemberRepository extends JpaRepository<WorkspaceMember
 	List<WorkspaceMember> findByMemberLoginId(String loginId);
 
 	Page<WorkspaceMember> findByMemberLoginId(String loginId, Pageable pageable);
-	
+
 	Optional<WorkspaceMember> findByMemberLoginIdAndWorkspaceId(String loginId, Long workspaceId);
 
 	Optional<WorkspaceMember> findByMemberLoginIdAndWorkspaceCode(String loginId, String workspaceCode);
+
+	Optional<WorkspaceMember> findByMemberIdAndWorkspaceCode(Long id, String workspaceCode);
 
 	int countByWorkspaceId(Long workspaceId);
 

--- a/src/test/java/com/uranus/taskmanager/api/invitation/controller/InvitationControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/invitation/controller/InvitationControllerTest.java
@@ -29,7 +29,7 @@ import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.service.CheckCodeDuplicationService;
-import com.uranus.taskmanager.api.workspace.service.WorkspaceService;
+import com.uranus.taskmanager.api.workspace.service.WorkspaceAccessService;
 import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
@@ -46,7 +46,7 @@ class InvitationControllerTest {
 	private ObjectMapper objectMapper;
 
 	@MockBean
-	private WorkspaceService workspaceService;
+	private WorkspaceAccessService workspaceAccessService;
 	@MockBean
 	private CheckCodeDuplicationService workspaceCreateService;
 	@MockBean

--- a/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
@@ -54,9 +54,9 @@ import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceParticipateRes
 import com.uranus.taskmanager.api.workspace.exception.InvalidWorkspacePasswordException;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.service.CheckCodeDuplicationService;
+import com.uranus.taskmanager.api.workspace.service.WorkspaceAccessService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceCommandService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceQueryService;
-import com.uranus.taskmanager.api.workspace.service.WorkspaceService;
 import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
@@ -68,7 +68,7 @@ import com.uranus.taskmanager.fixture.entity.WorkspaceMemberEntityFixture;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@WebMvcTest(WorkspaceController.class)
+@WebMvcTest({WorkspaceController.class, WorkspaceAccessController.class})
 class WorkspaceControllerTest {
 
 	@Autowired
@@ -77,7 +77,7 @@ class WorkspaceControllerTest {
 	private ObjectMapper objectMapper;
 
 	@MockBean
-	private WorkspaceService workspaceService;
+	private WorkspaceAccessService workspaceAccessService;
 	@MockBean
 	private MemberService memberService;
 	@MockBean
@@ -381,7 +381,7 @@ class WorkspaceControllerTest {
 
 		InviteMemberResponse inviteMemberResponse = InviteMemberResponse.from(invitation);
 
-		when(workspaceService.inviteMember(eq(workspaceCode), ArgumentMatchers.any(InviteMemberRequest.class)))
+		when(workspaceAccessService.inviteMember(eq(workspaceCode), ArgumentMatchers.any(InviteMemberRequest.class)))
 			.thenReturn(inviteMemberResponse);
 
 		// when & then
@@ -412,7 +412,7 @@ class WorkspaceControllerTest {
 
 		InviteMembersResponse inviteMembersResponse = new InviteMembersResponse(successfulResponses, failedResponses);
 
-		when(workspaceService.inviteMembers(eq(workspaceCode), ArgumentMatchers.any(InviteMembersRequest.class)))
+		when(workspaceAccessService.inviteMembers(eq(workspaceCode), ArgumentMatchers.any(InviteMembersRequest.class)))
 			.thenReturn(inviteMembersResponse);
 
 		// then
@@ -456,7 +456,7 @@ class WorkspaceControllerTest {
 			.build();
 
 		// when
-		when(workspaceService.inviteMembers(eq(workspaceCode), ArgumentMatchers.any(InviteMembersRequest.class)))
+		when(workspaceAccessService.inviteMembers(eq(workspaceCode), ArgumentMatchers.any(InviteMembersRequest.class)))
 			.thenReturn(inviteMembersResponse);
 
 		// then
@@ -488,7 +488,7 @@ class WorkspaceControllerTest {
 
 		WorkspaceParticipateResponse response = WorkspaceParticipateResponse.from(workspace, workspaceMember, false);
 
-		when(workspaceService.participateWorkspace(eq(workspaceCode),
+		when(workspaceAccessService.joinWorkspace(eq(workspaceCode),
 			ArgumentMatchers.any(WorkspaceParticipateRequest.class),
 			ArgumentMatchers.any(LoginMemberDto.class))).thenReturn(response);
 
@@ -513,7 +513,7 @@ class WorkspaceControllerTest {
 		WorkspaceParticipateRequest request = new WorkspaceParticipateRequest(invalidPassword);
 		String requestBody = objectMapper.writeValueAsString(request);
 
-		when(workspaceService.participateWorkspace(eq(workspaceCode),
+		when(workspaceAccessService.joinWorkspace(eq(workspaceCode),
 			ArgumentMatchers.any(WorkspaceParticipateRequest.class),
 			ArgumentMatchers.any(LoginMemberDto.class)))
 			.thenThrow(new InvalidWorkspacePasswordException());

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceAccessServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceAccessServiceTest.java
@@ -1,155 +1,122 @@
 package com.uranus.taskmanager.api.workspace.service;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
 
 import java.util.List;
-import java.util.Optional;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.uranus.taskmanager.api.authentication.dto.request.LoginMemberDto;
 import com.uranus.taskmanager.api.invitation.InvitationStatus;
-import com.uranus.taskmanager.api.invitation.domain.Invitation;
-import com.uranus.taskmanager.api.invitation.exception.InvitationAlreadyExistsException;
 import com.uranus.taskmanager.api.invitation.repository.InvitationRepository;
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.member.exception.MemberNotFoundException;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
-import com.uranus.taskmanager.api.security.PasswordEncoder;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspace.dto.WorkspaceDetail;
 import com.uranus.taskmanager.api.workspace.dto.request.InviteMemberRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.InviteMembersRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.KickWorkspaceMemberRequest;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceParticipateRequest;
+import com.uranus.taskmanager.api.workspace.dto.response.FailedInvitedMember;
 import com.uranus.taskmanager.api.workspace.dto.response.InviteMemberResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.InviteMembersResponse;
+import com.uranus.taskmanager.api.workspace.dto.response.InvitedMember;
+import com.uranus.taskmanager.api.workspace.dto.response.KickWorkspaceMemberResponse;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceParticipateResponse;
 import com.uranus.taskmanager.api.workspace.exception.InvalidWorkspacePasswordException;
 import com.uranus.taskmanager.api.workspace.exception.WorkspaceNotFoundException;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
-import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
 import com.uranus.taskmanager.api.workspacemember.exception.AlreadyJoinedWorkspaceException;
+import com.uranus.taskmanager.api.workspacemember.exception.MemberNotInWorkspaceException;
 import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
-import com.uranus.taskmanager.fixture.dto.LoginMemberDtoFixture;
-import com.uranus.taskmanager.fixture.entity.InvitationEntityFixture;
-import com.uranus.taskmanager.fixture.entity.MemberEntityFixture;
-import com.uranus.taskmanager.fixture.entity.WorkspaceEntityFixture;
-import com.uranus.taskmanager.fixture.entity.WorkspaceMemberEntityFixture;
+import com.uranus.taskmanager.fixture.repository.MemberRepositoryFixture;
+import com.uranus.taskmanager.fixture.repository.WorkspaceRepositoryFixture;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@ExtendWith(MockitoExtension.class)
-class WorkspaceAccessServiceTest {
+@SpringBootTest
+public class WorkspaceAccessServiceTest {
 
-	@InjectMocks
+	@Autowired
 	private WorkspaceAccessService workspaceAccessService;
-	@InjectMocks
+	@Autowired
 	private WorkspaceQueryService workspaceQueryService;
-
-	@Mock
+	@Autowired
 	private WorkspaceRepository workspaceRepository;
-	@Mock
+	@Autowired
 	private MemberRepository memberRepository;
-	@Mock
+	@Autowired
 	private WorkspaceMemberRepository workspaceMemberRepository;
-	@Mock
+	@Autowired
 	private InvitationRepository invitationRepository;
-	@Mock
-	private PasswordEncoder passwordEncoder;
 
-	WorkspaceEntityFixture workspaceEntityFixture;
-	MemberEntityFixture memberEntityFixture;
-	WorkspaceMemberEntityFixture workspaceMemberEntityFixture;
-	InvitationEntityFixture invitationEntityFixture;
-	LoginMemberDtoFixture loginMemberDtoFixture;
+	@Autowired
+	private WorkspaceRepositoryFixture workspaceRepositoryFixture;
+	@Autowired
+	private MemberRepositoryFixture memberRepositoryFixture;
+
+	private Member member;
 
 	@BeforeEach
-	public void setup() {
-		workspaceEntityFixture = new WorkspaceEntityFixture();
-		memberEntityFixture = new MemberEntityFixture();
-		workspaceMemberEntityFixture = new WorkspaceMemberEntityFixture();
-		invitationEntityFixture = new InvitationEntityFixture();
-		loginMemberDtoFixture = new LoginMemberDtoFixture();
+	void setUp() {
+		Workspace workspace = workspaceRepositoryFixture.createWorkspace("Test Workspace", "Test Description",
+			"TESTCODE", null);
+		member = memberRepositoryFixture.createMember("member1", "member1@test.com", "password1234!");
+		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.USER);
+	}
+
+	@AfterEach
+	void tearDown() {
+		invitationRepository.deleteAll();
+		workspaceMemberRepository.deleteAll();
+		workspaceRepository.deleteAll();
+		memberRepository.deleteAll();
 	}
 
 	@Test
 	@DisplayName("유효한 워크스페이스 코드로 워크스페이스를 조회하면, 워크스페이스를 반환한다")
-	void test2() {
+	void testGetWorkspaceDetail_Success() {
+		// given
 		String workspaceCode = "TESTCODE";
-		Workspace workspace = Workspace.builder()
-			.code(workspaceCode)
-			.name("Test Workspace")
-			.description("Test Description")
-			.build();
+		LoginMemberDto loginMember = new LoginMemberDto(member.getLoginId(), member.getEmail());
 
-		Member member = Member.builder()
-			.loginId("member1")
-			.build();
-
-		LoginMemberDto loginMember = LoginMemberDto.builder()
-			.loginId("member1")
-			.build();
-
-		WorkspaceMember workspaceMember = WorkspaceMember.builder()
-			.workspace(workspace)
-			.member(member)
-			.build();
-
-		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
-		when(workspaceMemberRepository.findByMemberLoginIdAndWorkspaceCode("member1", workspaceCode))
-			.thenReturn(Optional.of(workspaceMember));
-
+		// when
 		WorkspaceDetail response = workspaceQueryService.getWorkspaceDetail(workspaceCode, loginMember);
 
+		// then
 		assertThat(response).isNotNull();
 		assertThat(response.getCode()).isEqualTo(workspaceCode);
-		verify(workspaceRepository, times(1)).findByCode(workspaceCode);
 	}
 
 	@Test
-	@DisplayName("유효하지 워크스페이스 코드로 워크스페이스를 조회하면, WorkspaceNotFoundException 발생")
-	void test3() {
-		String workspaceCode = "INVALIDCODE";
+	@DisplayName("유효하지 않은 워크스페이스 코드로 워크스페이스를 조회하면, 예외가 발생한다")
+	void testGetWorkspaceDetail_WorkspaceNotFoundException() {
+		// given
+		String invalidCode = "INVALIDCODE";
+		LoginMemberDto loginMember = new LoginMemberDto(member.getLoginId(), member.getEmail());
 
-		LoginMemberDto loginMember = LoginMemberDto.builder()
-			.loginId("member1")
-			.build();
-
-		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.empty());
-
-		assertThatThrownBy(() -> workspaceQueryService.getWorkspaceDetail(workspaceCode, loginMember)).isInstanceOf(
-			WorkspaceNotFoundException.class);
-
-		verify(workspaceRepository, times(1)).findByCode(workspaceCode);
+		// when & then
+		assertThatThrownBy(() -> workspaceQueryService.getWorkspaceDetail(invalidCode, loginMember))
+			.isInstanceOf(WorkspaceNotFoundException.class);
 	}
 
 	@Test
 	@DisplayName("초대가 성공하면 초대가 PENDING 상태로 저장된다")
-	void test8() {
+	void testInviteMember_Success() {
 		// given
 		String workspaceCode = "TESTCODE";
-
-		String invitedLoginId = "inviteduser123";
-		String invitedEmail = "inviteduser123@test.com";
-
-		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
-
-		Member invitedMember = memberEntityFixture.createMember(invitedLoginId, invitedEmail);
-
-		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(invitedLoginId);
-		String identifier = inviteMemberRequest.getMemberIdentifier();
-
-		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
-
-		when(memberRepository.findByLoginIdOrEmail(identifier, identifier)).thenReturn(Optional.of(invitedMember));
+		Member invitedMember = memberRepositoryFixture.createMember("member2", "member2@test.com",
+			"password1234!");
+		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(invitedMember.getLoginId());
 
 		// when
 		InviteMemberResponse inviteMemberResponse = workspaceAccessService.inviteMember(workspaceCode,
@@ -157,199 +124,100 @@ class WorkspaceAccessServiceTest {
 
 		// then
 		assertThat(inviteMemberResponse.getStatus()).isEqualTo(InvitationStatus.PENDING);
-		verify(invitationRepository, times(1)).save(any(Invitation.class));
 	}
 
 	@Test
-	@DisplayName("유효하지 않은 워크스페이스 코드로 멤버를 초대하면 WorkspaceNotFoundException이 발생한다")
-	void test4() {
-		// given
-		String workspaceCode = "INVALIDCODE";
-
-		String invitedLoginId = "inviteduser123";
-
-		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(invitedLoginId);
-
-		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.empty());
-
-		// when & then
-		assertThatThrownBy(
-			() -> workspaceAccessService.inviteMember(workspaceCode, inviteMemberRequest))
-			.isInstanceOf(WorkspaceNotFoundException.class);
-
-	}
-
-	@Test
-	@DisplayName("유효하지 않은 멤버 식별자를 사용해서 멤버를 초대하면 MemberNotFoundException이 발생한다")
-	void test5() {
+	@DisplayName("존재하지 않는 멤버를 초대하면 예외가 발생한다")
+	void testInviteMember_MemberNotFoundException() {
 		// given
 		String workspaceCode = "TESTCODE";
-
-		String invitedLoginId = "inviteduser123";
-
-		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
-
-		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(invitedLoginId);
-		String identifier = inviteMemberRequest.getMemberIdentifier();
-
-		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
-
-		when(memberRepository.findByLoginIdOrEmail(identifier, identifier)).thenReturn(Optional.empty());
+		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest("nonexistentUser");
 
 		// when & then
-		assertThatThrownBy(
-			() -> workspaceAccessService.inviteMember(workspaceCode, inviteMemberRequest))
+		assertThatThrownBy(() -> workspaceAccessService.inviteMember(workspaceCode, inviteMemberRequest))
 			.isInstanceOf(MemberNotFoundException.class);
 	}
 
 	@Test
-	@DisplayName("멤버를 다시 초대할 때 초대가 존재하고 초대 상태가 PENDING이면 InvitationAlreadyExistsException이 발생한다")
-	void test6() {
+	@DisplayName("해당 워크스페이스에 이미 참여하고 있는 멤버를 다시 초대하면 예외가 발생한다")
+	void testInviteMember_AlreadyJoinedWorkspaceException() {
 		// given
 		String workspaceCode = "TESTCODE";
-
-		String invitedLoginId = "inviteduser123";
-		String invitedEmail = "inviteduser123@test.com";
-
-		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
-
-		Member invitedMember = memberEntityFixture.createMember(invitedLoginId, invitedEmail);
-		Invitation invitation = invitationEntityFixture.createPendingInvitation(workspace, invitedMember);
-
-		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(invitedLoginId);
-		String identifier = inviteMemberRequest.getMemberIdentifier();
-
-		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
-
-		when(memberRepository.findByLoginIdOrEmail(identifier, identifier)).thenReturn(Optional.of(invitedMember));
-
-		when(invitationRepository.findByWorkspaceAndMember(workspace, invitedMember))
-			.thenReturn(Optional.of(invitation));
+		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(member.getLoginId());
 
 		// when & then
-		assertThatThrownBy(
-			() -> workspaceAccessService.inviteMember(workspaceCode, inviteMemberRequest))
-			.isInstanceOf(InvitationAlreadyExistsException.class);
-	}
-
-	@Test
-	@DisplayName("해당 워크스페이스에 이미 참여하고 있는 멤버를 다시 초대하면 MemberAlreadyParticipatingException이 발생한다")
-	void test7() {
-		// given
-		String workspaceCode = "TESTCODE";
-
-		String invitedLoginId = "inviteduser123";
-		String invitedEmail = "inviteduser123@test.com";
-
-		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
-
-		Member invitedMember = memberEntityFixture.createMember(invitedLoginId, invitedEmail);
-		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createUserWorkspaceMember(invitedMember,
-			workspace);
-
-		InviteMemberRequest inviteMemberRequest = new InviteMemberRequest(invitedLoginId);
-		String identifier = inviteMemberRequest.getMemberIdentifier();
-
-		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
-
-		when(memberRepository.findByLoginIdOrEmail(identifier, identifier)).thenReturn(Optional.of(invitedMember));
-
-		when(workspaceMemberRepository.findByMemberLoginIdAndWorkspaceCode(invitedLoginId, workspaceCode)).thenReturn(
-			Optional.of(workspaceMember));
-
-		// when & then
-		assertThatThrownBy(
-			() -> workspaceAccessService.inviteMember(workspaceCode, inviteMemberRequest))
+		assertThatThrownBy(() -> workspaceAccessService.inviteMember(workspaceCode, inviteMemberRequest))
 			.isInstanceOf(AlreadyJoinedWorkspaceException.class);
 	}
 
+	/**
+	 * Todo
+	 *  - InvitedMember, FailedInvitedMember가 일치하지 않는 문제 때문에 equals & hashCode를 구현했다
+	 *  - 추후에 중복 멤버 또는 identifier를 거르기 위해서 Set을 사용할 예정
+	 *  - InvitedMember, FailedInvitedMember로 분리하지 않고 하나의 클래스를 만들어서 통합하기
+	 */
 	@Test
-	@DisplayName("다수의 멤버를 초대 시 모든 멤버의 초대를 성공하면 실패한 멤버의 리스트는 비어있다")
-	void test9() {
+	@DisplayName("다수의 멤버의 초대를 시도하면, 성공한 멤버와 실패한 멤버로 나뉜 응답을 받을 수 있다")
+	void testInviteMembers_Success() {
 		// given
 		String workspaceCode = "TESTCODE";
-		String member1Id = "member1";
-		String member2Id = "member2";
-		String member1Email = "member1@test.com";
-		String member2Email = "member2@test.com";
+		Member member2 = memberRepositoryFixture.createMember("member2", "member2@test.com", "password1234!");
+		Member member3 = memberRepositoryFixture.createMember("member3", "member3@test.com", "password1234!");
 
-		List<String> memberIdentifiers = List.of(member1Id, member2Id);
-		InviteMembersRequest inviteMembersRequest = new InviteMembersRequest(memberIdentifiers);
+		InviteMembersRequest request = new InviteMembersRequest(
+			List.of(member.getLoginId(), member2.getLoginId(), member3.getLoginId()));
 
-		// Mock Workspace
-		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
-		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
-
-		// Mock Member
-		Member member1 = memberEntityFixture.createMember(member1Id, member1Email);
-		Member member2 = memberEntityFixture.createMember(member2Id, member2Email);
-		when(memberRepository.findByLoginIdOrEmail(member1Id, member1Id)).thenReturn(Optional.of(member1));
-		when(memberRepository.findByLoginIdOrEmail(member2Id, member2Id)).thenReturn(Optional.of(member2));
-
-		// Mock Invitation
-		Invitation invitation1 = invitationEntityFixture.createPendingInvitation(workspace, member1);
-		Invitation invitation2 = invitationEntityFixture.createPendingInvitation(workspace, member2);
-		when(invitationRepository.save(any(Invitation.class))).thenReturn(invitation1).thenReturn(invitation2);
+		List<InvitedMember> invitedMembers = List.of(new InvitedMember(member2.getLoginId(), member2.getEmail()),
+			new InvitedMember(member3.getLoginId(), member3.getEmail()));
+		List<FailedInvitedMember> failedInvitedMembers = List.of(
+			new FailedInvitedMember("member1", "Member already joined this Workspace"));
 
 		// when
-		InviteMembersResponse response = workspaceAccessService.inviteMembers(workspaceCode, inviteMembersRequest);
-
-		log.info("response = {}", response);
+		InviteMembersResponse response = workspaceAccessService.inviteMembers(workspaceCode, request);
 
 		// then
-		assertThat(response.getInvitedMembers().size()).isEqualTo(2);
-		assertThat(response.getFailedInvitedMembers()).isEmpty();
-
+		assertThat(response.getInvitedMembers()).isEqualTo(invitedMembers);
+		assertThat(response.getFailedInvitedMembers()).isEqualTo(failedInvitedMembers);
 	}
 
 	@Test
-	@DisplayName("워크스페이스 참여가 성공하는 경우 참여 응답 DTO를 데이터로 제공하고, 참여 플래그는 False이다")
-	void test10() {
+	@DisplayName("워크스페이스 참여 시 비밀번호가 일치하지 않는 경우 예외가 발생한다")
+	void testJoinWorkspace_InvalidPasswordException() {
+		// given
+		String workspaceCode = "CODE1234";
+		Workspace workspaceWithPassword = workspaceRepositoryFixture.createWorkspace("Workspace", "Description",
+			"CODE1234", "password1234!");
+		WorkspaceParticipateRequest request = new WorkspaceParticipateRequest("WrongPassword1234!");
+		LoginMemberDto loginMember = new LoginMemberDto(member.getLoginId(), member.getEmail());
+
+		// when & then
+		assertThatThrownBy(() -> workspaceAccessService.joinWorkspace(workspaceCode, request, loginMember))
+			.isInstanceOf(InvalidWorkspacePasswordException.class);
+	}
+
+	@Test
+	@DisplayName("워크스페이스 참여가 성공하는 경우 워크스페이스 참여 응답을 정상적으로 반환한다")
+	void testJoinWorkspace_Success() {
 		// given
 		String workspaceCode = "TESTCODE";
-		String loginId = "user123";
-		String email = "user123@test.com";
-		String workspacePassword = "workspace1234!";
-
-		Workspace workspace = workspaceEntityFixture.createWorkspaceWithPassword(workspaceCode, workspacePassword);
-		Member member = memberEntityFixture.createMember(loginId, email);
-		LoginMemberDto loginMember = loginMemberDtoFixture.createLoginMemberDto(loginId, email);
-		WorkspaceParticipateRequest request = new WorkspaceParticipateRequest(workspace.getPassword());
-
-		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
-		when(memberRepository.findByLoginId(loginMember.getLoginId())).thenReturn(Optional.of(member));
-		when(workspaceMemberRepository.findByMemberLoginIdAndWorkspaceCode(loginMember.getLoginId(), workspaceCode))
-			.thenReturn(Optional.empty());
-		when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
+		WorkspaceParticipateRequest request = new WorkspaceParticipateRequest(null);
+		LoginMemberDto loginMember = new LoginMemberDto(member.getLoginId(), member.getEmail());
 
 		// when
 		WorkspaceParticipateResponse response = workspaceAccessService.joinWorkspace(workspaceCode, request,
 			loginMember);
 
 		// then
-		assertThat(response.isAlreadyMember()).isFalse();
-		assertThat(response.getWorkspaceDetail().getCode()).isEqualTo(workspaceCode);
+		assertThat(response).isNotNull();
 	}
 
 	@Test
-	@DisplayName("워크스페이스 참여 시 이미 참여하고 있는 경우 정상 응답을 하되, 참여 플래그는 True이다")
-	void test11() {
+	@DisplayName("이미 워크스페이스에 참여하는 멤버가 참여를 시도하는 경우 응답은 정상적으로 반환되나, 참여 플래그를 true로 반환받는다")
+	void testJoinWorkspace_isAlreadyMemberTrue() {
 		// given
 		String workspaceCode = "TESTCODE";
-		String loginId = "user123";
-		String email = "user123@test.com";
-		String workspacePassword = "workspace1234!";
-
-		Workspace workspace = workspaceEntityFixture.createWorkspaceWithPassword(workspaceCode, workspacePassword);
-		Member member = memberEntityFixture.createMember(loginId, email);
-		LoginMemberDto loginMember = loginMemberDtoFixture.createLoginMemberDto(loginId, email);
-		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createUserWorkspaceMember(member, workspace);
-		WorkspaceParticipateRequest request = new WorkspaceParticipateRequest(workspace.getPassword());
-
-		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
-		when(memberRepository.findByLoginId(loginMember.getLoginId())).thenReturn(Optional.of(member));
-		when(workspaceMemberRepository.findByMemberLoginIdAndWorkspaceCode(loginMember.getLoginId(), workspaceCode))
-			.thenReturn(Optional.of(workspaceMember));
+		WorkspaceParticipateRequest request = new WorkspaceParticipateRequest(null);
+		LoginMemberDto loginMember = new LoginMemberDto(member.getLoginId(), member.getEmail());
 
 		// when
 		WorkspaceParticipateResponse response = workspaceAccessService.joinWorkspace(workspaceCode, request,
@@ -358,31 +226,80 @@ class WorkspaceAccessServiceTest {
 		// then
 		assertThat(response).isNotNull();
 		assertThat(response.isAlreadyMember()).isTrue();
-		assertThat(response.getWorkspaceDetail().getCode()).isEqualTo(workspaceCode);
 	}
 
 	@Test
-	@DisplayName("워크스페이스 참여 시 비밀번호가 일치하지 않는 경우 예외가 발생한다")
-	void test12() {
+	@DisplayName("해당 워크스페이스에 참여하지 않은 멤버가 참여에 성공하는 경우, 참여 플래그를 false로 반환받는다")
+	void testJoinWorkspace_isAlreadyMemberFalse() {
 		// given
 		String workspaceCode = "TESTCODE";
-		String loginId = "user123";
-		String email = "user123@test.com";
-		String workspacePassword = "workspace1234!";
-		String invalidPassword = "invalid1234!";
+		WorkspaceParticipateRequest request = new WorkspaceParticipateRequest(null);
+		Member joiningMember = memberRepositoryFixture.createMember("member2", "member2@test.com",
+			"password1234!");
+		LoginMemberDto loginMember = new LoginMemberDto(joiningMember.getLoginId(), joiningMember.getEmail());
 
-		Workspace workspace = workspaceEntityFixture.createWorkspaceWithPassword(workspaceCode, workspacePassword);
-		Member member = memberEntityFixture.createMember(loginId, email);
-		LoginMemberDto loginMember = loginMemberDtoFixture.createLoginMemberDto(loginId, email);
-		WorkspaceParticipateRequest request = new WorkspaceParticipateRequest(invalidPassword);
+		// when
+		WorkspaceParticipateResponse response = workspaceAccessService.joinWorkspace(workspaceCode, request,
+			loginMember);
 
-		when(workspaceRepository.findByCode(workspaceCode)).thenReturn(Optional.of(workspace));
-		when(memberRepository.findByLoginId(loginMember.getLoginId())).thenReturn(Optional.of(member));
-		when(workspaceMemberRepository.findByMemberLoginIdAndWorkspaceCode(loginMember.getLoginId(), workspaceCode))
-			.thenReturn(Optional.empty());
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.isAlreadyMember()).isFalse();
+	}
+
+	/**
+	 * 트랜잭션 애노테이션 제거 시 LazyInitializationException 발생
+	 * <p>
+	 * 원인:
+	 *  - Hibernate 세션이 닫힌 상태에서 지연 로딩된 속성에 접근하려 할 때 발생합니다.
+	 *  - 현재 테스트의 경우, Workspace 엔티티의 workspaceMembers 컬렉션을 액세스하려고 할 때
+	 * 	세션이 종료되어 이 오류가 발생합니다.
+	 */
+	@Transactional
+	@Test
+	@DisplayName("멤버가 워크스페이스에서 성공적으로 추방되면 응답이 반환되어야 한다")
+	void kickWorkspaceMember_Success() {
+		// given
+		String workspaceCode = "TESTCODE";
+		Workspace workspace = workspaceRepository.findByCode(workspaceCode).get();
+		Member member2 = memberRepositoryFixture.createMember("member2", "member2@test.com", "password1234!");
+		workspaceRepositoryFixture.addMemberToWorkspace(member2, workspace, WorkspaceRole.USER);
+
+		KickWorkspaceMemberRequest request = new KickWorkspaceMemberRequest(member2.getLoginId());
+
+		// when
+		KickWorkspaceMemberResponse response = workspaceAccessService.kickWorkspaceMember(workspaceCode, request);
+
+		// then
+		assertThat(member2.getLoginId()).isEqualTo(response.getMemberIdentifier());
+		assertThat(
+			workspaceMemberRepository.findByMemberIdAndWorkspaceCode(member2.getId(), workspaceCode)).isPresent();
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 멤버를 추방하려고 하면 예외가 발생한다")
+	void kickWorkspaceMember_MemberNotFoundException() {
+		// given
+		String workspaceCode = "TESTCODE";
+		KickWorkspaceMemberRequest request = new KickWorkspaceMemberRequest("nonExistentIdentifier");
 
 		// when & then
-		assertThatThrownBy(() -> workspaceAccessService.joinWorkspace(workspaceCode, request,
-			loginMember)).isInstanceOf(InvalidWorkspacePasswordException.class);
+		assertThatThrownBy(() -> workspaceAccessService.kickWorkspaceMember(workspaceCode, request))
+			.isInstanceOf(MemberNotFoundException.class);
+	}
+
+	@Test
+	@DisplayName("워크스페이스에 소속되지 않은 멤버를 추방하려는 경우 예외가 발생 한다")
+	void kickWorkspaceMember_MemberNotInWorkspaceException() {
+		// given
+		String workspaceCode = "TESTCODE";
+		Member nonWorkspaceMember = memberRepositoryFixture.createMember("member3", "member3@test.com",
+			"password1234!");
+
+		KickWorkspaceMemberRequest request = new KickWorkspaceMemberRequest(nonWorkspaceMember.getLoginId());
+
+		// when & then
+		assertThatThrownBy(() -> workspaceAccessService.kickWorkspaceMember(workspaceCode, request))
+			.isInstanceOf(MemberNotInWorkspaceException.class);
 	}
 }

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceAccessServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceAccessServiceTest.java
@@ -35,7 +35,7 @@ import com.uranus.taskmanager.api.workspace.exception.InvalidWorkspacePasswordEx
 import com.uranus.taskmanager.api.workspace.exception.WorkspaceNotFoundException;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
-import com.uranus.taskmanager.api.workspacemember.exception.MemberAlreadyParticipatingException;
+import com.uranus.taskmanager.api.workspacemember.exception.AlreadyJoinedWorkspaceException;
 import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
 import com.uranus.taskmanager.fixture.dto.LoginMemberDtoFixture;
 import com.uranus.taskmanager.fixture.entity.InvitationEntityFixture;
@@ -47,10 +47,10 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @ExtendWith(MockitoExtension.class)
-class WorkspaceServiceTest {
+class WorkspaceAccessServiceTest {
 
 	@InjectMocks
-	private WorkspaceService workspaceService;
+	private WorkspaceAccessService workspaceAccessService;
 	@InjectMocks
 	private WorkspaceQueryService workspaceQueryService;
 
@@ -152,7 +152,8 @@ class WorkspaceServiceTest {
 		when(memberRepository.findByLoginIdOrEmail(identifier, identifier)).thenReturn(Optional.of(invitedMember));
 
 		// when
-		InviteMemberResponse inviteMemberResponse = workspaceService.inviteMember(workspaceCode, inviteMemberRequest);
+		InviteMemberResponse inviteMemberResponse = workspaceAccessService.inviteMember(workspaceCode,
+			inviteMemberRequest);
 
 		// then
 		assertThat(inviteMemberResponse.getStatus()).isEqualTo(InvitationStatus.PENDING);
@@ -173,7 +174,7 @@ class WorkspaceServiceTest {
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest))
+			() -> workspaceAccessService.inviteMember(workspaceCode, inviteMemberRequest))
 			.isInstanceOf(WorkspaceNotFoundException.class);
 
 	}
@@ -197,7 +198,7 @@ class WorkspaceServiceTest {
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest))
+			() -> workspaceAccessService.inviteMember(workspaceCode, inviteMemberRequest))
 			.isInstanceOf(MemberNotFoundException.class);
 	}
 
@@ -227,7 +228,7 @@ class WorkspaceServiceTest {
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest))
+			() -> workspaceAccessService.inviteMember(workspaceCode, inviteMemberRequest))
 			.isInstanceOf(InvitationAlreadyExistsException.class);
 	}
 
@@ -258,8 +259,8 @@ class WorkspaceServiceTest {
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceService.inviteMember(workspaceCode, inviteMemberRequest))
-			.isInstanceOf(MemberAlreadyParticipatingException.class);
+			() -> workspaceAccessService.inviteMember(workspaceCode, inviteMemberRequest))
+			.isInstanceOf(AlreadyJoinedWorkspaceException.class);
 	}
 
 	@Test
@@ -291,7 +292,7 @@ class WorkspaceServiceTest {
 		when(invitationRepository.save(any(Invitation.class))).thenReturn(invitation1).thenReturn(invitation2);
 
 		// when
-		InviteMembersResponse response = workspaceService.inviteMembers(workspaceCode, inviteMembersRequest);
+		InviteMembersResponse response = workspaceAccessService.inviteMembers(workspaceCode, inviteMembersRequest);
 
 		log.info("response = {}", response);
 
@@ -322,7 +323,7 @@ class WorkspaceServiceTest {
 		when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
 
 		// when
-		WorkspaceParticipateResponse response = workspaceService.participateWorkspace(workspaceCode, request,
+		WorkspaceParticipateResponse response = workspaceAccessService.joinWorkspace(workspaceCode, request,
 			loginMember);
 
 		// then
@@ -351,7 +352,7 @@ class WorkspaceServiceTest {
 			.thenReturn(Optional.of(workspaceMember));
 
 		// when
-		WorkspaceParticipateResponse response = workspaceService.participateWorkspace(workspaceCode, request,
+		WorkspaceParticipateResponse response = workspaceAccessService.joinWorkspace(workspaceCode, request,
 			loginMember);
 
 		// then
@@ -381,7 +382,7 @@ class WorkspaceServiceTest {
 			.thenReturn(Optional.empty());
 
 		// when & then
-		assertThatThrownBy(() -> workspaceService.participateWorkspace(workspaceCode, request,
+		assertThatThrownBy(() -> workspaceAccessService.joinWorkspace(workspaceCode, request,
 			loginMember)).isInstanceOf(InvalidWorkspacePasswordException.class);
 	}
 }

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandServiceTest.java
@@ -33,7 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 public class WorkspaceCommandServiceTest {
 
 	@Autowired
-	private WorkspaceService workspaceService;
+	private WorkspaceAccessService workspaceAccessService;
 	@Autowired
 	private WorkspaceCommandService workspaceCommandService;
 	@Autowired

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandServiceTest.java
@@ -22,7 +22,7 @@ import com.uranus.taskmanager.api.workspace.exception.WorkspaceNotFoundException
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
 import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
-import com.uranus.taskmanager.fixture.repository.MemberRespositoryFixture;
+import com.uranus.taskmanager.fixture.repository.MemberRepositoryFixture;
 import com.uranus.taskmanager.fixture.repository.WorkspaceRepositoryFixture;
 
 import jakarta.persistence.EntityManager;
@@ -50,7 +50,7 @@ public class WorkspaceCommandServiceTest {
 	@Autowired
 	private WorkspaceRepositoryFixture workspaceRepositoryFixture;
 	@Autowired
-	private MemberRespositoryFixture memberRespositoryFixture;
+	private MemberRepositoryFixture memberRepositoryFixture;
 
 	@AfterEach
 	void tearDown() {
@@ -63,9 +63,9 @@ public class WorkspaceCommandServiceTest {
 	@DisplayName("유효한 워크스페이스 코드와 비밀번호로 워크스페이스를 삭제할 수 있다")
 	void test1() {
 		// given
-		Member member = memberRespositoryFixture.createMember("member1", "member1@test.com", "member1password!");
+		Member member = memberRepositoryFixture.createMember("member1", "member1@test.com", "member1password!");
 		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			passwordEncoder.encode("password1234!"));
+			"password1234!");
 		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.ADMIN);
 
 		workspaceRepositoryFixture.createWorkspace("workspace2", "description2", "TEST2222", null);
@@ -82,9 +82,9 @@ public class WorkspaceCommandServiceTest {
 	@DisplayName("워크스페이스 삭제 시도 시 비밀번호가 맞지 않으면 예외가 발생한다")
 	void test2() {
 		// given
-		Member member = memberRespositoryFixture.createMember("member1", "member1@test.com", "member1password!");
+		Member member = memberRepositoryFixture.createMember("member1", "member1@test.com", "member1password!");
 		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			passwordEncoder.encode("password1234!"));
+			"password1234!");
 		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.ADMIN);
 
 		// when & then
@@ -99,9 +99,9 @@ public class WorkspaceCommandServiceTest {
 	@DisplayName("워크스페이스 삭제 시도 시 코드가 유효하지 않으면 예외가 발생한다")
 	void test3() {
 		// given
-		Member member = memberRespositoryFixture.createMember("member1", "member1@test.com", "member1password!");
+		Member member = memberRepositoryFixture.createMember("member1", "member1@test.com", "member1password!");
 		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			passwordEncoder.encode("password1234!"));
+			"password1234!");
 		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.ADMIN);
 
 		// when & then
@@ -178,7 +178,7 @@ public class WorkspaceCommandServiceTest {
 	void test7() {
 		// given
 		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			passwordEncoder.encode("password1234!"));
+			"password1234!");
 
 		WorkspacePasswordUpdateRequest request = WorkspacePasswordUpdateRequest.builder()
 			.originalPassword("password1234!")
@@ -220,7 +220,7 @@ public class WorkspaceCommandServiceTest {
 	void test9() {
 		// given
 		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			passwordEncoder.encode("password1234!"));
+			"password1234!");
 
 		WorkspacePasswordUpdateRequest request = WorkspacePasswordUpdateRequest.builder()
 			.originalPassword("invalid1234!")
@@ -238,7 +238,7 @@ public class WorkspaceCommandServiceTest {
 	void test10() {
 		// given
 		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			passwordEncoder.encode("password1234!"));
+			"password1234!");
 
 		WorkspacePasswordUpdateRequest request = WorkspacePasswordUpdateRequest.builder()
 			.originalPassword("password1234!")
@@ -260,7 +260,7 @@ public class WorkspaceCommandServiceTest {
 	void test11() {
 		// given
 		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			passwordEncoder.encode("password1234!"));
+			"password1234!");
 
 		WorkspacePasswordUpdateRequest request = WorkspacePasswordUpdateRequest.builder()
 			.originalPassword("password1234!")

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceQueryServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceQueryServiceTest.java
@@ -35,7 +35,7 @@ import com.uranus.taskmanager.fixture.repository.WorkspaceRepositoryFixture;
 public class WorkspaceQueryServiceTest {
 
 	@Autowired
-	private WorkspaceService workspaceService;
+	private WorkspaceAccessService workspaceAccessService;
 	@Autowired
 	private WorkspaceQueryService workspaceQueryService;
 	@Autowired
@@ -98,7 +98,7 @@ public class WorkspaceQueryServiceTest {
 			.email("member2@test.com")
 			.build();
 
-		workspaceService.participateWorkspace("TEST1111", new WorkspaceParticipateRequest(), loginMember2);
+		workspaceAccessService.joinWorkspace("TEST1111", new WorkspaceParticipateRequest(), loginMember2);
 		Pageable pageable = PageRequest.of(0, 20);
 
 		// when
@@ -119,7 +119,7 @@ public class WorkspaceQueryServiceTest {
 			.email("member2@test.com")
 			.build();
 
-		workspaceService.participateWorkspace("TEST1111", new WorkspaceParticipateRequest(), loginMember2);
+		workspaceAccessService.joinWorkspace("TEST1111", new WorkspaceParticipateRequest(), loginMember2);
 
 		// when
 		WorkspaceDetail response = workspaceQueryService.getWorkspaceDetail("TEST1111", loginMember2);

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceQueryServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceQueryServiceTest.java
@@ -28,9 +28,12 @@ import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
 import com.uranus.taskmanager.api.workspacemember.exception.MemberNotInWorkspaceException;
 import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
-import com.uranus.taskmanager.fixture.repository.MemberRespositoryFixture;
+import com.uranus.taskmanager.fixture.repository.MemberRepositoryFixture;
 import com.uranus.taskmanager.fixture.repository.WorkspaceRepositoryFixture;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @SpringBootTest
 public class WorkspaceQueryServiceTest {
 
@@ -48,12 +51,12 @@ public class WorkspaceQueryServiceTest {
 	@Autowired
 	private WorkspaceRepositoryFixture workspaceRepositoryFixture;
 	@Autowired
-	private MemberRespositoryFixture memberRespositoryFixture;
+	private MemberRepositoryFixture memberRepositoryFixture;
 
 	@BeforeEach
 	void setup() {
 		// member1이 workspace1,2를 생성
-		Member member1 = memberRespositoryFixture.createMember("member1", "member1@test.com", "member1password!");
+		Member member1 = memberRepositoryFixture.createMember("member1", "member1@test.com", "member1password!");
 		Workspace workspace1 = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
 			null);
 		Workspace workspace2 = workspaceRepositoryFixture.createWorkspace("workspace2", "description2", "TEST2222",
@@ -92,7 +95,7 @@ public class WorkspaceQueryServiceTest {
 	@DisplayName("멤버는 자기가 참여한 모든 워크스페이스를 조회할 수 있다(자기가 생성하지 않은 워크스페이스)")
 	void test2() {
 		// given
-		memberRespositoryFixture.createMember("member2", "member2@test.com", "member2password!");
+		memberRepositoryFixture.createMember("member2", "member2@test.com", "member2password!");
 		LoginMemberDto loginMember2 = LoginMemberDto.builder()
 			.loginId("member2")
 			.email("member2@test.com")
@@ -113,7 +116,7 @@ public class WorkspaceQueryServiceTest {
 	@DisplayName("해당 워크스페이스에 참여하고 있으면, 워크스페이스의 코드로 상세 정보를 조회할 수 있다")
 	void test3() {
 		// given
-		memberRespositoryFixture.createMember("member2", "member2@test.com", "member2password!");
+		memberRepositoryFixture.createMember("member2", "member2@test.com", "member2password!");
 		LoginMemberDto loginMember2 = LoginMemberDto.builder()
 			.loginId("member2")
 			.email("member2@test.com")
@@ -134,7 +137,7 @@ public class WorkspaceQueryServiceTest {
 	@DisplayName("해당 워크스페이스에 참여하지 않으면, 유효한 코드로 상세 정보를 조회해도 예외가 발생한다")
 	void test4() {
 		// given
-		memberRespositoryFixture.createMember("member2", "member2@test.com", "member2password!");
+		memberRepositoryFixture.createMember("member2", "member2@test.com", "member2password!");
 		LoginMemberDto loginMember2 = LoginMemberDto.builder()
 			.loginId("member2")
 			.email("member2@test.com")
@@ -150,7 +153,7 @@ public class WorkspaceQueryServiceTest {
 	@DisplayName("유효하지 않은 코드로 워크스페이스를 조회하면 예외가 발생한다")
 	void test5() {
 		// given
-		memberRespositoryFixture.createMember("member2", "member2@test.com", "member2password!");
+		memberRepositoryFixture.createMember("member2", "member2@test.com", "member2password!");
 		LoginMemberDto loginMember2 = LoginMemberDto.builder()
 			.loginId("member2")
 			.email("member2@test.com")
@@ -166,15 +169,13 @@ public class WorkspaceQueryServiceTest {
 	@DisplayName("워크스페이스 전체 조회에서 이름에 대한 역정렬을 적용하면, 역정렬된 결과로 조회할 수 있다")
 	void test6() {
 		// given
-		Member member2 = memberRespositoryFixture.createMember("member2", "member2@test.com", "member1password!");
+		Member member2 = memberRepositoryFixture.createMember("member2", "member2@test.com", "member1password!");
 		LoginMemberDto loginMember2 = LoginMemberDto.builder()
 			.loginId("member2")
 			.email("member2@test.com")
 			.build();
 
-		/*
-		 * workspace3 ~ 7 이름으로 워크스페이스 5개 생성
-		 */
+		// workspace3 ~ 7 이라는 이름으로 워크스페이스 5개 생성
 		for (int i = 3; i <= 7; i++) {
 			Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace" + i, "description" + i,
 				"TEST" + i, null);

--- a/src/test/java/com/uranus/taskmanager/basetest/BaseApiIntegrationTest.java
+++ b/src/test/java/com/uranus/taskmanager/basetest/BaseApiIntegrationTest.java
@@ -11,7 +11,7 @@ import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.member.service.MemberService;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.service.CheckCodeDuplicationService;
-import com.uranus.taskmanager.api.workspace.service.WorkspaceService;
+import com.uranus.taskmanager.api.workspace.service.WorkspaceAccessService;
 import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -20,7 +20,7 @@ public abstract class BaseApiIntegrationTest {
 	protected int port;
 
 	@Autowired
-	protected WorkspaceService workspaceService;
+	protected WorkspaceAccessService workspaceAccessService;
 	@Autowired
 	protected CheckCodeDuplicationService workspaceCreateService;
 	@Autowired

--- a/src/test/java/com/uranus/taskmanager/basetest/BaseServiceIntegrationTest.java
+++ b/src/test/java/com/uranus/taskmanager/basetest/BaseServiceIntegrationTest.java
@@ -10,14 +10,14 @@ import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.member.service.MemberService;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.service.CheckCodeDuplicationService;
-import com.uranus.taskmanager.api.workspace.service.WorkspaceService;
+import com.uranus.taskmanager.api.workspace.service.WorkspaceAccessService;
 import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
 
 @SpringBootTest
 public class BaseServiceIntegrationTest {
 
 	@Autowired
-	protected WorkspaceService workspaceService;
+	protected WorkspaceAccessService workspaceAccessService;
 	@Autowired
 	protected CheckCodeDuplicationService workspaceCreateService;
 	@Autowired

--- a/src/test/java/com/uranus/taskmanager/fixture/repository/MemberRepositoryFixture.java
+++ b/src/test/java/com/uranus/taskmanager/fixture/repository/MemberRepositoryFixture.java
@@ -6,27 +6,30 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
+import com.uranus.taskmanager.api.security.PasswordEncoder;
 
 @Component
 @Transactional
-public class MemberRespositoryFixture {
+public class MemberRepositoryFixture {
 
 	@Autowired
 	private MemberRepository memberRepository;
+	@Autowired
+	private PasswordEncoder passwordEncoder;
 
 	/**
 	 * 멤버를 생성하고 저장합니다.
 	 *
 	 * @param loginId - 로그인 ID
 	 * @param email - 이메일
-	 * @param password - 비밀번호 (암호화되지 않은 상태)
+	 * @param password - 비밀번호 (암호화)
 	 * @return 저장된 Member 객체
 	 */
 	public Member createMember(String loginId, String email, String password) {
 		Member member = Member.builder()
 			.loginId(loginId)
 			.email(email)
-			.password(password) // 테스트에서는 비밀번호를 미리 암호화하지 않음
+			.password(passwordEncoder.encode(password))
 			.build();
 		return memberRepository.save(member);
 	}


### PR DESCRIPTION
## 🚀 설명
- `participateWorkspace` -> `joinWorkspace`로 이름 변경
- `WorkspaceController`에서 다음의 API를 `WorkspaceAccessController`로 분리
  - `inviteMembers`
  - `inviteMember`
  - `joinWorkspace`
 - 워크스페이스 멤버 추방 기능 구현
 - 테스트 추가
 - 기존 `WorkspaceAccessServiceTest`에서 `@SprintBootTest`를 사용하도록 변경

---
## ✅ 변경 사항
- [x] `participateWorkspace` -> `joinWorkspace`
- [x] `WorkspaceController`에서 다음의 API를 `WorkspaceAccessController`로 분리
- [x] `kickWorkspaceMember` 추가(구현)
- [x] 테스트 추가
- [x] `WorkspaceAccessServiceTest`를 통합 테스트로 변경

---
## 🚩 관련 이슈, PR
- #30 
- #63 

---
## 📖 참고