### PR TITLE
Feat/#70 멤버 업데이트 권한 얻기, 멤버 이메일과 패스워드 업데이트 기능

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/authentication/SessionKey.java
+++ b/src/main/java/com/uranus/taskmanager/api/authentication/SessionKey.java
@@ -4,4 +4,7 @@ public abstract class SessionKey {
 	public static final String LOGIN_MEMBER_ID = "id";
 	public static final String LOGIN_MEMBER_LOGIN_ID = "loginId";
 	public static final String LOGIN_MEMBER_EMAIL = "email";
+
+	public static final String UPDATE_AUTH = "UPDATE_AUTH";
+	public static final String UPDATE_AUTH_EXPIRES_AT = "UPDATE_AUTH_EXPIRES_AT";
 }

--- a/src/main/java/com/uranus/taskmanager/api/common/ApiResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/ApiResponse.java
@@ -24,7 +24,7 @@ public class ApiResponse<T> {
 	}
 
 	public static <T> ApiResponse<T> okWithNoContent(String message) {
-		return new ApiResponse<>(HttpStatus.NO_CONTENT, message, null);
+		return new ApiResponse<>(HttpStatus.OK, message, null);
 	}
 
 	public static <T> ApiResponse<T> created(String message, T data) {

--- a/src/main/java/com/uranus/taskmanager/api/common/exception/CommonException.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/exception/CommonException.java
@@ -6,18 +6,16 @@ import lombok.Getter;
 
 @Getter
 public class CommonException extends RuntimeException {
-	private final String message;
 	private final HttpStatus httpStatus;
 
 	public CommonException(String message, HttpStatus httpStatus) {
-		this.message = message;
+		super(message);
 		this.httpStatus = httpStatus;
 	}
 
 	public CommonException(String message,
 		HttpStatus httpStatus, Throwable cause) {
-		super(cause);
-		this.message = message;
+		super(message, cause);
 		this.httpStatus = httpStatus;
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/member/controller/MemberController.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/controller/MemberController.java
@@ -1,17 +1,30 @@
 package com.uranus.taskmanager.api.member.controller;
 
+import java.time.LocalDateTime;
+
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.uranus.taskmanager.api.authentication.ResolveLoginMember;
+import com.uranus.taskmanager.api.authentication.SessionKey;
+import com.uranus.taskmanager.api.authentication.dto.LoginMember;
 import com.uranus.taskmanager.api.common.ApiResponse;
+import com.uranus.taskmanager.api.member.dto.request.MemberEmailUpdateRequest;
+import com.uranus.taskmanager.api.member.dto.request.MemberPasswordUpdateRequest;
 import com.uranus.taskmanager.api.member.dto.request.SignupRequest;
+import com.uranus.taskmanager.api.member.dto.request.UpdateAuthRequest;
+import com.uranus.taskmanager.api.member.dto.response.MemberEmailUpdateResponse;
 import com.uranus.taskmanager.api.member.dto.response.SignupResponse;
+import com.uranus.taskmanager.api.member.service.MemberQueryService;
 import com.uranus.taskmanager.api.member.service.MemberService;
+import com.uranus.taskmanager.api.workspacemember.authorization.exception.UpdateAuthorizationException;
 
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -26,18 +39,76 @@ public class MemberController {
 	 *  - 비밀번호 변경
 	 *  - 회원 탈퇴
 	 *    - 7일 동안 PENDING 상태에 있다가, 탈퇴 취소 요청 없을 시 탈퇴 처리
-	 *  - 참여하고 있는 워크스페이스 목록 조회
 	 *  - 비밀번호 찾기 (세션 불필요)
 	 * 	  - 가입한 이메일, 로그인 ID를 통한 비밀번호 찾기
 	 * 	  - 기입한 로그인 ID, 이메일이 일치하면 이메일로 임시 비밀번호 보내기
+	 * 	  - 또는 비밀번호 재설정 링크 보내기
 	 */
 	private final MemberService memberService;
+	private final MemberQueryService memberQueryService;
 
 	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping("/signup")
 	public ApiResponse<SignupResponse> signup(@Valid @RequestBody SignupRequest request) {
 
 		SignupResponse response = memberService.signup(request);
-		return ApiResponse.created("Signup Success", response);
+		return ApiResponse.created("Signup success", response);
 	}
+
+	@PostMapping("/update-auth")
+	public ApiResponse<Void> getUpdateAuthorization(
+		@RequestBody @Valid UpdateAuthRequest request,
+		@ResolveLoginMember LoginMember loginMember,
+		HttpSession session) {
+
+		memberQueryService.validatePasswordForUpdate(request, loginMember.getId());
+
+		// 5분간 유효한 업데이트 권한 부여
+		LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(5);
+		session.setAttribute(SessionKey.UPDATE_AUTH, true);
+		session.setAttribute(SessionKey.UPDATE_AUTH_EXPIRES_AT, expiresAt);
+
+		return ApiResponse.okWithNoContent("Update authorization granted");
+	}
+
+	@PatchMapping("/email")
+	public ApiResponse<MemberEmailUpdateResponse> updateEmail(
+		@RequestBody @Valid MemberEmailUpdateRequest request,
+		@ResolveLoginMember LoginMember loginMember,
+		HttpSession session) {
+
+		validateUpdateAuth(session);
+		MemberEmailUpdateResponse response = memberService.updateEmail(request, loginMember.getId());
+		session.setAttribute("LOGIN_MEMBER_EMAIL", request.getUpdateEmail());
+
+		return ApiResponse.ok("Email update success", response);
+	}
+
+	@PatchMapping("/password")
+	public ApiResponse<Void> updatePassword(
+		@RequestBody @Valid MemberPasswordUpdateRequest request,
+		@ResolveLoginMember LoginMember loginMember,
+		HttpSession session) {
+
+		validateUpdateAuth(session);
+		memberService.updatePassword(request, loginMember.getId());
+
+		return ApiResponse.okWithNoContent("Password update success");
+	}
+
+	private void validateUpdateAuth(HttpSession session) {
+		Boolean hasAuth = (Boolean)session.getAttribute("UPDATE_AUTH");
+		LocalDateTime expiresAt = (LocalDateTime)session.getAttribute("UPDATE_AUTH_EXPIRES_AT");
+
+		if (hasAuth == null || !hasAuth || expiresAt == null || LocalDateTime.now().isAfter(expiresAt)) {
+			clearUpdateAuth(session);
+			throw new UpdateAuthorizationException();
+		}
+	}
+
+	private void clearUpdateAuth(HttpSession session) {
+		session.removeAttribute("UPDATE_AUTH");
+		session.removeAttribute("UPDATE_AUTH_EXPIRES_AT");
+	}
+
 }

--- a/src/main/java/com/uranus/taskmanager/api/member/domain/Member.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/domain/Member.java
@@ -53,6 +53,13 @@ public class Member extends BaseDateEntity {
 	@OneToMany(mappedBy = "member")
 	private List<Invitation> invitations = new ArrayList<>();
 
+	@Builder
+	public Member(String loginId, String email, String password) {
+		this.loginId = loginId;
+		this.email = email;
+		this.password = password;
+	}
+
 	public void increaseWorkspaceCount() {
 		if (this.workspaceCount >= 50) {
 			throw new WorkspaceCreationLimitExceededException();
@@ -66,10 +73,11 @@ public class Member extends BaseDateEntity {
 		}
 	}
 
-	@Builder
-	public Member(String loginId, String email, String password) {
-		this.loginId = loginId;
-		this.email = email;
+	public void updatePassword(String password) {
 		this.password = password;
+	}
+
+	public void updateEmail(String email) {
+		this.email = email;
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/member/dto/MemberDetail.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/dto/MemberDetail.java
@@ -1,0 +1,40 @@
+package com.uranus.taskmanager.api.member.dto;
+
+import java.time.LocalDateTime;
+
+import com.uranus.taskmanager.api.member.domain.Member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberDetail {
+	private Long id;
+	private String loginId;
+	private String email;
+	private LocalDateTime joinedAt;
+	private LocalDateTime updatedAt;
+	private int createdWorkspaceCount;
+
+	@Builder
+	public MemberDetail(Long id, String loginId, String email, LocalDateTime joinedAt, LocalDateTime updatedAt,
+		int createdWorkspaceCount) {
+		this.id = id;
+		this.loginId = loginId;
+		this.email = email;
+		this.joinedAt = joinedAt;
+		this.updatedAt = updatedAt;
+		this.createdWorkspaceCount = createdWorkspaceCount;
+	}
+
+	public static MemberDetail from(Member member) {
+		return MemberDetail.builder()
+			.id(member.getId())
+			.loginId(member.getLoginId())
+			.email(member.getEmail())
+			.joinedAt(member.getCreatedDate())
+			.updatedAt(member.getLastModifiedDate())
+			.createdWorkspaceCount(member.getWorkspaceCount())
+			.build();
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/member/dto/request/MemberEmailUpdateRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/dto/request/MemberEmailUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.uranus.taskmanager.api.member.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberEmailUpdateRequest {
+
+	@NotBlank(message = "Email must not be blank")
+	@Size(min = 5, max = 254, message = "Email must be between 5 and 254 characters")
+	@Email(message = "Email should be in a valid format")
+	private String updateEmail;
+}

--- a/src/main/java/com/uranus/taskmanager/api/member/dto/request/MemberEmailUpdateRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/dto/request/MemberEmailUpdateRequest.java
@@ -3,15 +3,20 @@ package com.uranus.taskmanager.api.member.dto.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberEmailUpdateRequest {
 
 	@NotBlank(message = "Email must not be blank")
 	@Size(min = 5, max = 254, message = "Email must be between 5 and 254 characters")
 	@Email(message = "Email should be in a valid format")
 	private String updateEmail;
+
+	public MemberEmailUpdateRequest(String updateEmail) {
+		this.updateEmail = updateEmail;
+	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/member/dto/request/MemberPasswordUpdateRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/dto/request/MemberPasswordUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.uranus.taskmanager.api.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberPasswordUpdateRequest {
+
+	@NotBlank(message = "Password must not be blank")
+	@Pattern(regexp = "^(?!.*[가-힣])(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,30}",
+		message = "The password must be alphanumeric"
+			+ " including at least one special character and must be between 8 and 30 characters")
+	private String updatePassword;
+}

--- a/src/main/java/com/uranus/taskmanager/api/member/dto/request/MemberPasswordUpdateRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/dto/request/MemberPasswordUpdateRequest.java
@@ -2,11 +2,12 @@ package com.uranus.taskmanager.api.member.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberPasswordUpdateRequest {
 
 	@NotBlank(message = "Password must not be blank")
@@ -14,4 +15,8 @@ public class MemberPasswordUpdateRequest {
 		message = "The password must be alphanumeric"
 			+ " including at least one special character and must be between 8 and 30 characters")
 	private String updatePassword;
+
+	public MemberPasswordUpdateRequest(String updatePassword) {
+		this.updatePassword = updatePassword;
+	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/member/dto/request/SignupRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/dto/request/SignupRequest.java
@@ -8,7 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
 public class SignupRequest {
 	/**
 	 * Todo
@@ -19,16 +18,23 @@ public class SignupRequest {
 	@Pattern(regexp = "^[a-zA-Z0-9]{2,20}$",
 		message = "Login ID must be alphanumeric"
 			+ " and must be between 2 and 20 characters")
-	private final String loginId;
+	private String loginId;
 
 	@NotBlank(message = "Email must not be blank")
 	@Size(min = 5, max = 254, message = "Email must be between 5 and 254 characters")
 	@Email(message = "Email should be in a valid format")
-	private final String email;
+	private String email;
 
 	@NotBlank(message = "Password must not be blank")
 	@Pattern(regexp = "^(?!.*[가-힣])(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,30}",
 		message = "The password must be alphanumeric"
 			+ " including at least one special character and must be between 8 and 30 characters")
-	private final String password;
+	private String password;
+
+	@Builder
+	public SignupRequest(String loginId, String email, String password) {
+		this.loginId = loginId;
+		this.email = email;
+		this.password = password;
+	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/member/dto/request/UpdateAuthRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/dto/request/UpdateAuthRequest.java
@@ -1,10 +1,15 @@
 package com.uranus.taskmanager.api.member.dto.request;
 
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UpdateAuthRequest {
 	private String password;
+
+	public UpdateAuthRequest(String password) {
+		this.password = password;
+	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/member/dto/request/UpdateAuthRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/dto/request/UpdateAuthRequest.java
@@ -1,0 +1,10 @@
+package com.uranus.taskmanager.api.member.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateAuthRequest {
+	private String password;
+}

--- a/src/main/java/com/uranus/taskmanager/api/member/dto/response/MemberEmailUpdateResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/dto/response/MemberEmailUpdateResponse.java
@@ -1,0 +1,17 @@
+package com.uranus.taskmanager.api.member.dto.response;
+
+import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.member.dto.MemberDetail;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberEmailUpdateResponse {
+	private MemberDetail memberDetail;
+
+	public static MemberEmailUpdateResponse from(Member member) {
+		return new MemberEmailUpdateResponse(MemberDetail.from(member));
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/member/exception/InvalidMemberPasswordException.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/exception/InvalidMemberPasswordException.java
@@ -1,0 +1,19 @@
+package com.uranus.taskmanager.api.member.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.common.exception.MemberException;
+
+public class InvalidMemberPasswordException extends MemberException {
+
+	private static final String MESSAGE = "The given password is invalid";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
+
+	public InvalidMemberPasswordException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public InvalidMemberPasswordException(Throwable cause) {
+		super(MESSAGE, HTTP_STATUS, cause);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/member/service/MemberQueryService.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/service/MemberQueryService.java
@@ -1,0 +1,31 @@
+package com.uranus.taskmanager.api.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.member.dto.request.UpdateAuthRequest;
+import com.uranus.taskmanager.api.member.exception.InvalidMemberPasswordException;
+import com.uranus.taskmanager.api.member.exception.MemberNotFoundException;
+import com.uranus.taskmanager.api.member.repository.MemberRepository;
+import com.uranus.taskmanager.api.security.PasswordEncoder;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class MemberQueryService {
+
+	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	@Transactional(readOnly = true)
+	public void validatePasswordForUpdate(UpdateAuthRequest request, Long id) {
+		Member member = memberRepository.findById(id)
+			.orElseThrow(MemberNotFoundException::new);
+
+		if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
+			throw new InvalidMemberPasswordException();
+		}
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/member/service/MemberService.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/service/MemberService.java
@@ -4,10 +4,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.member.dto.request.MemberEmailUpdateRequest;
+import com.uranus.taskmanager.api.member.dto.request.MemberPasswordUpdateRequest;
 import com.uranus.taskmanager.api.member.dto.request.SignupRequest;
+import com.uranus.taskmanager.api.member.dto.response.MemberEmailUpdateResponse;
 import com.uranus.taskmanager.api.member.dto.response.SignupResponse;
 import com.uranus.taskmanager.api.member.exception.DuplicateEmailException;
 import com.uranus.taskmanager.api.member.exception.DuplicateLoginIdException;
+import com.uranus.taskmanager.api.member.exception.MemberNotFoundException;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
 import com.uranus.taskmanager.api.security.PasswordEncoder;
 
@@ -22,11 +26,34 @@ public class MemberService {
 
 	@Transactional
 	public SignupResponse signup(SignupRequest request) {
-
 		checkLoginIdAndEmailDuplication(request);
 		Member member = createMember(request);
 
 		return SignupResponse.from(memberRepository.save(member));
+	}
+
+	@Transactional
+	public MemberEmailUpdateResponse updateEmail(MemberEmailUpdateRequest request, Long id) {
+		Member member = memberRepository.findById(id)
+			.orElseThrow(MemberNotFoundException::new);
+
+		String toBeEmail = request.getUpdateEmail();
+
+		checkEmailDuplicate(toBeEmail);
+
+		member.updateEmail(toBeEmail);
+
+		return MemberEmailUpdateResponse.from(member);
+	}
+
+	@Transactional
+	public void updatePassword(MemberPasswordUpdateRequest request, Long id) {
+		Member member = memberRepository.findById(id)
+			.orElseThrow(MemberNotFoundException::new);
+
+		String toBePassword = encodePassword(request.getUpdatePassword());
+
+		member.updatePassword(toBePassword);
 	}
 
 	private Member createMember(SignupRequest request) {

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/CheckCodeDuplicationService.java
@@ -61,7 +61,7 @@ public class CheckCodeDuplicationService implements WorkspaceCreateService {
 		setEncodedPasswordIfPresent(request);
 
 		Workspace workspace = saveWorkspace(request);
-		addAdminMemberToWorkspace(member, workspace);
+		addOwnerMemberToWorkspace(member, workspace);
 
 		return WorkspaceCreateResponse.from(workspace);
 	}
@@ -108,9 +108,9 @@ public class CheckCodeDuplicationService implements WorkspaceCreateService {
 		return workspaceRepository.save(workspaceCreateRequest.to());
 	}
 
-	private void addAdminMemberToWorkspace(Member member, Workspace workspace) {
+	private void addOwnerMemberToWorkspace(Member member, Workspace workspace) {
 		WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace,
-			WorkspaceRole.MANAGER,
+			WorkspaceRole.OWNER,
 			member.getEmail());
 
 		workspaceMemberRepository.save(workspaceMember);

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/HandleDatabaseExceptionService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/HandleDatabaseExceptionService.java
@@ -52,7 +52,7 @@ public class HandleDatabaseExceptionService implements WorkspaceCreateService {
 				setEncodedPasswordIfPresent(request);
 
 				Workspace workspace = workspaceRepository.saveWithNewTransaction(request.to());
-				addAdminMemberToWorkspace(member, workspace);
+				addOwnerMemberToWorkspace(member, workspace);
 
 				return WorkspaceCreateResponse.from(workspace);
 			} catch (DataIntegrityViolationException | ConstraintViolationException e) {
@@ -64,8 +64,8 @@ public class HandleDatabaseExceptionService implements WorkspaceCreateService {
 		throw new WorkspaceCodeCollisionHandleException();
 	}
 
-	private void addAdminMemberToWorkspace(Member member, Workspace workspace) {
-		WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace, WorkspaceRole.MANAGER,
+	private void addOwnerMemberToWorkspace(Member member, Workspace workspace) {
+		WorkspaceMember workspaceMember = WorkspaceMember.addWorkspaceMember(member, workspace, WorkspaceRole.OWNER,
 			member.getEmail());
 
 		workspaceMemberRepository.save(workspaceMember);

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/exception/UpdateAuthorizationException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/authorization/exception/UpdateAuthorizationException.java
@@ -1,0 +1,16 @@
+package com.uranus.taskmanager.api.workspacemember.authorization.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UpdateAuthorizationException extends AuthorizationException {
+	private static final String MESSAGE = "You do not have authorization for update or has expired";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.FORBIDDEN;
+
+	public UpdateAuthorizationException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public UpdateAuthorizationException(Throwable cause) {
+		super(MESSAGE, HTTP_STATUS, cause);
+	}
+}

--- a/src/test/java/com/uranus/taskmanager/api/invitation/service/InvitationServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/invitation/service/InvitationServiceTest.java
@@ -72,7 +72,8 @@ class InvitationServiceTest {
 
 		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
 		Member member = memberEntityFixture.createMember(loginId, email);
-		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createUserWorkspaceMember(member, workspace);
+		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createCollaboratorWorkspaceMember(member,
+			workspace);
 		Invitation invitation = invitationEntityFixture.createPendingInvitation(workspace, member);
 
 		when(invitationRepository.findByWorkspaceCodeAndMemberId(workspaceCode, memberId)).thenReturn(
@@ -98,7 +99,8 @@ class InvitationServiceTest {
 
 		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
 		Member member = memberEntityFixture.createMember(loginId, email);
-		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createUserWorkspaceMember(member, workspace);
+		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createCollaboratorWorkspaceMember(member,
+			workspace);
 		Invitation invitation = invitationEntityFixture.createPendingInvitation(workspace, member);
 
 		when(invitationRepository.findByWorkspaceCodeAndMemberId(workspaceCode, memberId))
@@ -126,7 +128,8 @@ class InvitationServiceTest {
 
 		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
 		Member member = memberEntityFixture.createMember(loginId, email);
-		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createUserWorkspaceMember(member, workspace);
+		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createCollaboratorWorkspaceMember(member,
+			workspace);
 		Invitation invitation = invitationEntityFixture.createPendingInvitation(workspace, member);
 
 		when(invitationRepository.findByWorkspaceCodeAndMemberId(workspaceCode, memberId)).thenReturn(

--- a/src/test/java/com/uranus/taskmanager/api/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/member/controller/MemberControllerTest.java
@@ -1,13 +1,16 @@
 package com.uranus.taskmanager.api.member.controller;
 
-import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.params.provider.Arguments.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -15,8 +18,15 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 
+import com.uranus.taskmanager.api.authentication.SessionKey;
+import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.member.dto.request.MemberEmailUpdateRequest;
 import com.uranus.taskmanager.api.member.dto.request.SignupRequest;
+import com.uranus.taskmanager.api.member.dto.request.UpdateAuthRequest;
+import com.uranus.taskmanager.api.member.dto.response.MemberEmailUpdateResponse;
+import com.uranus.taskmanager.api.member.exception.InvalidMemberPasswordException;
 import com.uranus.taskmanager.helper.ControllerTestHelper;
 
 class MemberControllerTest extends ControllerTestHelper {
@@ -109,17 +119,114 @@ class MemberControllerTest extends ControllerTestHelper {
 			.email(email)
 			.password(password)
 			.build();
-		String requestBody = objectMapper.writeValueAsString(signupRequest);
 
 		// when & then
 		mockMvc.perform(post("/api/v1/members/signup")
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(requestBody))
+				.content(objectMapper.writeValueAsString(signupRequest)))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.data[*].field").value(hasItem("loginId")))
-			.andExpect(jsonPath("$.data[*].field").value(hasItem("email")))
-			.andExpect(jsonPath("$.data[*].field").value(hasItem("password")))
+			.andExpect(jsonPath("$.data[*].field").value(Matchers.hasItem("loginId")))
+			.andExpect(jsonPath("$.data[*].field").value(Matchers.hasItem("email")))
+			.andExpect(jsonPath("$.data[*].field").value(Matchers.hasItem("password")))
 			.andDo(print());
 	}
 
+	@Test
+	@DisplayName("POST /members/update-auth - 업데이트 권한 요청에 성공하면 OK를 응답한다")
+	void getUpdateAuthorization_success_OK() throws Exception {
+		// given
+		UpdateAuthRequest request = new UpdateAuthRequest("password1234!");
+
+		doNothing()
+			.when(memberQueryService)
+			.validatePasswordForUpdate(any(UpdateAuthRequest.class), anyLong());
+
+		// when & then
+		mockMvc.perform(post("/api/v1/members/update-auth")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("Update authorization granted"))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("POST /members/update-auth - 패스워드 검증에 실패하면 업데이트 권한 요청에 대해 UNAUTHORIZED를 응답한다")
+	void getUpdateAuthorization_returnsUnauthorized_whenInvalidMemberPasswordException() throws Exception {
+		// given
+		UpdateAuthRequest request = new UpdateAuthRequest("password1234!");
+
+		doThrow(new InvalidMemberPasswordException())
+			.when(memberQueryService)
+			.validatePasswordForUpdate(any(UpdateAuthRequest.class), anyLong());
+
+		// when & then
+		mockMvc.perform(post("/api/v1/members/update-auth")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.message").value("The given password is invalid"))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("PATCH /members/email - 이메일 업데이트를 성공하면 OK를 응답한다")
+	void updateEmail_success_OK() throws Exception {
+		// given
+		MemberEmailUpdateRequest request = new MemberEmailUpdateRequest("newemail@test.com");
+
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute(SessionKey.UPDATE_AUTH, true);
+		session.setAttribute(SessionKey.UPDATE_AUTH_EXPIRES_AT, LocalDateTime.now().plusMinutes(5));
+
+		// when & then
+		mockMvc.perform(patch("/api/v1/members/email")
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("Email update success"))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("PATCH /members/email - 이메일 업데이트를 성공하면 이메일 업데이트 응답을 데이터로 받는다")
+	void updateEmail_success_returnsMemberEmailUpdateResponse() throws Exception {
+		// given
+		MemberEmailUpdateRequest request = new MemberEmailUpdateRequest("newemail@test.com");
+
+		MockHttpSession session = new MockHttpSession();
+		session.setAttribute(SessionKey.UPDATE_AUTH, true);
+		session.setAttribute(SessionKey.UPDATE_AUTH_EXPIRES_AT, LocalDateTime.now().plusMinutes(5));
+
+		MemberEmailUpdateResponse response = MemberEmailUpdateResponse.from(
+			Member.builder().email("newemail@test.com").build());
+
+		when(memberService.updateEmail(any(MemberEmailUpdateRequest.class), anyLong())).thenReturn(response);
+
+		// when & then
+		mockMvc.perform(patch("/api/v1/members/email")
+				.session(session)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("Email update success"))
+			.andExpect(jsonPath("$.data.memberDetail.email").value("newemail@test.com"))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("PATCH /members/email - 이메일 업데이트 요청 시 업데이트 권한이 없으면 FORBIDDEN을 응답한다")
+	void updateEmail_forbidden_ifUpdateAuthIsInvalid() throws Exception {
+		// given
+		MemberEmailUpdateRequest request = new MemberEmailUpdateRequest("newemail@test.com");
+
+		// when & then
+		mockMvc.perform(patch("/api/v1/members/email")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.message").value("You do not have authorization for update or has expired"))
+			.andDo(print());
+	}
 }

--- a/src/test/java/com/uranus/taskmanager/api/member/service/MemberQueryServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/member/service/MemberQueryServiceTest.java
@@ -1,0 +1,71 @@
+package com.uranus.taskmanager.api.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.member.dto.request.UpdateAuthRequest;
+import com.uranus.taskmanager.api.member.exception.InvalidMemberPasswordException;
+import com.uranus.taskmanager.api.member.exception.MemberNotFoundException;
+import com.uranus.taskmanager.helper.ServiceIntegrationTestHelper;
+
+class MemberQueryServiceTest extends ServiceIntegrationTestHelper {
+
+	@AfterEach
+	public void tearDown() {
+		databaseCleaner.execute();
+	}
+
+	@Test
+	@DisplayName("업데이트 인가의 비밀번호 검증에 성공하면 예외가 발생하지 않는다")
+	void validatePasswordForUpdate_ifSuccess_NoException() {
+		// given
+		Member member = memberRepository.save(Member.builder()
+			.loginId("member1")
+			.email("member1@test.com")
+			.password(passwordEncoder.encode("password1234!"))
+			.build());
+
+		UpdateAuthRequest request = new UpdateAuthRequest("password1234!");
+
+		// when & then
+		assertThatNoException()
+			.isThrownBy(() -> memberQueryService.validatePasswordForUpdate(request, member.getId()));
+
+	}
+
+	@Test
+	@DisplayName("업데이트 인가의 비밀번호 검증에 실패하면 예외가 발생한다")
+	void validatePasswordForUpdate_ifFail_InvalidMemberPasswordException() {
+		// given
+		Member member = memberRepository.save(Member.builder()
+			.loginId("member1")
+			.email("member1@test.com")
+			.password(passwordEncoder.encode("password1234!"))
+			.build());
+
+		UpdateAuthRequest request = new UpdateAuthRequest("invalidPassword");
+
+		// when & then
+		assertThatThrownBy(() -> memberQueryService.validatePasswordForUpdate(request, member.getId()))
+			.isInstanceOf(InvalidMemberPasswordException.class);
+
+	}
+
+	@Test
+	@DisplayName("업데이트 인가에서 존재하지 않는 회원으로 시도하면 예외가 발생한다")
+	void validatePasswordForUpdate_ifFail_MemberNotFoundException() {
+		// given
+		UpdateAuthRequest request = new UpdateAuthRequest("invalidPassword");
+
+		// when & then
+		Long invalidMemberId = 999L;
+
+		assertThatThrownBy(() -> memberQueryService.validatePasswordForUpdate(request, invalidMemberId))
+			.isInstanceOf(MemberNotFoundException.class);
+
+	}
+}

--- a/src/test/java/com/uranus/taskmanager/api/member/service/MemberServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/member/service/MemberServiceTest.java
@@ -4,25 +4,29 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.member.dto.request.MemberEmailUpdateRequest;
+import com.uranus.taskmanager.api.member.dto.request.MemberPasswordUpdateRequest;
 import com.uranus.taskmanager.api.member.dto.request.SignupRequest;
+import com.uranus.taskmanager.api.member.dto.response.MemberEmailUpdateResponse;
 import com.uranus.taskmanager.api.member.dto.response.SignupResponse;
+import com.uranus.taskmanager.api.member.exception.DuplicateEmailException;
 import com.uranus.taskmanager.helper.ServiceIntegrationTestHelper;
 
 class MemberServiceTest extends ServiceIntegrationTestHelper {
 
-	@BeforeEach
-	public void init() {
+	@AfterEach
+	public void tearDown() {
 		databaseCleaner.execute();
 	}
 
 	@Test
-	@DisplayName("회원 가입 시 멤버가 저장된다")
-	void test1() {
+	@DisplayName("회원 가입에 성공하면 멤버가 저장된다")
+	void signup_sucess_memberIsSaved() {
 		// given
 		SignupRequest signupRequest = SignupRequest.builder()
 			.loginId("testuser")
@@ -39,8 +43,8 @@ class MemberServiceTest extends ServiceIntegrationTestHelper {
 	}
 
 	@Test
-	@DisplayName("회원 가입시 패스워드가 암호화 된다")
-	void test2() {
+	@DisplayName("회원 가입에 성공하여 저장된 멤버의 패스워드는 암호화 되어 있다")
+	void signup_sucess_memberPasswordIsEncrypted() {
 		// given
 		SignupRequest signupRequest = SignupRequest.builder()
 			.loginId("testuser")
@@ -49,18 +53,17 @@ class MemberServiceTest extends ServiceIntegrationTestHelper {
 			.build();
 
 		// when
-		SignupResponse signupResponse = memberService.signup(signupRequest);
-		Optional<Member> member = memberRepository.findByLoginId("testuser");
-		assertThat(member).isPresent();
-		String encodedPassword = member.get().getPassword();
+		memberService.signup(signupRequest);
 
 		// then
+		Optional<Member> member = memberRepository.findByLoginId("testuser");
+		String encodedPassword = member.get().getPassword();
 		assertThat(passwordEncoder.matches("testpassword1234!", encodedPassword)).isTrue();
 	}
 
 	@Test
-	@DisplayName("회원 가입시 입력한 패스워드와 암호화한 패스워드는 서로 달라야한다")
-	void test3() {
+	@DisplayName("회원 가입 시 입력한 패스워드와 암호화한 패스워드는 서로 다르다")
+	void signup_sucess_requestPaswordMustBeDifferentWithEncryptedPassword() {
 		// given
 		SignupRequest signupRequest = SignupRequest.builder()
 			.loginId("testuser")
@@ -69,13 +72,91 @@ class MemberServiceTest extends ServiceIntegrationTestHelper {
 			.build();
 
 		// when
-		SignupResponse signupResponse = memberService.signup(signupRequest);
-		Optional<Member> member = memberRepository.findByLoginId("testuser");
-		assertThat(member).isPresent();
-		String encodedPassword = member.get().getPassword();
+		memberService.signup(signupRequest);
 
 		// then
+		Optional<Member> member = memberRepository.findByLoginId("testuser");
+		String encodedPassword = member.get().getPassword();
 		assertThat(encodedPassword).isNotEqualTo("testpassword1234!");
 	}
 
+	@Test
+	@DisplayName("이메일 업데이트를 성공하면 이메일 업데이트 응답을 반환한다")
+	void updateEmail_success_returnsMemberEmailUpdateResponse() {
+		// given
+		Member member = memberRepository.save(Member.builder()
+			.loginId("member1")
+			.email("member1@test.com")
+			.password(passwordEncoder.encode("password1234!"))
+			.build());
+
+		String newEmail = "newemail@test.com";
+		MemberEmailUpdateRequest request = new MemberEmailUpdateRequest(newEmail);
+
+		// when
+		MemberEmailUpdateResponse response = memberService.updateEmail(request, member.getId());
+
+		// then
+		assertThat(response.getMemberDetail().getEmail()).isEqualTo(newEmail);
+
+		Member updatedMember = memberRepository.findById(member.getId()).get();
+		assertThat(updatedMember.getEmail()).isEqualTo(newEmail);
+	}
+
+	@Test
+	@DisplayName("이메일 업데이트 시 이메일이 중복되면 예외가 발생한다")
+	void updateEmail_throwsException_whenEmailDuplicated() {
+		// given
+		Member existingMember = memberRepository.save(
+			Member.builder()
+				.loginId("member1")
+				.email("member1@test.com")
+				.password(passwordEncoder.encode("password1"))
+				.build()
+		);
+
+		MemberEmailUpdateRequest request = new MemberEmailUpdateRequest(existingMember.getEmail());
+
+		// when & then
+		assertThatThrownBy(() -> memberService.updateEmail(request, existingMember.getId()))
+			.isInstanceOf(DuplicateEmailException.class);
+	}
+
+	@Test
+	@DisplayName("패스워드 업데이트를 성공하면 아무것도 반환하지 않는다")
+	void updatePassword_success_returnsNothing() {
+		// given
+		Member member = memberRepository.save(Member.builder()
+			.loginId("member1")
+			.email("member1@test.com")
+			.password(passwordEncoder.encode("password1234!"))
+			.build());
+
+		String newPassword = "newpassword1234!";
+		MemberPasswordUpdateRequest request = new MemberPasswordUpdateRequest(newPassword);
+
+		// when & then
+		assertThatNoException().isThrownBy(() -> memberService.updatePassword(request, member.getId()));
+	}
+
+	@Test
+	@DisplayName("패스워드 업데이트를 성공하면 업데이트 된 멤버는 암호화된 새로운 패스워드를 가진다")
+	void updatePassword_success_updatedMemberHasNewEncrytedPassword() {
+		// given
+		Member member = memberRepository.save(Member.builder()
+			.loginId("member1")
+			.email("member1@test.com")
+			.password(passwordEncoder.encode("password1234!"))
+			.build());
+
+		String newPassword = "newpassword1234!";
+		MemberPasswordUpdateRequest request = new MemberPasswordUpdateRequest(newPassword);
+
+		// when
+		memberService.updatePassword(request, member.getId());
+
+		// then
+		Member updatedMember = memberRepository.findById(member.getId()).get();
+		assertThat(passwordEncoder.matches(newPassword, updatedMember.getPassword())).isTrue();
+	}
 }

--- a/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceAccessControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/controller/WorkspaceAccessControllerTest.java
@@ -191,7 +191,8 @@ class WorkspaceAccessControllerTest extends ControllerTestHelper {
 
 		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
 		Member member = memberEntityFixture.createMember(loginId, email);
-		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createUserWorkspaceMember(member, workspace);
+		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createCollaboratorWorkspaceMember(member,
+			workspace);
 		WorkspaceJoinRequest request = new WorkspaceJoinRequest();
 
 		WorkspaceJoinResponse response = WorkspaceJoinResponse.from(workspace, workspaceMember, false);
@@ -250,7 +251,8 @@ class WorkspaceAccessControllerTest extends ControllerTestHelper {
 
 		Member member = memberEntityFixture.createMember("member1", "member1@test.com");
 		Workspace workspace = workspaceEntityFixture.createWorkspace(workspaceCode);
-		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createUserWorkspaceMember(member, workspace);
+		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createCollaboratorWorkspaceMember(member,
+			workspace);
 
 		KickWorkspaceMemberRequest request = new KickWorkspaceMemberRequest("member1");
 

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/DeprecatedWorkspaceCreateServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/DeprecatedWorkspaceCreateServiceTest.java
@@ -34,7 +34,7 @@ import com.uranus.taskmanager.fixture.entity.WorkspaceEntityFixture;
 import com.uranus.taskmanager.fixture.entity.WorkspaceMemberEntityFixture;
 
 @ExtendWith(MockitoExtension.class)
-class WorkspaceCreateServiceTestDeprecated {
+class DeprecatedWorkspaceCreateServiceTest {
 
 	@InjectMocks
 	private CheckCodeDuplicationService workspaceCreateService;
@@ -66,7 +66,7 @@ class WorkspaceCreateServiceTestDeprecated {
 	}
 
 	@Test
-	@DisplayName("워크스페이스 생성에는 생성 요청과 로그인 멤버를 필요로 한다")
+	@DisplayName("워크스페이스 생성에는 워크스페이스가 저장된다")
 	void test1() {
 		// given
 		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
@@ -85,10 +85,10 @@ class WorkspaceCreateServiceTestDeprecated {
 
 		// then
 		assertThat(response).isNotNull();
-		verify(memberRepository, times(1)).findById(1L);
+		verify(workspaceRepository, times(1)).save(any(Workspace.class));
 	}
 
-	@DisplayName("워크스페이스 생성을 성공하면 WorkspaceResponse를 반환한다")
+	@DisplayName("워크스페이스 생성을 성공하면 워크스페이스 생성 응답을 반환한다")
 	void test2() {
 		// given
 		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
@@ -141,7 +141,7 @@ class WorkspaceCreateServiceTestDeprecated {
 		Workspace workspace = workspaceEntityFixture.createWorkspace("testcode");
 		Member member = memberEntityFixture.createMember("user123", "test@test.com");
 		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
-		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createAdminWorkspaceMember(member, workspace);
+		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createManagerWorkspaceMember(member, workspace);
 		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
 		when(workspaceCodeGenerator.generateWorkspaceCode()).thenReturn(code);
 		when(workspaceRepository.save(any(Workspace.class))).thenReturn(workspace);
@@ -164,7 +164,7 @@ class WorkspaceCreateServiceTestDeprecated {
 		Workspace workspace = workspaceEntityFixture.createWorkspace("testcode");
 		Member member = memberEntityFixture.createMember("user123", "test@test.com");
 		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
-		WorkspaceMember adminWorkspaceMember = workspaceMemberEntityFixture.createAdminWorkspaceMember(member,
+		WorkspaceMember adminWorkspaceMember = workspaceMemberEntityFixture.createManagerWorkspaceMember(member,
 			workspace);
 
 		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
@@ -182,7 +182,7 @@ class WorkspaceCreateServiceTestDeprecated {
 	}
 
 	@Test
-	@DisplayName("워크스페이스 생성 시 WorkspaceMember의 권한은 ADMIN으로 설정된다")
+	@DisplayName("워크스페이스 생성 시 WorkspaceMember의 권한은 OWNER로 설정된다")
 	void test6() {
 		// given
 		WorkspaceCreateRequest request = workspaceCreateDtoFixture.createWorkspaceCreateRequest(null);
@@ -191,7 +191,7 @@ class WorkspaceCreateServiceTestDeprecated {
 		Workspace workspace = workspaceEntityFixture.createWorkspace("testcode");
 		Member member = memberEntityFixture.createMember("user123", "test@test.com");
 		LoginMember loginMember = loginMemberDtoFixture.createLoginMemberDto(1L, "user123", "test@test.com");
-		WorkspaceMember adminWorkspaceMember = workspaceMemberEntityFixture.createAdminWorkspaceMember(member,
+		WorkspaceMember adminWorkspaceMember = workspaceMemberEntityFixture.createOwnerWorkspaceMember(member,
 			workspace);
 
 		when(memberRepository.findById(loginMember.getId())).thenReturn(Optional.of(member));
@@ -204,7 +204,7 @@ class WorkspaceCreateServiceTestDeprecated {
 
 		// then
 		verify(workspaceMemberRepository, times(1)).save(argThat(workspaceMember ->
-			workspaceMember.getRole().equals(WorkspaceRole.MANAGER)
+			workspaceMember.getRole().equals(WorkspaceRole.OWNER)
 		));
 	}
 

--- a/src/test/java/com/uranus/taskmanager/api/workspacemember/authorization/AuthorizationInterceptorTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspacemember/authorization/AuthorizationInterceptorTest.java
@@ -169,7 +169,8 @@ class AuthorizationInterceptorTest {
 		// given
 		Workspace workspace = workspaceEntityFixture.createWorkspace("TESTCODE");
 		Member member = memberEntityFixture.createMember("user123", "user123@test.com");
-		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createUserWorkspaceMember(member, workspace);
+		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createCollaboratorWorkspaceMember(member,
+			workspace);
 
 		RoleRequired roleRequired = mock(RoleRequired.class);
 
@@ -193,7 +194,8 @@ class AuthorizationInterceptorTest {
 		// given
 		Workspace workspace = workspaceEntityFixture.createWorkspace("TESTCODE");
 		Member member = memberEntityFixture.createMember("user123", "user123@test.com");
-		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createUserWorkspaceMember(member, workspace);
+		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createCollaboratorWorkspaceMember(member,
+			workspace);
 
 		RoleRequired roleRequired = mock(RoleRequired.class);
 

--- a/src/test/java/com/uranus/taskmanager/fixture/entity/WorkspaceMemberEntityFixture.java
+++ b/src/test/java/com/uranus/taskmanager/fixture/entity/WorkspaceMemberEntityFixture.java
@@ -6,12 +6,17 @@ import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 
 public class WorkspaceMemberEntityFixture {
-	public WorkspaceMember createAdminWorkspaceMember(Member member, Workspace workspace) {
+	public WorkspaceMember createOwnerWorkspaceMember(Member member, Workspace workspace) {
+		return WorkspaceMember.addWorkspaceMember(member, workspace, WorkspaceRole.OWNER,
+			member.getEmail());
+	}
+
+	public WorkspaceMember createManagerWorkspaceMember(Member member, Workspace workspace) {
 		return WorkspaceMember.addWorkspaceMember(member, workspace, WorkspaceRole.MANAGER,
 			member.getEmail());
 	}
 
-	public WorkspaceMember createUserWorkspaceMember(Member member, Workspace workspace) {
+	public WorkspaceMember createCollaboratorWorkspaceMember(Member member, Workspace workspace) {
 		return WorkspaceMember.addWorkspaceMember(member, workspace, WorkspaceRole.COLLABORATOR,
 			member.getEmail());
 	}

--- a/src/test/java/com/uranus/taskmanager/helper/ControllerTestHelper.java
+++ b/src/test/java/com/uranus/taskmanager/helper/ControllerTestHelper.java
@@ -19,6 +19,7 @@ import com.uranus.taskmanager.api.invitation.repository.InvitationRepository;
 import com.uranus.taskmanager.api.invitation.service.InvitationService;
 import com.uranus.taskmanager.api.member.controller.MemberController;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
+import com.uranus.taskmanager.api.member.service.MemberQueryService;
 import com.uranus.taskmanager.api.member.service.MemberService;
 import com.uranus.taskmanager.api.workspace.controller.WorkspaceAccessController;
 import com.uranus.taskmanager.api.workspace.controller.WorkspaceController;
@@ -58,6 +59,8 @@ public abstract class ControllerTestHelper {
 
 	@MockBean
 	protected MemberService memberService;
+	@MockBean
+	protected MemberQueryService memberQueryService;
 	@MockBean
 	protected WorkspaceAccessService workspaceAccessService;
 	@MockBean

--- a/src/test/java/com/uranus/taskmanager/helper/ServiceIntegrationTestHelper.java
+++ b/src/test/java/com/uranus/taskmanager/helper/ServiceIntegrationTestHelper.java
@@ -5,6 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import com.uranus.taskmanager.api.invitation.repository.InvitationRepository;
 import com.uranus.taskmanager.api.member.repository.MemberRepository;
+import com.uranus.taskmanager.api.member.service.MemberQueryService;
 import com.uranus.taskmanager.api.member.service.MemberService;
 import com.uranus.taskmanager.api.security.PasswordEncoder;
 import com.uranus.taskmanager.api.workspace.repository.WorkspaceRepository;
@@ -44,6 +45,8 @@ public abstract class ServiceIntegrationTestHelper {
 	protected WorkspaceCommandService workspaceCommandService;
 	@Autowired
 	protected MemberService memberService;
+	@Autowired
+	protected MemberQueryService memberQueryService;
 	@Autowired
 	protected CheckCodeDuplicationService workspaceCreateService;
 


### PR DESCRIPTION
## 🚀 설명
- 멤버의 정보 수정과 관련 기능 개발

---
## ✅ 변경 사항
- [ ] `MemberService`와 `MemberQueryService`로 분리
- [ ] 멤버 업데이트를 위한 권한 얻기 API
- [ ] 멤버 이메일 업데이트 API
- [ ] 멤버 패스워드 업데이트 API
- [ ] 관련 서비스 통합 테스트 코드
- [ ] 관련 컨트롤러 단위 테스트 코드

---
## 🚩 관련 이슈, PR
- #70 

---
## 📖 참고