### PR TITLE
Feat/#68 별칭 업데이트 구현

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/command/create/RetryCodeGenerationOnExceptionService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/command/create/RetryCodeGenerationOnExceptionService.java
@@ -50,7 +50,10 @@ public class RetryCodeGenerationOnExceptionService implements WorkspaceCreateSer
 				setWorkspaceCode(request);
 				setEncodedPasswordIfPresent(request);
 
-				Workspace workspace = workspaceRepository.saveWithNewTransaction(CreateWorkspaceRequest.to(request));
+				/*
+				 * 테스트 용이성을 위해서 saveWithNewTransaction의 사용을 고려하자
+				 */
+				Workspace workspace = workspaceRepository.saveAndFlush(CreateWorkspaceRequest.to(request));
 				addOwnerMemberToWorkspace(member, workspace);
 
 				return CreateWorkspaceResponse.from(workspace);

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/domain/WorkspaceMember.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/domain/WorkspaceMember.java
@@ -15,12 +15,21 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "UK_WORKSPACE_NICKNAME",
+			columnNames = {"workspace_code", "nickname"})
+	}
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WorkspaceMember extends BaseEntity {
@@ -103,6 +112,10 @@ public class WorkspaceMember extends BaseEntity {
 		validateCurrentRoleIsNotOwner();
 		this.role = WorkspaceRole.OWNER;
 		this.member.increaseMyWorkspaceCount();
+	}
+
+	public void updateNickname(String nickname) {
+		this.nickname = nickname;
 	}
 
 	private void validateCannotUpdateToOwnerRole(WorkspaceRole newRole) {

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/DuplicateNicknameException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/DuplicateNicknameException.java
@@ -1,0 +1,22 @@
+package com.uranus.taskmanager.api.workspacemember.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.common.exception.WorkspaceMemberException;
+
+public class DuplicateNicknameException extends WorkspaceMemberException {
+	private static final String MESSAGE = "Nickname already exists in this workspace.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public DuplicateNicknameException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public DuplicateNicknameException(String message) {
+		super(message, HTTP_STATUS);
+	}
+
+	public DuplicateNicknameException(Throwable cause) {
+		super(MESSAGE, HTTP_STATUS, cause);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMembershipController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMembershipController.java
@@ -14,10 +14,12 @@ import com.uranus.taskmanager.api.security.authentication.resolver.ResolveLoginM
 import com.uranus.taskmanager.api.security.authorization.interceptor.RoleRequired;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceRole;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.InviteMembersRequest;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateMemberNicknameRequest;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateMemberRoleRequest;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.InviteMembersResponse;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.RemoveMemberResponse;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.TransferOwnershipResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateMemberNicknameResponse;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateMemberRoleResponse;
 import com.uranus.taskmanager.api.workspacemember.service.command.WorkspaceMemberCommandService;
 import com.uranus.taskmanager.api.workspacemember.service.command.WorkspaceMemberInviteService;
@@ -49,12 +51,27 @@ public class WorkspaceMembershipController {
 		@PathVariable String code,
 		@RequestBody @Valid InviteMembersRequest request
 	) {
-
 		InviteMembersResponse response = workspaceMemberInviteService.inviteMembers(
 			code,
 			request
 		);
 		return ApiResponse.ok("Members invited", response);
+	}
+
+	@LoginRequired
+	@RoleRequired(roles = {WorkspaceRole.VIEWER})
+	@PatchMapping("/nickname")
+	public ApiResponse<UpdateMemberNicknameResponse> updateMemberNickname(
+		@PathVariable String code,
+		@ResolveLoginMember Long loginMemberId,
+		@RequestBody @Valid UpdateMemberNicknameRequest request
+	) {
+		UpdateMemberNicknameResponse response = workspaceMemberCommandService.updateWorkspaceMemberNickname(
+			code,
+			loginMemberId,
+			request
+		);
+		return ApiResponse.ok("Nickname updated.", response);
 	}
 
 	@LoginRequired
@@ -66,7 +83,6 @@ public class WorkspaceMembershipController {
 		@ResolveLoginMember Long loginMemberId,
 		@RequestBody @Valid UpdateMemberRoleRequest request
 	) {
-
 		UpdateMemberRoleResponse response = workspaceMemberCommandService.updateWorkspaceMemberRole(
 			code,
 			memberId,
@@ -84,7 +100,6 @@ public class WorkspaceMembershipController {
 		@PathVariable Long memberId,
 		@ResolveLoginMember Long loginMemberId
 	) {
-
 		TransferOwnershipResponse response = workspaceMemberCommandService.transferWorkspaceOwnership(
 			code,
 			memberId,
@@ -101,7 +116,6 @@ public class WorkspaceMembershipController {
 		@PathVariable Long memberId,
 		@ResolveLoginMember Long loginMemberId
 	) {
-
 		RemoveMemberResponse response = workspaceMemberCommandService.removeMember(
 			code,
 			memberId,

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceParticipationController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceParticipationController.java
@@ -15,7 +15,7 @@ import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.JoinW
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.JoinWorkspaceResponse;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.MyWorkspacesResponse;
 import com.uranus.taskmanager.api.workspacemember.service.command.WorkspaceParticipationCommandService;
-import com.uranus.taskmanager.api.workspacemember.service.query.MemberWorkspaceQueryService;
+import com.uranus.taskmanager.api.workspacemember.service.query.WorkspaceParticipationQueryService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/api/v1/workspaces")
 public class WorkspaceParticipationController {
 
-	private final MemberWorkspaceQueryService memberWorkspaceQueryService;
+	private final WorkspaceParticipationQueryService workspaceParticipationQueryService;
 	private final WorkspaceParticipationCommandService workspaceParticipationCommandService;
 
 	/**
@@ -60,7 +60,7 @@ public class WorkspaceParticipationController {
 		Pageable pageable
 	) {
 
-		MyWorkspacesResponse response = memberWorkspaceQueryService.getMyWorkspaces(
+		MyWorkspacesResponse response = workspaceParticipationQueryService.getMyWorkspaces(
 			loginMemberId,
 			pageable
 		);

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/request/UpdateMemberNicknameRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/request/UpdateMemberNicknameRequest.java
@@ -1,0 +1,20 @@
+package com.uranus.taskmanager.api.workspacemember.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateMemberNicknameRequest {
+
+	@NotBlank(message = "Nickname must not be blank.")
+	@Size(min = 2, max = 30, message = "Nickname must be between 2 and 30 characters.")
+	private String nickname;
+
+	public UpdateMemberNicknameRequest(String nickname) {
+		this.nickname = nickname;
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/response/UpdateMemberNicknameResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/response/UpdateMemberNicknameResponse.java
@@ -1,0 +1,19 @@
+package com.uranus.taskmanager.api.workspacemember.presentation.dto.response;
+
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.WorkspaceMemberDetail;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateMemberNicknameResponse {
+	private WorkspaceMemberDetail updatedDetail;
+
+	public UpdateMemberNicknameResponse(WorkspaceMemberDetail updatedDetail) {
+		this.updatedDetail = updatedDetail;
+	}
+
+	public static UpdateMemberNicknameResponse from(WorkspaceMember workspaceMember) {
+		return new UpdateMemberNicknameResponse(WorkspaceMemberDetail.from(workspaceMember));
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/service/command/WorkspaceMemberCommandService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/service/command/WorkspaceMemberCommandService.java
@@ -1,19 +1,26 @@
 package com.uranus.taskmanager.api.workspacemember.service.command;
 
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 import com.uranus.taskmanager.api.workspacemember.domain.repository.WorkspaceMemberRepository;
+import com.uranus.taskmanager.api.workspacemember.exception.DuplicateNicknameException;
 import com.uranus.taskmanager.api.workspacemember.exception.MemberNotInWorkspaceException;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateMemberNicknameRequest;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateMemberRoleRequest;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.RemoveMemberResponse;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.TransferOwnershipResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateMemberNicknameResponse;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateMemberRoleResponse;
 import com.uranus.taskmanager.api.workspacemember.validator.WorkspaceMemberValidator;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class WorkspaceMemberCommandService {
@@ -22,20 +29,23 @@ public class WorkspaceMemberCommandService {
 	private final WorkspaceMemberValidator workspaceMemberValidator;
 
 	@Transactional
-	public RemoveMemberResponse removeMember(
+	public UpdateMemberNicknameResponse updateWorkspaceMemberNickname(
 		String code,
-		Long targetId,
-		Long requesterId
+		Long memberId,
+		UpdateMemberNicknameRequest request
 	) {
-		WorkspaceMember requester = findWorkspaceMember(code, requesterId);
-		WorkspaceMember target = findWorkspaceMember(code, targetId);
+		try {
+			WorkspaceMember workspaceMember = findWorkspaceMember(code, memberId);
 
-		workspaceMemberValidator.validateRemoveMember(requester, target);
+			workspaceMember.updateNickname(request.getNickname());
+			workspaceMemberRepository.saveAndFlush(workspaceMember);
 
-		target.remove();
-		workspaceMemberRepository.delete(target);
+			return UpdateMemberNicknameResponse.from(workspaceMember);
 
-		return RemoveMemberResponse.from(targetId, target);
+		} catch (DataIntegrityViolationException | ConstraintViolationException e) {
+			log.error("Exception: ", e);
+			throw new DuplicateNicknameException(e);
+		}
 	}
 
 	@Transactional
@@ -68,6 +78,23 @@ public class WorkspaceMemberCommandService {
 		target.updateRoleToOwner();
 
 		return TransferOwnershipResponse.from(requester, target);
+	}
+
+	@Transactional
+	public RemoveMemberResponse removeMember(
+		String code,
+		Long targetId,
+		Long requesterId
+	) {
+		WorkspaceMember requester = findWorkspaceMember(code, requesterId);
+		WorkspaceMember target = findWorkspaceMember(code, targetId);
+
+		workspaceMemberValidator.validateRemoveMember(requester, target);
+
+		target.remove();
+		workspaceMemberRepository.delete(target);
+
+		return RemoveMemberResponse.from(targetId, target);
 	}
 
 	private WorkspaceMember findWorkspaceMember(String code, Long memberId) {

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/service/query/WorkspaceParticipationQueryService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/service/query/WorkspaceParticipationQueryService.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-public class MemberWorkspaceQueryService {
+public class WorkspaceParticipationQueryService {
 
 	private final WorkspaceMemberRepository workspaceMemberRepository;
 

--- a/src/test/java/com/uranus/taskmanager/api/workspace/service/command/RetryCodeGenerationOnExceptionServiceTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspace/service/command/RetryCodeGenerationOnExceptionServiceTest.java
@@ -1,0 +1,123 @@
+package com.uranus.taskmanager.api.workspace.service.command;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.uranus.taskmanager.api.member.domain.Member;
+import com.uranus.taskmanager.api.member.domain.repository.MemberRepository;
+import com.uranus.taskmanager.api.util.WorkspaceCodeGenerator;
+import com.uranus.taskmanager.api.workspace.domain.Workspace;
+import com.uranus.taskmanager.api.workspace.domain.repository.WorkspaceRepository;
+import com.uranus.taskmanager.api.workspace.exception.WorkspaceCodeCollisionHandleException;
+import com.uranus.taskmanager.api.workspace.presentation.dto.request.CreateWorkspaceRequest;
+import com.uranus.taskmanager.api.workspace.presentation.dto.response.CreateWorkspaceResponse;
+import com.uranus.taskmanager.api.workspace.service.command.create.RetryCodeGenerationOnExceptionService;
+import com.uranus.taskmanager.util.DatabaseCleaner;
+
+import jakarta.persistence.EntityManager;
+
+@SpringBootTest
+class RetryCodeGenerationOnExceptionServiceTest {
+
+	@Autowired
+	private RetryCodeGenerationOnExceptionService workspaceCreateService;
+
+	@Autowired
+	private WorkspaceRepository workspaceRepository;
+	@Autowired
+	private MemberRepository memberRepository;
+	@Autowired
+	private EntityManager entityManager;
+	@Autowired
+	private DatabaseCleaner databaseCleaner;
+
+	@MockBean
+	private WorkspaceCodeGenerator workspaceCodeGenerator;
+
+	@AfterEach
+	void tearDown() {
+		databaseCleaner.execute();
+	}
+
+	@Test
+	@Disabled("saveWithNewTransaction을 사용하면 테스트 가능 - 테스트 환경에서 트랜잭션과 세션의 동작방식에 의한 문제 발생")
+	@DisplayName("워크스페이스 코드 충돌이 발생하면 최대 5번까지 재시도한다")
+	void createWorkspace_RetryOnCodeCollision() {
+		// given
+		Member member = memberRepository.save(Member.builder()
+			.email("test@test.com")
+			.password("password1234!")
+			.loginId("tester")
+			.build());
+
+		CreateWorkspaceRequest request = CreateWorkspaceRequest.builder()
+			.name("Test Workspace")
+			.description("Test Description")
+			.build();
+
+		workspaceRepository.save(Workspace.builder()
+			.name("Existing Workspace")
+			.description("Existing Description")
+			.code("DUPLICATE-CODE")
+			.build()
+		);
+
+		// 처음 4번은 중복되는 코드 반환, 5번째에 성공
+		when(workspaceCodeGenerator.generateWorkspaceCode())
+			.thenReturn("DUPLICATE-CODE")  // 1차 시도
+			.thenReturn("DUPLICATE-CODE")  // 2차 시도
+			.thenReturn("DUPLICATE-CODE")  // 3차 시도
+			.thenReturn("DUPLICATE-CODE")  // 4차 시도
+			.thenReturn("SUCCESS-CODE");   // 5차 시도
+
+		// when
+		CreateWorkspaceResponse response = workspaceCreateService.createWorkspace(request, member.getId());
+
+		// then
+		assertThat(response.getCode()).isEqualTo("SUCCESS-CODE");
+		verify(workspaceCodeGenerator, times(5)).generateWorkspaceCode();
+	}
+
+	@Test
+	@DisplayName("최대 재시도 횟수를 초과하면 예외가 발생한다")
+	void createWorkspace_ExceedMaxRetries() {
+		// given
+		Member member = memberRepository.save(Member.builder()
+			.email("test@test.com")
+			.password("password1234!")
+			.loginId("tester")
+			.build());
+
+		CreateWorkspaceRequest request = CreateWorkspaceRequest.builder()
+			.name("Test Workspace")
+			.description("Test Description")
+			.build();
+
+		// 항상 중복되는 코드 반환
+		when(workspaceCodeGenerator.generateWorkspaceCode())
+			.thenReturn("DUPLICATE-CODE");
+
+		// 중복 코드를 가진 워크스페이스 미리 생성
+		workspaceRepository.save(Workspace.builder()
+			.name("Existing Workspace")
+			.description("Existing Description")
+			.code("DUPLICATE-CODE")
+			.build());
+
+		// when & then
+		assertThatThrownBy(() ->
+			workspaceCreateService.createWorkspace(request, member.getId())
+		)
+			.isInstanceOf(WorkspaceCodeCollisionHandleException.class);
+
+		verify(workspaceCodeGenerator, times(5)).generateWorkspaceCode();
+	}
+}

--- a/src/test/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceParticipationControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceParticipationControllerTest.java
@@ -143,7 +143,7 @@ class WorkspaceParticipationControllerTest extends ControllerTestHelper {
 		MockHttpSession session = new MockHttpSession();
 		session.setAttribute(SessionAttributes.LOGIN_MEMBER_ID, 1L);
 
-		when(memberWorkspaceQueryService.getMyWorkspaces(anyLong(), ArgumentMatchers.any(Pageable.class)))
+		when(workspaceParticipationQueryService.getMyWorkspaces(anyLong(), ArgumentMatchers.any(Pageable.class)))
 			.thenReturn(response);
 
 		// 기대하는 JSON 응답 생성
@@ -161,7 +161,7 @@ class WorkspaceParticipationControllerTest extends ControllerTestHelper {
 			.andExpect(content().json(expectedJson))
 			.andDo(print());
 
-		verify(memberWorkspaceQueryService, times(1))
+		verify(workspaceParticipationQueryService, times(1))
 			.getMyWorkspaces(anyLong(), ArgumentMatchers.any(Pageable.class));
 	}
 
@@ -199,7 +199,7 @@ class WorkspaceParticipationControllerTest extends ControllerTestHelper {
 			.totalElements(2L)
 			.build();
 
-		when(memberWorkspaceQueryService.getMyWorkspaces(anyLong(), ArgumentMatchers.any(Pageable.class)))
+		when(workspaceParticipationQueryService.getMyWorkspaces(anyLong(), ArgumentMatchers.any(Pageable.class)))
 			.thenReturn(response);
 
 		// when & then
@@ -210,7 +210,7 @@ class WorkspaceParticipationControllerTest extends ControllerTestHelper {
 				.param("size", "10"))
 			.andExpect(status().isOk());
 
-		verify(memberWorkspaceQueryService, times(1))
+		verify(workspaceParticipationQueryService, times(1))
 			.getMyWorkspaces(anyLong(), ArgumentMatchers.any(Pageable.class));
 
 	}

--- a/src/test/java/com/uranus/taskmanager/api/workspacemember/service/query/WorkspaceParticipationQueryServiceIT.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspacemember/service/query/WorkspaceParticipationQueryServiceIT.java
@@ -23,7 +23,7 @@ import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.JoinW
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.MyWorkspacesResponse;
 import com.uranus.taskmanager.helper.ServiceIntegrationTestHelper;
 
-class MemberWorkspaceQueryServiceIT extends ServiceIntegrationTestHelper {
+class WorkspaceParticipationQueryServiceIT extends ServiceIntegrationTestHelper {
 
 	@BeforeEach
 	void setup() {
@@ -66,7 +66,7 @@ class MemberWorkspaceQueryServiceIT extends ServiceIntegrationTestHelper {
 		Pageable pageable = PageRequest.of(0, 20);
 
 		// when
-		MyWorkspacesResponse response = memberWorkspaceQueryService.getMyWorkspaces(1L, pageable);
+		MyWorkspacesResponse response = workspaceParticipationQueryService.getMyWorkspaces(1L, pageable);
 
 		// then
 		assertThat(response.getTotalElements()).isEqualTo(2);
@@ -92,7 +92,7 @@ class MemberWorkspaceQueryServiceIT extends ServiceIntegrationTestHelper {
 		Pageable pageable = PageRequest.of(0, 20);
 
 		// when
-		MyWorkspacesResponse response = memberWorkspaceQueryService.getMyWorkspaces(2L, pageable);
+		MyWorkspacesResponse response = workspaceParticipationQueryService.getMyWorkspaces(2L, pageable);
 
 		// then
 		assertThat(response.getTotalElements()).isEqualTo(1);
@@ -130,7 +130,7 @@ class MemberWorkspaceQueryServiceIT extends ServiceIntegrationTestHelper {
 		);
 
 		// when
-		MyWorkspacesResponse response = memberWorkspaceQueryService.getMyWorkspaces(member2.getId(), pageable);
+		MyWorkspacesResponse response = workspaceParticipationQueryService.getMyWorkspaces(member2.getId(), pageable);
 
 		// then
 		assertThat(response.getTotalElements()).isEqualTo(5);

--- a/src/test/java/com/uranus/taskmanager/helper/ControllerTestHelper.java
+++ b/src/test/java/com/uranus/taskmanager/helper/ControllerTestHelper.java
@@ -34,7 +34,7 @@ import com.uranus.taskmanager.api.workspacemember.presentation.controller.Worksp
 import com.uranus.taskmanager.api.workspacemember.service.command.WorkspaceMemberCommandService;
 import com.uranus.taskmanager.api.workspacemember.service.command.WorkspaceMemberInviteService;
 import com.uranus.taskmanager.api.workspacemember.service.command.WorkspaceParticipationCommandService;
-import com.uranus.taskmanager.api.workspacemember.service.query.MemberWorkspaceQueryService;
+import com.uranus.taskmanager.api.workspacemember.service.query.WorkspaceParticipationQueryService;
 import com.uranus.taskmanager.config.WebMvcTestConfig;
 
 import lombok.extern.slf4j.Slf4j;
@@ -84,7 +84,7 @@ public abstract class ControllerTestHelper {
 	@MockBean
 	protected WorkspaceMemberInviteService workspaceMemberInviteService;
 	@MockBean
-	protected MemberWorkspaceQueryService memberWorkspaceQueryService;
+	protected WorkspaceParticipationQueryService workspaceParticipationQueryService;
 	@MockBean
 	protected WorkspaceParticipationCommandService workspaceParticipationCommandService;
 	@MockBean

--- a/src/test/java/com/uranus/taskmanager/helper/ServiceIntegrationTestHelper.java
+++ b/src/test/java/com/uranus/taskmanager/helper/ServiceIntegrationTestHelper.java
@@ -17,8 +17,8 @@ import com.uranus.taskmanager.api.workspacemember.domain.repository.WorkspaceMem
 import com.uranus.taskmanager.api.workspacemember.service.command.WorkspaceMemberCommandService;
 import com.uranus.taskmanager.api.workspacemember.service.command.WorkspaceMemberInviteService;
 import com.uranus.taskmanager.api.workspacemember.service.command.WorkspaceParticipationCommandService;
-import com.uranus.taskmanager.api.workspacemember.service.query.MemberWorkspaceQueryService;
 import com.uranus.taskmanager.api.workspacemember.service.query.WorkspaceMemberQueryService;
+import com.uranus.taskmanager.api.workspacemember.service.query.WorkspaceParticipationQueryService;
 import com.uranus.taskmanager.fixture.repository.MemberRepositoryFixture;
 import com.uranus.taskmanager.fixture.repository.WorkspaceRepositoryFixture;
 import com.uranus.taskmanager.util.DatabaseCleaner;
@@ -48,7 +48,7 @@ public abstract class ServiceIntegrationTestHelper {
 	@Autowired
 	protected WorkspaceMemberQueryService workspaceMemberQueryService;
 	@Autowired
-	protected MemberWorkspaceQueryService memberWorkspaceQueryService;
+	protected WorkspaceParticipationQueryService workspaceParticipationQueryService;
 	@Autowired
 	protected WorkspaceParticipationCommandService workspaceParticipationCommandService;
 	@Autowired


### PR DESCRIPTION
## 🚀 설명
- 별칭 업데이트 구현
- 별칭은 워크스페이스 마다 유일해야 함
- 중복 처리 또는 동시성 문제에 대한 해결은 유일성 제약 위반에 대한 예외를 잡는 방식으로 해결

---
## ✅ 변경 사항
- [x] 별칭 업데이트 구현
- [x] 테스트 추가
- [x] 워크스페이스 중복 처리에 대한 테스트도 추가

---
## 🚩 관련 이슈, PR
- #68 

---
## 📖 참고