### PR TITLE
Feat/#96 워크스페이스 소유권 이전 기능 구현

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberController.java
@@ -17,11 +17,13 @@ import com.uranus.taskmanager.api.workspacemember.WorkspaceRole;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.InviteMemberRequest;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.InviteMembersRequest;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.KickWorkspaceMemberRequest;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.TransferWorkspaceOwnershipRequest;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateWorkspaceMemberRoleRequest;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.WorkspaceJoinRequest;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.InviteMemberResponse;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.InviteMembersResponse;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.KickWorkspaceMemberResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.TransferWorkspaceOwnershipResponse;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateWorkspaceMemberRoleResponse;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.WorkspaceJoinResponse;
 import com.uranus.taskmanager.api.workspacemember.service.WorkspaceMemberService;
@@ -101,5 +103,19 @@ public class WorkspaceMemberController {
 		UpdateWorkspaceMemberRoleResponse response = workspaceMemberService.updateWorkspaceMemberRole(code, request,
 			loginMember.getId());
 		return ApiResponse.ok("Member's role for this workspace was updated", response);
+	}
+
+	@LoginRequired
+	@RoleRequired(roles = {WorkspaceRole.OWNER})
+	@PatchMapping("/{code}/members/workspaces/ownership")
+	public ApiResponse<TransferWorkspaceOwnershipResponse> transferWorkspaceOwnership(
+		@PathVariable String code,
+		@RequestBody @Valid TransferWorkspaceOwnershipRequest request,
+		@ResolveLoginMember LoginMember loginMember
+	) {
+
+		TransferWorkspaceOwnershipResponse response = workspaceMemberService.transferWorkspaceOwnership(code, request,
+			loginMember.getId());
+		return ApiResponse.ok("The ownership was successfully transfered", response);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/request/TransferWorkspaceOwnershipRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/request/TransferWorkspaceOwnershipRequest.java
@@ -1,0 +1,15 @@
+package com.uranus.taskmanager.api.workspacemember.presentation.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TransferWorkspaceOwnershipRequest {
+	private String memberIdentifier;
+
+	public TransferWorkspaceOwnershipRequest(String memberIdentifier) {
+		this.memberIdentifier = memberIdentifier;
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/response/TransferWorkspaceOwnershipResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/response/TransferWorkspaceOwnershipResponse.java
@@ -1,0 +1,21 @@
+package com.uranus.taskmanager.api.workspacemember.presentation.dto.response;
+
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.WorkspaceMemberDetail;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class TransferWorkspaceOwnershipResponse {
+	private WorkspaceMemberDetail workspaceMemberDetail;
+
+	public TransferWorkspaceOwnershipResponse(WorkspaceMemberDetail workspaceMemberDetail) {
+		this.workspaceMemberDetail = workspaceMemberDetail;
+	}
+
+	public static TransferWorkspaceOwnershipResponse from(WorkspaceMember workspaceMember) {
+		return new TransferWorkspaceOwnershipResponse(WorkspaceMemberDetail.from(workspaceMember));
+	}
+}


### PR DESCRIPTION
## 🚀 설명
- 워크스페이스 소유권 이전 기능
  - 내 권한 `OWNER` -> `MANAGER`, 내 `workspaceCount` 1 증가
  - 대상 멤버 권한 `기존 권한` -> `OWNER`, `workspaceCount` 1 감소

- 엔티티에 대한 검증 로직, 또는 해당 엔티티만 사용하는 로직을 엔티티에서 정의해서 사용하도록 변경 예정

---
## ✅ 변경 사항
- [x] 워크스페이스 소유권 이전 기능 구현

---
## 🚩 관련 이슈, PR
- #96 

---
## 📖 참고