### PR TITLE
Feat/#46 워크스페이스 생성 제한 구현, 워크스페이스 권한 세분화

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/invitation/service/InvitationService.java
+++ b/src/main/java/com/uranus/taskmanager/api/invitation/service/InvitationService.java
@@ -31,7 +31,7 @@ public class InvitationService {
 		changeStatusToAccepted(invitation);
 		addMemberToWorkspace(invitation);
 
-		return InvitationAcceptResponse.from(invitation.getWorkspace(), WorkspaceRole.USER);
+		return InvitationAcceptResponse.from(invitation.getWorkspace(), WorkspaceRole.COLLABORATOR);
 	}
 
 	@Transactional
@@ -61,7 +61,7 @@ public class InvitationService {
 		Workspace workspace = invitation.getWorkspace();
 		Member member = invitation.getMember();
 		WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member,
-			workspace, WorkspaceRole.USER, member.getEmail());
+			workspace, WorkspaceRole.COLLABORATOR, member.getEmail());
 
 		workspace.increaseMemberCount();
 

--- a/src/main/java/com/uranus/taskmanager/api/member/domain/Member.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/domain/Member.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.uranus.taskmanager.api.common.entity.BaseDateEntity;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
+import com.uranus.taskmanager.api.member.exception.WorkspaceCreationLimitExceededException;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 
 import jakarta.persistence.CascadeType;
@@ -36,11 +37,34 @@ public class Member extends BaseDateEntity {
 	@Column(nullable = false)
 	private String password;
 
+	/**
+	 * Todo
+	 * 	- 이슈 #82 참고
+	 * 	- 워크스페이스 생성/유지 한도를 관리하기 위해 사용(최대 50개)
+	 * 	- 정보 제공 목적으로 사용
+	 * 	- 추후에 50을 상수로 따로 분리, 외부 설정으로 설정을 주입할 수 있도록 구현해야 함
+	 */
+	@Column(nullable = false)
+	private int workspaceCount = 0;
+
 	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<WorkspaceMember> workspaceMembers = new ArrayList<>();
 
 	@OneToMany(mappedBy = "member")
 	private List<Invitation> invitations = new ArrayList<>();
+
+	public void increaseWorkspaceCount() {
+		if (this.workspaceCount >= 50) {
+			throw new WorkspaceCreationLimitExceededException();
+		}
+		this.workspaceCount++;
+	}
+
+	public void decreaseWorkspaceCount() {
+		if (this.workspaceCount > 0) {
+			this.workspaceCount--;
+		}
+	}
 
 	@Builder
 	public Member(String loginId, String email, String password) {

--- a/src/main/java/com/uranus/taskmanager/api/member/exception/WorkspaceCreationLimitExceededException.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/exception/WorkspaceCreationLimitExceededException.java
@@ -1,0 +1,18 @@
+package com.uranus.taskmanager.api.member.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.common.exception.MemberException;
+
+public class WorkspaceCreationLimitExceededException extends MemberException {
+	private static final String MESSAGE = "Maximum workspace creation limit of 50 reached";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
+
+	public WorkspaceCreationLimitExceededException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public WorkspaceCreationLimitExceededException(Throwable cause) {
+		super(MESSAGE, HTTP_STATUS, cause);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceAccessController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceAccessController.java
@@ -36,7 +36,7 @@ public class WorkspaceAccessController {
 	private final WorkspaceAccessService workspaceAccessService;
 
 	@LoginRequired
-	@RoleRequired(roles = {WorkspaceRole.ADMIN})
+	@RoleRequired(roles = {WorkspaceRole.MANAGER})
 	@PostMapping("/{code}/invite")
 	public ApiResponse<InviteMemberResponse> inviteMember(
 		@PathVariable String code,
@@ -47,7 +47,7 @@ public class WorkspaceAccessController {
 	}
 
 	@LoginRequired
-	@RoleRequired(roles = {WorkspaceRole.ADMIN})
+	@RoleRequired(roles = {WorkspaceRole.MANAGER})
 	@PostMapping("/{code}/invites")
 	public ApiResponse<InviteMembersResponse> inviteMembers(
 		@PathVariable String code,
@@ -69,8 +69,13 @@ public class WorkspaceAccessController {
 		return ApiResponse.ok("Joined Workspace", response);
 	}
 
+	/**
+	 * Todo
+	 *  - 자기 자신 강퇴 불가능하게 로직 수정
+	 *  - 자기보다 낮은 권한만 강퇴할 수 있도록 로직 추가
+	 */
 	@LoginRequired
-	@RoleRequired(roles = {WorkspaceRole.ADMIN})
+	@RoleRequired(roles = {WorkspaceRole.MANAGER})
 	@DeleteMapping("/{code}/kick")
 	public ApiResponse<KickWorkspaceMemberResponse> kickWorkspaceMember(
 		@PathVariable String code,

--- a/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceController.java
@@ -57,17 +57,18 @@ public class WorkspaceController {
 	}
 
 	@LoginRequired
-	@RoleRequired(roles = WorkspaceRole.ADMIN)
+	@RoleRequired(roles = WorkspaceRole.OWNER)
 	@DeleteMapping("/{code}")
 	public ApiResponse<String> deleteWorkspace(@PathVariable String code,
+		@ResolveLoginMember LoginMember loginMember,
 		@RequestBody WorkspaceDeleteRequest request) {
 
-		workspaceCommandService.deleteWorkspace(request, code);
+		workspaceCommandService.deleteWorkspace(request, code, loginMember.getId());
 		return ApiResponse.ok("Workspace Deleted", code);
 	}
 
 	@LoginRequired
-	@RoleRequired(roles = WorkspaceRole.ADMIN)
+	@RoleRequired(roles = WorkspaceRole.MANAGER)
 	@PatchMapping("/{code}")
 	public ApiResponse<WorkspaceContentUpdateResponse> updateWorkspaceContent(@PathVariable String code,
 		@RequestBody @Valid WorkspaceContentUpdateRequest request) {
@@ -77,7 +78,7 @@ public class WorkspaceController {
 	}
 
 	@LoginRequired
-	@RoleRequired(roles = WorkspaceRole.ADMIN)
+	@RoleRequired(roles = WorkspaceRole.MANAGER)
 	@PutMapping("/{code}/password")
 	public ApiResponse<String> updateWorkspacePassword(@PathVariable String code,
 		@RequestBody @Valid WorkspacePasswordUpdateRequest request) {

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
@@ -110,7 +110,7 @@ public class CheckCodeDuplicationService implements WorkspaceCreateService {
 
 	private void addAdminMemberToWorkspace(Member member, Workspace workspace) {
 		WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace,
-			WorkspaceRole.ADMIN,
+			WorkspaceRole.MANAGER,
 			member.getEmail());
 
 		workspaceMemberRepository.save(workspaceMember);

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
@@ -39,17 +39,15 @@ public class CheckCodeDuplicationService implements WorkspaceCreateService {
 	private final PasswordEncoder passwordEncoder;
 
 	/**
-	 * Todo: 서비스용 DTO를 만들면, 다시 리팩토링
 	 * 로그인 정보를 사용해서 멤버의 존재 유무를 검증한다
 	 * 워크스페이스 생성 요청에 유일한 코드를 생성하고 설정한다
 	 * 만약 코드가 중복되면 최대 5회 재성성 시도를 한다
-	 * 워크세프이스 생성 요청의 평문 비밀번호를 암호화하고 설정한다
 	 * 워크스페이스 생성 요청을 사용해서 워크스페이스를 생성하고 저장한다
 	 * 로그인 정보를 통해 찾은 멤버를 해당 워크스페이스에 참여시킨다
 	 *
-	 * @param request - 컨트롤러의 워크스페이스 생성 요청 객체
+	 * @param request  - 컨트롤러의 워크스페이스 생성 요청 객체
 	 * @param memberId - 컨트롤러에서의 로그인 정보에서 꺼내온 멤버 id(PK)
-	 * @return WorkspaceCreateResponse
+	 * @return WorkspaceCreateResponse - 워크스페이스 생성 응답 DTO
 	 */
 	@Override
 	@Transactional
@@ -57,6 +55,7 @@ public class CheckCodeDuplicationService implements WorkspaceCreateService {
 		Long memberId) {
 
 		Member member = findMemberById(memberId);
+		member.increaseWorkspaceCount();
 
 		setUniqueWorkspaceCode(request);
 		setEncodedPasswordIfPresent(request);

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/HandleDatabaseExceptionService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/HandleDatabaseExceptionService.java
@@ -65,7 +65,7 @@ public class HandleDatabaseExceptionService implements WorkspaceCreateService {
 	}
 
 	private void addAdminMemberToWorkspace(Member member, Workspace workspace) {
-		WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace, WorkspaceRole.ADMIN,
+		WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace, WorkspaceRole.MANAGER,
 			member.getEmail());
 
 		workspaceMemberRepository.save(workspaceMember);

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/HandleDatabaseExceptionService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/HandleDatabaseExceptionService.java
@@ -41,10 +41,10 @@ public class HandleDatabaseExceptionService implements WorkspaceCreateService {
 
 	@Override
 	@Transactional
-	public WorkspaceCreateResponse createWorkspace(WorkspaceCreateRequest request,
-		Long memberId) {
+	public WorkspaceCreateResponse createWorkspace(WorkspaceCreateRequest request, Long memberId) {
 
 		Member member = findMemberById(memberId);
+		member.increaseWorkspaceCount();
 
 		for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
 			try {
@@ -65,8 +65,7 @@ public class HandleDatabaseExceptionService implements WorkspaceCreateService {
 	}
 
 	private void addAdminMemberToWorkspace(Member member, Workspace workspace) {
-		WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace,
-			WorkspaceRole.ADMIN,
+		WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace, WorkspaceRole.ADMIN,
 			member.getEmail());
 
 		workspaceMemberRepository.save(workspaceMember);

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceAccessService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceAccessService.java
@@ -102,8 +102,8 @@ public class WorkspaceAccessService {
 	 * 참여할 워크스페이스의 코드와 참여 요청의 패스워드(null 허용)를 사용해서
 	 * 참여를 요청한 로그인 멤버를 해당 워크스페이스에 참여시킨다.
 	 *
-	 * @param code - 워크스페이스의 고유 코드
-	 * @param request - 워크스페이스 참여 요청 객체
+	 * @param code     - 워크스페이스의 고유 코드
+	 * @param request  - 워크스페이스 참여 요청 객체
 	 * @param memberId - 세션에서 꺼낸 멤버 id(PK)
 	 * @return - 워크스페이스 참여 응답을 위한 DTO
 	 */
@@ -121,7 +121,8 @@ public class WorkspaceAccessService {
 
 		validatePasswordIfExists(workspace.getPassword(), request.getPassword());
 
-		WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace, WorkspaceRole.USER,
+		WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace,
+			WorkspaceRole.COLLABORATOR,
 			member.getEmail());
 		/*
 		 * Todo

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandService.java
@@ -56,20 +56,12 @@ public class WorkspaceCommandService {
 	}
 
 	@Transactional
-	public void deleteWorkspace(WorkspaceDeleteRequest request, String code) {
+	public void deleteWorkspace(WorkspaceDeleteRequest request, String code, Long id) {
 		Workspace workspace = findWorkspaceByCode(code);
-		/*
-		 * Todo
-		 *  - 워크스페이스의 주인(생성자)의 로그인 Id를 통해서 주인 멤버 찾기
-		 *  - 해당 멤버의 workspaceCount 감소
-		 *  - 추후에 로직 개선 필요(DD를 적용하면 전체적으로 변할 듯)
-		 *  - 주인(Owner) Role 추가 -> 그냥 워크스페이스 삭제를 주인만 가능하도록 제한하면 더 쉬울 듯
-		 *  - -> 컨트롤러에서 LoginMember(id)를 읽어와서 사용하면 됨
-		 */
-		Member workspaceOwner = memberRepository.findByLoginId(workspace.getCreatedBy())
-			.orElseThrow(MemberNotInWorkspaceException::new);
 
-		workspaceOwner.decreaseWorkspaceCount();
+		Member member = memberRepository.findById(id)
+			.orElseThrow(MemberNotInWorkspaceException::new);
+		member.decreaseWorkspaceCount();
 
 		validatePasswordIfExists(workspace.getPassword(), request.getPassword());
 

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/WorkspaceRole.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/WorkspaceRole.java
@@ -6,9 +6,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum WorkspaceRole {
-	ADMIN(3),
-	USER(2),
-	READER(1);
+	OWNER(4),
+	MANAGER(3),
+	COLLABORATOR(2),
+	VIEWER(1);
 
 	private final int level;
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/RoleRequired.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/RoleRequired.java
@@ -10,5 +10,5 @@ import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RoleRequired {
-	WorkspaceRole[] roles(); // 요구되는 권한을 배열로 받는다
+	WorkspaceRole[] roles();
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/domain/WorkspaceMember.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/domain/WorkspaceMember.java
@@ -40,6 +40,7 @@ public class WorkspaceMember {
 	@Column(nullable = false)
 	private WorkspaceRole role;
 
+	@Column(nullable = false)
 	private String nickname;
 
 	@Builder

--- a/src/test/java/com/uranus/taskmanager/api/invitation/controller/InvitationControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/invitation/controller/InvitationControllerTest.java
@@ -48,7 +48,7 @@ class InvitationControllerTest extends ControllerTestHelper {
 			.build();
 
 		InvitationAcceptResponse response = InvitationAcceptResponse.builder()
-			.workspaceDetail(WorkspaceDetail.from(workspace, WorkspaceRole.USER))
+			.workspaceDetail(WorkspaceDetail.from(workspace, WorkspaceRole.COLLABORATOR))
 			.nickname("member1@test.com")
 			.build();
 

--- a/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceControllerTest.java
@@ -144,7 +144,7 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 			.code("TEST1111")
 			.build();
 		WorkspaceMember workspaceMember = WorkspaceMember.builder()
-			.role(WorkspaceRole.ADMIN)
+			.role(WorkspaceRole.MANAGER)
 			.build();
 
 		// AuthorizationInterceptor 행위 모킹
@@ -183,7 +183,7 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 			.code("TEST1111")
 			.build();
 		WorkspaceMember workspaceMember = WorkspaceMember.builder()
-			.role(WorkspaceRole.ADMIN)
+			.role(WorkspaceRole.MANAGER)
 			.build();
 
 		// AuthorizationInterceptor 행위 모킹
@@ -201,7 +201,7 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 			.andExpect(jsonPath("$.data").value("TEST1111"));
 
 		verify(workspaceCommandService, times(1))
-			.deleteWorkspace(ArgumentMatchers.any(WorkspaceDeleteRequest.class), eq("TEST1111"));
+			.deleteWorkspace(ArgumentMatchers.any(WorkspaceDeleteRequest.class), eq("TEST1111"), anyLong());
 	}
 
 	@Test
@@ -213,7 +213,7 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 		WorkspaceDetail workspaceDetail = WorkspaceDetail.builder()
 			.name("Test Workspace")
 			.description("Test Description")
-			.role(WorkspaceRole.ADMIN)
+			.role(WorkspaceRole.MANAGER)
 			.code(code)
 			.build();
 
@@ -247,7 +247,7 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 			.createdAt(LocalDateTime.now().minusDays(5))
 			.updatedBy("updater1")
 			.updatedAt(LocalDateTime.now())
-			.role(WorkspaceRole.USER)
+			.role(WorkspaceRole.COLLABORATOR)
 			.build();
 
 		WorkspaceDetail workspaceDetail2 = WorkspaceDetail.builder()
@@ -259,7 +259,7 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 			.createdAt(LocalDateTime.now().minusDays(10))
 			.updatedBy("updater2")
 			.updatedAt(LocalDateTime.now())
-			.role(WorkspaceRole.USER)
+			.role(WorkspaceRole.COLLABORATOR)
 			.build();
 
 		MyWorkspacesResponse response = MyWorkspacesResponse.builder()
@@ -308,7 +308,7 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 			.createdAt(LocalDateTime.now().minusDays(5))
 			.updatedBy("updater1")
 			.updatedAt(LocalDateTime.now())
-			.role(WorkspaceRole.USER)
+			.role(WorkspaceRole.COLLABORATOR)
 			.build();
 
 		WorkspaceDetail workspaceDetail2 = WorkspaceDetail.builder()
@@ -320,7 +320,7 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 			.createdAt(LocalDateTime.now().minusDays(10))
 			.updatedBy("updater2")
 			.updatedAt(LocalDateTime.now())
-			.role(WorkspaceRole.ADMIN)
+			.role(WorkspaceRole.MANAGER)
 			.build();
 
 		MyWorkspacesResponse response = MyWorkspacesResponse.builder()

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceAccessServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceAccessServiceTest.java
@@ -42,7 +42,7 @@ class WorkspaceAccessServiceTest extends ServiceIntegrationTestHelper {
 		Workspace workspace = workspaceRepositoryFixture.createWorkspace("Test Workspace", "Test Description",
 			"TESTCODE", null);
 		member = memberRepositoryFixture.createMember("member1", "member1@test.com", "password1234!");
-		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.USER);
+		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.COLLABORATOR);
 	}
 
 	@AfterEach
@@ -232,7 +232,7 @@ class WorkspaceAccessServiceTest extends ServiceIntegrationTestHelper {
 		String workspaceCode = "TESTCODE";
 		Workspace workspace = workspaceRepository.findByCode(workspaceCode).get();
 		Member member2 = memberRepositoryFixture.createMember("member2", "member2@test.com", "password1234!");
-		workspaceRepositoryFixture.addMemberToWorkspace(member2, workspace, WorkspaceRole.USER);
+		workspaceRepositoryFixture.addMemberToWorkspace(member2, workspace, WorkspaceRole.COLLABORATOR);
 
 		KickWorkspaceMemberRequest request = new KickWorkspaceMemberRequest(member2.getLoginId());
 

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandServiceTest.java
@@ -3,6 +3,7 @@ package com.uranus.taskmanager.api.workspace.service;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,12 @@ class WorkspaceCommandServiceTest extends ServiceIntegrationTestHelper {
 		databaseCleaner.execute();
 	}
 
+	/**
+	 * Todo
+	 *  - deleteWorkspace의 주석 참고
+	 *  - 로직 수정 후 테스트 적용
+	 */
+	@Disabled
 	@Test
 	@DisplayName("유효한 워크스페이스 코드와 비밀번호로 워크스페이스를 삭제할 수 있다")
 	void test1() {
@@ -43,6 +50,12 @@ class WorkspaceCommandServiceTest extends ServiceIntegrationTestHelper {
 		assertThat(workspaceRepository.findByCode("TEST1111")).isEmpty();
 	}
 
+	/**
+	 * Todo
+	 *  - deleteWorkspace의 주석 참고
+	 *  - 로직 수정 후 테스트 적용
+	 */
+	@Disabled
 	@Transactional
 	@Test
 	@DisplayName("워크스페이스 삭제 시도 시 비밀번호가 맞지 않으면 예외가 발생한다")

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCommandServiceTest.java
@@ -3,7 +3,6 @@ package com.uranus.taskmanager.api.workspace.service;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,12 +25,6 @@ class WorkspaceCommandServiceTest extends ServiceIntegrationTestHelper {
 		databaseCleaner.execute();
 	}
 
-	/**
-	 * Todo
-	 *  - deleteWorkspace의 주석 참고
-	 *  - 로직 수정 후 테스트 적용
-	 */
-	@Disabled
 	@Test
 	@DisplayName("유효한 워크스페이스 코드와 비밀번호로 워크스페이스를 삭제할 수 있다")
 	void test1() {
@@ -39,23 +32,18 @@ class WorkspaceCommandServiceTest extends ServiceIntegrationTestHelper {
 		Member member = memberRepositoryFixture.createMember("member1", "member1@test.com", "member1password!");
 		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
 			"password1234!");
-		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.ADMIN);
+		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.MANAGER);
 
 		workspaceRepositoryFixture.createWorkspace("workspace2", "description2", "TEST2222", null);
 
 		// when
-		workspaceCommandService.deleteWorkspace(new WorkspaceDeleteRequest("password1234!"), "TEST1111");
+		workspaceCommandService.deleteWorkspace(new WorkspaceDeleteRequest("password1234!"), "TEST1111",
+			member.getId());
 
 		// then
 		assertThat(workspaceRepository.findByCode("TEST1111")).isEmpty();
 	}
 
-	/**
-	 * Todo
-	 *  - deleteWorkspace의 주석 참고
-	 *  - 로직 수정 후 테스트 적용
-	 */
-	@Disabled
 	@Transactional
 	@Test
 	@DisplayName("워크스페이스 삭제 시도 시 비밀번호가 맞지 않으면 예외가 발생한다")
@@ -64,11 +52,12 @@ class WorkspaceCommandServiceTest extends ServiceIntegrationTestHelper {
 		Member member = memberRepositoryFixture.createMember("member1", "member1@test.com", "member1password!");
 		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
 			"password1234!");
-		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.ADMIN);
+		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.MANAGER);
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceCommandService.deleteWorkspace(new WorkspaceDeleteRequest("InvalidPassword"), "TEST1111"))
+			() -> workspaceCommandService.deleteWorkspace(new WorkspaceDeleteRequest("InvalidPassword"), "TEST1111",
+				member.getId()))
 			.isInstanceOf(InvalidWorkspacePasswordException.class);
 
 	}
@@ -81,11 +70,12 @@ class WorkspaceCommandServiceTest extends ServiceIntegrationTestHelper {
 		Member member = memberRepositoryFixture.createMember("member1", "member1@test.com", "member1password!");
 		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
 			"password1234!");
-		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.ADMIN);
+		workspaceRepositoryFixture.addMemberToWorkspace(member, workspace, WorkspaceRole.MANAGER);
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceCommandService.deleteWorkspace(new WorkspaceDeleteRequest("password1234!"), "INVALIDCODE"))
+			() -> workspaceCommandService.deleteWorkspace(new WorkspaceDeleteRequest("password1234!"), "INVALIDCODE",
+				member.getId()))
 			.isInstanceOf(WorkspaceNotFoundException.class);
 
 	}
@@ -95,8 +85,7 @@ class WorkspaceCommandServiceTest extends ServiceIntegrationTestHelper {
 	@DisplayName("유효한 워크스페이스 코드로 워크스페이스의 이름과 설명을 수정할 수 있다")
 	void test4() {
 		// given
-		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			null);
+		workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111", null);
 
 		WorkspaceContentUpdateRequest request = WorkspaceContentUpdateRequest.builder()
 			.name("Updated Name")
@@ -116,8 +105,7 @@ class WorkspaceCommandServiceTest extends ServiceIntegrationTestHelper {
 	@DisplayName("워크스페이스의 이름만 수정하면 해당 필드만 업데이트된다")
 	void test5() {
 		// given
-		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			null);
+		workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111", null);
 
 		WorkspaceContentUpdateRequest request = WorkspaceContentUpdateRequest.builder()
 			.name("Updated Name")
@@ -136,8 +124,7 @@ class WorkspaceCommandServiceTest extends ServiceIntegrationTestHelper {
 	@DisplayName("워크스페이스의 설명만 수정하면 해당 필드만 업데이트된다")
 	void test6() {
 		// given
-		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			null);
+		workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111", null);
 
 		WorkspaceContentUpdateRequest request = WorkspaceContentUpdateRequest.builder()
 			.description("Updated Description")
@@ -156,8 +143,7 @@ class WorkspaceCommandServiceTest extends ServiceIntegrationTestHelper {
 	@DisplayName("비밀번호 수정 요청의 원본 비밀번호가 유효하면 요청의 수정 비밀번호로 업데이트된다")
 	void test7() {
 		// given
-		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			"password1234!");
+		workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111", "password1234!");
 
 		WorkspacePasswordUpdateRequest request = WorkspacePasswordUpdateRequest.builder()
 			.originalPassword("password1234!")
@@ -178,8 +164,7 @@ class WorkspaceCommandServiceTest extends ServiceIntegrationTestHelper {
 	@DisplayName("워크스페이스의 비밀번호가 null이면 비밀번호 수정 요청의 수정 비밀번호로 업데이트된다")
 	void test8() {
 		// given
-		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			null);
+		workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111", null);
 
 		WorkspacePasswordUpdateRequest request = WorkspacePasswordUpdateRequest.builder()
 			.updatePassword("updated1234!")
@@ -198,8 +183,7 @@ class WorkspaceCommandServiceTest extends ServiceIntegrationTestHelper {
 	@DisplayName("비밀번호 수정 요청의 원본 비밀번호가 유효하지 않으면 예외가 발생한다")
 	void test9() {
 		// given
-		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			"password1234!");
+		workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111", "password1234!");
 
 		WorkspacePasswordUpdateRequest request = WorkspacePasswordUpdateRequest.builder()
 			.originalPassword("invalid1234!")
@@ -216,8 +200,7 @@ class WorkspaceCommandServiceTest extends ServiceIntegrationTestHelper {
 	@DisplayName("비밀번호 수정 요청의 수정 비밀번호를 제공하지 않으면 비밀번호는 null로 업데이트 된다")
 	void test10() {
 		// given
-		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			"password1234!");
+		workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111", "password1234!");
 
 		WorkspacePasswordUpdateRequest request = WorkspacePasswordUpdateRequest.builder()
 			.originalPassword("password1234!")
@@ -238,8 +221,7 @@ class WorkspaceCommandServiceTest extends ServiceIntegrationTestHelper {
 	@DisplayName("비밀번호 수정 요청의 수정 비밀번호를 null로 제공하면 비밀번호는 null로 업데이트 된다")
 	void test11() {
 		// given
-		Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111",
-			"password1234!");
+		workspaceRepositoryFixture.createWorkspace("workspace1", "description1", "TEST1111", "password1234!");
 
 		WorkspacePasswordUpdateRequest request = WorkspacePasswordUpdateRequest.builder()
 			.originalPassword("password1234!")

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTest.java
@@ -1,210 +1,148 @@
 package com.uranus.taskmanager.api.workspace.service;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
 
-import java.util.Optional;
-
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.uranus.taskmanager.api.authentication.dto.LoginMember;
 import com.uranus.taskmanager.api.member.domain.Member;
-import com.uranus.taskmanager.api.member.repository.MemberRepository;
-import com.uranus.taskmanager.api.security.PasswordEncoder;
-import com.uranus.taskmanager.api.workspace.domain.Workspace;
+import com.uranus.taskmanager.api.member.exception.WorkspaceCreationLimitExceededException;
 import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceDeleteRequest;
 import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceCreateResponse;
-import com.uranus.taskmanager.api.workspace.exception.WorkspaceCodeCollisionHandleException;
-import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
-import com.uranus.taskmanager.api.workspace.util.WorkspaceCodeGenerator;
-import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
-import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
-import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
-import com.uranus.taskmanager.fixture.dto.LoginMemberDtoFixture;
-import com.uranus.taskmanager.fixture.dto.WorkspaceCreateDtoFixture;
-import com.uranus.taskmanager.fixture.entity.MemberEntityFixture;
-import com.uranus.taskmanager.fixture.entity.WorkspaceEntityFixture;
-import com.uranus.taskmanager.fixture.entity.WorkspaceMemberEntityFixture;
+import com.uranus.taskmanager.helper.ServiceIntegrationTestHelper;
 
-@ExtendWith(MockitoExtension.class)
-class WorkspaceCreateServiceTest {
+class WorkspaceCreateServiceTest extends ServiceIntegrationTestHelper {
 
-	@InjectMocks
-	private CheckCodeDuplicationService workspaceCreateService;
-
-	@Mock
-	private WorkspaceCodeGenerator workspaceCodeGenerator;
-	@Mock
-	private WorkspaceRepository workspaceRepository;
-	@Mock
-	private MemberRepository memberRepository;
-	@Mock
-	private WorkspaceMemberRepository workspaceMemberRepository;
-	@Mock
-	private PasswordEncoder passwordEncoder;
-
-	WorkspaceEntityFixture workspaceEntityFixture;
-	MemberEntityFixture memberEntityFixture;
-	WorkspaceMemberEntityFixture workspaceMemberEntityFixture;
-	LoginMemberDtoFixture loginMemberDtoFixture;
-	WorkspaceCreateDtoFixture workspaceCreateDtoFixture;
-
-	@BeforeEach
-	public void setup() {
-		workspaceMemberEntityFixture = new WorkspaceMemberEntityFixture();
-		memberEntityFixture = new MemberEntityFixture();
-		loginMemberDtoFixture = new LoginMemberDtoFixture();
-		workspaceEntityFixture = new WorkspaceEntityFixture();
-		workspaceCreateDtoFixture = new WorkspaceCreateDtoFixture();
+	@AfterEach
+	public void tearDown() {
+		databaseCleaner.execute();
 	}
 
 	@Test
-	@DisplayName("워크스페이스 생성에는 생성 요청과 로그인 멤버를 필요로 한다")
-	void test1() {
+	@DisplayName("워크스페이스 생성 시 멤버의 워크스페이스 카운트가 증가한다")
+	void createWorkspace_increasesWorkspaceCount() {
 		// given
-		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
-		String code = "TESTCODE";
+		Member member = memberRepository.save(
+			Member.builder()
+				.loginId("member1")
+				.email("member1@test.com")
+				.password("password1234!")
+				.build()
+		);
 
-		Workspace workspace = workspaceEntityFixture.createWorkspace("testcode");
-		Member member = memberEntityFixture.createMember("user123", "test@test.com");
-		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
-
-		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
-		when(workspaceCodeGenerator.generateWorkspaceCode()).thenReturn(code);
-		when(workspaceRepository.save(any(Workspace.class))).thenReturn(workspace);
+		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
+			.name("workspace1")
+			.description("description1")
+			.build();
 
 		// when
-		WorkspaceCreateResponse response = workspaceCreateService.createWorkspace(request, loginMember.getId());
+		workspaceCreateService.createWorkspace(request, member.getId());
 
 		// then
-		assertThat(response).isNotNull();
-		verify(memberRepository, times(1)).findById(1L);
-	}
-
-	@DisplayName("워크스페이스 생성을 성공하면 WorkspaceResponse를 반환한다")
-	void test2() {
-		// given
-		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
-		String code = "TESTCODE";
-
-		Workspace workspace = workspaceEntityFixture.createWorkspace("testcode");
-		Member member = memberEntityFixture.createMember("user123", "test@test.com");
-		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
-
-		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
-		when(workspaceCodeGenerator.generateWorkspaceCode()).thenReturn(code);
-		when(workspaceRepository.save(any(Workspace.class))).thenReturn(workspace);
-
-		// when
-		WorkspaceCreateResponse response = workspaceCreateService.createWorkspace(request, loginMember.getId());
-
-		// then
-		assertThat(response).isNotNull();
-		assertThat(response).isInstanceOf(WorkspaceCreateResponse.class);
-		verify(workspaceRepository, times(1)).save(any(Workspace.class));
+		Member updatedMember = memberRepository.findById(member.getId()).get();
+		assertThat(updatedMember.getWorkspaceCount()).isEqualTo(1);
 	}
 
 	@Test
-	@DisplayName("워크스페이스 코드가 중복될 때 최대 재시도 횟수(5회)를 소진하면 예외가 발생한다")
-	void test3() {
+	@DisplayName("워크스페이스 생성 시 멤버의 워크스페이스 카운트가 증가한다(워크스페이스 2개 생성)")
+	void createTwoWorkspaces_increasesWorkspaceCount() {
 		// given
-		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
+		Member member = memberRepository.save(
+			Member.builder()
+				.loginId("member1")
+				.email("member1@test.com")
+				.password("password1234!")
+				.build()
+		);
 
-		Member member = memberEntityFixture.createMember("user123", "test@test.com");
-		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
-		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
+		WorkspaceCreateRequest request1 = WorkspaceCreateRequest.builder()
+			.name("workspace1")
+			.description("description1")
+			.build();
 
-		when(workspaceCodeGenerator.generateWorkspaceCode())
-			.thenReturn("WORK123", "WORK124", "WORK125", "WORK126", "WORK127");
-		when(workspaceRepository.existsByCode(anyString())).thenReturn(true);
+		WorkspaceCreateRequest request2 = WorkspaceCreateRequest.builder()
+			.name("workspace2")
+			.description("description2")
+			.build();
+
+		// when
+		workspaceCreateService.createWorkspace(request1, member.getId());
+		workspaceCreateService.createWorkspace(request2, member.getId());
+
+		// then
+		Member updatedMember = memberRepository.findById(member.getId()).get();
+		assertThat(updatedMember.getWorkspaceCount()).isEqualTo(2);
+	}
+
+	@Test
+	@DisplayName("워크스페이스 50개 생성 후 추가 생성 시 예외가 발생한다")
+	void createWorkspace_throwsException_whenLimitReached() {
+		// given
+		Member member = memberRepository.save(
+			Member.builder()
+				.loginId("member1")
+				.email("member1@test.com")
+				.password("password1")
+				.build()
+		);
+
+		// Create 50 workspaces
+		for (int i = 0; i < 50; i++) {
+			WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
+				.name("workspace" + i)
+				.description("description" + i)
+				.build();
+			workspaceCreateService.createWorkspace(request, member.getId());
+		}
 
 		// when & then
-		assertThatThrownBy(() -> workspaceCreateService.createWorkspace(request, loginMember.getId()))
-			.isInstanceOf(WorkspaceCodeCollisionHandleException.class)
-			.hasMessageContaining("Failed to solve workspace code collision");
+		WorkspaceCreateRequest request51 = WorkspaceCreateRequest.builder()
+			.name("workspace51")
+			.description("description51")
+			.build();
+
+		assertThatThrownBy(() -> workspaceCreateService.createWorkspace(request51, member.getId()))
+			.isInstanceOf(WorkspaceCreationLimitExceededException.class);
 	}
 
+	/*
+	 * Todo
+	 *  - 워크스페이스의 주인(생성자)의 로그인 Id를 통해서 주인 멤버 찾기
+	 *  - 해당 멤버의 workspaceCount 감소
+	 *  - 추후에 로직 개선 필요(DD를 적용하면 전체적으로 변할 듯)
+	 *  - 주인(Owner) Role 추가 -> 그냥 워크스페이스 삭제를 주인만 가능하도록 제한하면 더 쉬울 듯
+	 *  - -> 컨트롤러에서 LoginMember(id)를 읽어와서 사용하면 됨
+	 *  <br>
+	 *  - 해당 workspaceDelete의 로직을 변경하고 나서 테스트 실행
+	 */
+	@Disabled
 	@Test
-	@DisplayName("워크스페이스 생성 시 WorkspaceMember도 생성되고 저장된다")
-	void test4() {
+	@DisplayName("워크스페이스 삭제 시 멤버의 워크스페이스 카운트가 감소한다")
+	void deleteWorkspace_decreasesWorkspaceCount() {
 		// given
-		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
-		String code = "TESTCODE";
+		Member member = memberRepository.save(
+			Member.builder()
+				.loginId("member1")
+				.email("member1@test.com")
+				.password("password1234!")
+				.build()
+		);
 
-		Workspace workspace = workspaceEntityFixture.createWorkspace("testcode");
-		Member member = memberEntityFixture.createMember("user123", "test@test.com");
-		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
-		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createAdminWorkspaceMember(member, workspace);
-		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
-		when(workspaceCodeGenerator.generateWorkspaceCode()).thenReturn(code);
-		when(workspaceRepository.save(any(Workspace.class))).thenReturn(workspace);
-		when(workspaceMemberRepository.save(any(WorkspaceMember.class))).thenReturn(workspaceMember);
+		WorkspaceCreateRequest request = WorkspaceCreateRequest.builder()
+			.name("workspace1")
+			.description("description1")
+			.build();
+
+		WorkspaceCreateResponse response = workspaceCreateService.createWorkspace(request, member.getId());
 
 		// when
-		workspaceCreateService.createWorkspace(request, loginMember.getId());
+		workspaceCommandService.deleteWorkspace(new WorkspaceDeleteRequest(), response.getCode());
 
 		// then
-		verify(workspaceMemberRepository, times(1)).save(any(WorkspaceMember.class));
-	}
-
-	@Test
-	@DisplayName("워크스페이스 생성 시 WorkspaceMember의 별칭은 생성자의 이메일로 설정된다")
-	void test5() {
-		// given
-		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
-		String code = "TESTCODE";
-
-		Workspace workspace = workspaceEntityFixture.createWorkspace("testcode");
-		Member member = memberEntityFixture.createMember("user123", "test@test.com");
-		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
-		WorkspaceMember adminWorkspaceMember = workspaceMemberEntityFixture.createAdminWorkspaceMember(member,
-			workspace);
-
-		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
-		when(workspaceCodeGenerator.generateWorkspaceCode()).thenReturn(code);
-		when(workspaceRepository.save(any(Workspace.class))).thenReturn(workspace);
-		when(workspaceMemberRepository.save(any(WorkspaceMember.class))).thenReturn(adminWorkspaceMember);
-
-		// when
-		workspaceCreateService.createWorkspace(request, loginMember.getId());
-
-		// then
-		verify(workspaceMemberRepository, times(1)).save(argThat(workspaceMember ->
-			workspaceMember.getNickname().equals("test@test.com")
-		));
-	}
-
-	@Test
-	@DisplayName("워크스페이스 생성 시 WorkspaceMember의 권한은 ADMIN으로 설정된다")
-	void test6() {
-		// given
-		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
-		String code = "TESTCODE";
-
-		Workspace workspace = workspaceEntityFixture.createWorkspace("testcode");
-		Member member = memberEntityFixture.createMember("user123", "test@test.com");
-		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
-		WorkspaceMember adminWorkspaceMember = workspaceMemberEntityFixture.createAdminWorkspaceMember(member,
-			workspace);
-
-		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
-		when(workspaceCodeGenerator.generateWorkspaceCode()).thenReturn(code);
-		when(workspaceRepository.save(any(Workspace.class))).thenReturn(workspace);
-		when(workspaceMemberRepository.save(any(WorkspaceMember.class))).thenReturn(adminWorkspaceMember);
-
-		// when
-		workspaceCreateService.createWorkspace(request, loginMember.getId());
-
-		// then
-		verify(workspaceMemberRepository, times(1)).save(argThat(workspaceMember ->
-			workspaceMember.getRole().equals(WorkspaceRole.ADMIN)
-		));
+		Member updatedMember = memberRepository.findById(member.getId()).get();
+		assertThat(updatedMember.getWorkspaceCount()).isEqualTo(0);
 	}
 }

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTest.java
@@ -3,7 +3,6 @@ package com.uranus.taskmanager.api.workspace.service;
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -107,18 +106,7 @@ class WorkspaceCreateServiceTest extends ServiceIntegrationTestHelper {
 		assertThatThrownBy(() -> workspaceCreateService.createWorkspace(request51, member.getId()))
 			.isInstanceOf(WorkspaceCreationLimitExceededException.class);
 	}
-
-	/*
-	 * Todo
-	 *  - 워크스페이스의 주인(생성자)의 로그인 Id를 통해서 주인 멤버 찾기
-	 *  - 해당 멤버의 workspaceCount 감소
-	 *  - 추후에 로직 개선 필요(DD를 적용하면 전체적으로 변할 듯)
-	 *  - 주인(Owner) Role 추가 -> 그냥 워크스페이스 삭제를 주인만 가능하도록 제한하면 더 쉬울 듯
-	 *  - -> 컨트롤러에서 LoginMember(id)를 읽어와서 사용하면 됨
-	 *  <br>
-	 *  - 해당 workspaceDelete의 로직을 변경하고 나서 테스트 실행
-	 */
-	@Disabled
+	
 	@Test
 	@DisplayName("워크스페이스 삭제 시 멤버의 워크스페이스 카운트가 감소한다")
 	void deleteWorkspace_decreasesWorkspaceCount() {
@@ -139,7 +127,7 @@ class WorkspaceCreateServiceTest extends ServiceIntegrationTestHelper {
 		WorkspaceCreateResponse response = workspaceCreateService.createWorkspace(request, member.getId());
 
 		// when
-		workspaceCommandService.deleteWorkspace(new WorkspaceDeleteRequest(), response.getCode());
+		workspaceCommandService.deleteWorkspace(new WorkspaceDeleteRequest(), response.getCode(), member.getId());
 
 		// then
 		Member updatedMember = memberRepository.findById(member.getId()).get();

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTestDeprecated.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTestDeprecated.java
@@ -204,8 +204,8 @@ class WorkspaceCreateServiceTestDeprecated {
 
 		// then
 		verify(workspaceMemberRepository, times(1)).save(argThat(workspaceMember ->
-			workspaceMember.getRole().equals(WorkspaceRole.ADMIN)
+			workspaceMember.getRole().equals(WorkspaceRole.MANAGER)
 		));
 	}
-	
+
 }

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTestDeprecated.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceCreateServiceTestDeprecated.java
@@ -1,0 +1,211 @@
+package com.uranus.taskmanager.api.workspace.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.uranus.taskmanager.api.authentication.dto.LoginMember;
+import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.member.repository.MemberRepository;
+import com.uranus.taskmanager.api.security.PasswordEncoder;
+import com.uranus.taskmanager.api.workspace.domain.Workspace;
+import com.uranus.taskmanager.api.workspace.dto.request.WorkspaceCreateRequest;
+import com.uranus.taskmanager.api.workspace.dto.response.WorkspaceCreateResponse;
+import com.uranus.taskmanager.api.workspace.exception.WorkspaceCodeCollisionHandleException;
+import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
+import com.uranus.taskmanager.api.workspace.util.WorkspaceCodeGenerator;
+import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspacemember.repository.WorkspaceMemberRepository;
+import com.uranus.taskmanager.fixture.dto.LoginMemberDtoFixture;
+import com.uranus.taskmanager.fixture.dto.WorkspaceCreateDtoFixture;
+import com.uranus.taskmanager.fixture.entity.MemberEntityFixture;
+import com.uranus.taskmanager.fixture.entity.WorkspaceEntityFixture;
+import com.uranus.taskmanager.fixture.entity.WorkspaceMemberEntityFixture;
+
+@ExtendWith(MockitoExtension.class)
+class WorkspaceCreateServiceTestDeprecated {
+
+	@InjectMocks
+	private CheckCodeDuplicationService workspaceCreateService;
+
+	@Mock
+	private WorkspaceCodeGenerator workspaceCodeGenerator;
+	@Mock
+	private WorkspaceRepository workspaceRepository;
+	@Mock
+	private MemberRepository memberRepository;
+	@Mock
+	private WorkspaceMemberRepository workspaceMemberRepository;
+	@Mock
+	private PasswordEncoder passwordEncoder;
+
+	WorkspaceEntityFixture workspaceEntityFixture;
+	MemberEntityFixture memberEntityFixture;
+	WorkspaceMemberEntityFixture workspaceMemberEntityFixture;
+	LoginMemberDtoFixture loginMemberDtoFixture;
+	WorkspaceCreateDtoFixture workspaceCreateDtoFixture;
+
+	@BeforeEach
+	public void setup() {
+		workspaceMemberEntityFixture = new WorkspaceMemberEntityFixture();
+		memberEntityFixture = new MemberEntityFixture();
+		loginMemberDtoFixture = new LoginMemberDtoFixture();
+		workspaceEntityFixture = new WorkspaceEntityFixture();
+		workspaceCreateDtoFixture = new WorkspaceCreateDtoFixture();
+	}
+
+	@Test
+	@DisplayName("워크스페이스 생성에는 생성 요청과 로그인 멤버를 필요로 한다")
+	void test1() {
+		// given
+		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
+		String code = "TESTCODE";
+
+		Workspace workspace = workspaceEntityFixture.createWorkspace("testcode");
+		Member member = memberEntityFixture.createMember("user123", "test@test.com");
+		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
+
+		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
+		when(workspaceCodeGenerator.generateWorkspaceCode()).thenReturn(code);
+		when(workspaceRepository.save(any(Workspace.class))).thenReturn(workspace);
+
+		// when
+		WorkspaceCreateResponse response = workspaceCreateService.createWorkspace(request, loginMember.getId());
+
+		// then
+		assertThat(response).isNotNull();
+		verify(memberRepository, times(1)).findById(1L);
+	}
+
+	@DisplayName("워크스페이스 생성을 성공하면 WorkspaceResponse를 반환한다")
+	void test2() {
+		// given
+		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
+		String code = "TESTCODE";
+
+		Workspace workspace = workspaceEntityFixture.createWorkspace("testcode");
+		Member member = memberEntityFixture.createMember("user123", "test@test.com");
+		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
+
+		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
+		when(workspaceCodeGenerator.generateWorkspaceCode()).thenReturn(code);
+		when(workspaceRepository.save(any(Workspace.class))).thenReturn(workspace);
+
+		// when
+		WorkspaceCreateResponse response = workspaceCreateService.createWorkspace(request, loginMember.getId());
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response).isInstanceOf(WorkspaceCreateResponse.class);
+		verify(workspaceRepository, times(1)).save(any(Workspace.class));
+	}
+
+	@Test
+	@DisplayName("워크스페이스 코드가 중복될 때 최대 재시도 횟수(5회)를 소진하면 예외가 발생한다")
+	void test3() {
+		// given
+		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
+
+		Member member = memberEntityFixture.createMember("user123", "test@test.com");
+		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
+		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
+
+		when(workspaceCodeGenerator.generateWorkspaceCode())
+			.thenReturn("WORK123", "WORK124", "WORK125", "WORK126", "WORK127");
+		when(workspaceRepository.existsByCode(anyString())).thenReturn(true);
+
+		// when & then
+		assertThatThrownBy(() -> workspaceCreateService.createWorkspace(request, loginMember.getId()))
+			.isInstanceOf(WorkspaceCodeCollisionHandleException.class)
+			.hasMessageContaining("Failed to solve workspace code collision");
+	}
+
+	@Test
+	@DisplayName("워크스페이스 생성 시 WorkspaceMember도 생성되고 저장된다")
+	void test4() {
+		// given
+		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
+		String code = "TESTCODE";
+
+		Workspace workspace = workspaceEntityFixture.createWorkspace("testcode");
+		Member member = memberEntityFixture.createMember("user123", "test@test.com");
+		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
+		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createAdminWorkspaceMember(member, workspace);
+		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
+		when(workspaceCodeGenerator.generateWorkspaceCode()).thenReturn(code);
+		when(workspaceRepository.save(any(Workspace.class))).thenReturn(workspace);
+		when(workspaceMemberRepository.save(any(WorkspaceMember.class))).thenReturn(workspaceMember);
+
+		// when
+		workspaceCreateService.createWorkspace(request, loginMember.getId());
+
+		// then
+		verify(workspaceMemberRepository, times(1)).save(any(WorkspaceMember.class));
+	}
+
+	@Test
+	@DisplayName("워크스페이스 생성 시 WorkspaceMember의 별칭은 생성자의 이메일로 설정된다")
+	void test5() {
+		// given
+		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
+		String code = "TESTCODE";
+
+		Workspace workspace = workspaceEntityFixture.createWorkspace("testcode");
+		Member member = memberEntityFixture.createMember("user123", "test@test.com");
+		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
+		WorkspaceMember adminWorkspaceMember = workspaceMemberEntityFixture.createAdminWorkspaceMember(member,
+			workspace);
+
+		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
+		when(workspaceCodeGenerator.generateWorkspaceCode()).thenReturn(code);
+		when(workspaceRepository.save(any(Workspace.class))).thenReturn(workspace);
+		when(workspaceMemberRepository.save(any(WorkspaceMember.class))).thenReturn(adminWorkspaceMember);
+
+		// when
+		workspaceCreateService.createWorkspace(request, loginMember.getId());
+
+		// then
+		verify(workspaceMemberRepository, times(1)).save(argThat(workspaceMember ->
+			workspaceMember.getNickname().equals("test@test.com")
+		));
+	}
+
+	@Test
+	@DisplayName("워크스페이스 생성 시 WorkspaceMember의 권한은 ADMIN으로 설정된다")
+	void test6() {
+		// given
+		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
+		String code = "TESTCODE";
+
+		Workspace workspace = workspaceEntityFixture.createWorkspace("testcode");
+		Member member = memberEntityFixture.createMember("user123", "test@test.com");
+		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
+		WorkspaceMember adminWorkspaceMember = workspaceMemberEntityFixture.createAdminWorkspaceMember(member,
+			workspace);
+
+		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
+		when(workspaceCodeGenerator.generateWorkspaceCode()).thenReturn(code);
+		when(workspaceRepository.save(any(Workspace.class))).thenReturn(workspace);
+		when(workspaceMemberRepository.save(any(WorkspaceMember.class))).thenReturn(adminWorkspaceMember);
+
+		// when
+		workspaceCreateService.createWorkspace(request, loginMember.getId());
+
+		// then
+		verify(workspaceMemberRepository, times(1)).save(argThat(workspaceMember ->
+			workspaceMember.getRole().equals(WorkspaceRole.ADMIN)
+		));
+	}
+	
+}

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceQueryServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/WorkspaceQueryServiceTest.java
@@ -194,7 +194,7 @@ class WorkspaceQueryServiceTest extends ServiceIntegrationTestHelper {
 		for (int i = 3; i <= 7; i++) {
 			Workspace workspace = workspaceRepositoryFixture.createWorkspace("workspace" + i, "description" + i,
 				"TEST" + i, null);
-			workspaceRepositoryFixture.addMemberToWorkspace(member2, workspace, WorkspaceRole.ADMIN);
+			workspaceRepositoryFixture.addMemberToWorkspace(member2, workspace, WorkspaceRole.MANAGER);
 		}
 
 		// 워크스페이스 name 기준 역정렬을 하기 위한 PageRequest

--- a/src/test/java/com/uranus/taskmanager/api/workspacemember/authorization/AuthorizationInterceptorTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspacemember/authorization/AuthorizationInterceptorTest.java
@@ -180,7 +180,7 @@ class AuthorizationInterceptorTest {
 		when(workspaceRepository.findByCode("TESTCODE")).thenReturn(Optional.of(workspace));
 		when(workspaceMemberRepository.findByMemberIdAndWorkspaceId(1L, null))
 			.thenReturn(Optional.of(workspaceMember));
-		when(roleRequired.roles()).thenReturn(new WorkspaceRole[] {WorkspaceRole.ADMIN});
+		when(roleRequired.roles()).thenReturn(new WorkspaceRole[] {WorkspaceRole.MANAGER});
 
 		// when & then
 		assertThatThrownBy(() -> authorizationInterceptor.preHandle(request, response, handlerMethod))
@@ -204,7 +204,7 @@ class AuthorizationInterceptorTest {
 		when(workspaceRepository.findByCode("TESTCODE")).thenReturn(Optional.of(workspace));
 		when(workspaceMemberRepository.findByMemberIdAndWorkspaceId(1L, null))
 			.thenReturn(Optional.of(workspaceMember));
-		when(roleRequired.roles()).thenReturn(new WorkspaceRole[] {WorkspaceRole.USER});
+		when(roleRequired.roles()).thenReturn(new WorkspaceRole[] {WorkspaceRole.COLLABORATOR});
 
 		// when
 		boolean result = authorizationInterceptor.preHandle(request, response, handlerMethod);

--- a/src/test/java/com/uranus/taskmanager/fixture/entity/WorkspaceMemberEntityFixture.java
+++ b/src/test/java/com/uranus/taskmanager/fixture/entity/WorkspaceMemberEntityFixture.java
@@ -7,12 +7,12 @@ import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 
 public class WorkspaceMemberEntityFixture {
 	public WorkspaceMember createAdminWorkspaceMember(Member member, Workspace workspace) {
-		return WorkspaceMember.addWorkspaceMember(member, workspace, WorkspaceRole.ADMIN,
+		return WorkspaceMember.addWorkspaceMember(member, workspace, WorkspaceRole.MANAGER,
 			member.getEmail());
 	}
 
 	public WorkspaceMember createUserWorkspaceMember(Member member, Workspace workspace) {
-		return WorkspaceMember.addWorkspaceMember(member, workspace, WorkspaceRole.USER,
+		return WorkspaceMember.addWorkspaceMember(member, workspace, WorkspaceRole.COLLABORATOR,
 			member.getEmail());
 	}
 }

--- a/src/test/java/com/uranus/taskmanager/helper/ServiceIntegrationTestHelper.java
+++ b/src/test/java/com/uranus/taskmanager/helper/ServiceIntegrationTestHelper.java
@@ -8,6 +8,7 @@ import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.member.service.MemberService;
 import com.uranus.taskmanager.api.security.PasswordEncoder;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
+import com.uranus.taskmanager.api.workspace.service.CheckCodeDuplicationService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceAccessService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceCommandService;
 import com.uranus.taskmanager.api.workspace.service.WorkspaceQueryService;
@@ -43,6 +44,8 @@ public abstract class ServiceIntegrationTestHelper {
 	protected WorkspaceCommandService workspaceCommandService;
 	@Autowired
 	protected MemberService memberService;
+	@Autowired
+	protected CheckCodeDuplicationService workspaceCreateService;
 
 	/**
 	 * Repository


### PR DESCRIPTION
## 🚀 설명
- #82 참고

---
## ✅ 변경 사항
- [x] `Member` 엔티티에 `workspaceCount` 추가
- [x] `Member` 엔티티에 `workspaceCount` 증가/감소 추가
- [x] `WorkspaceRoles` 수정(권한 세분화) 

---
## 🚩 관련 이슈, PR
- #82
- #83 
- #71 

---
## 📖 참고