### PR TITLE
Feat/#121 `ColorType` 추가, `Position` 색상 기능 추가

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/common/ColorPalette.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/ColorPalette.java
@@ -1,12 +1,17 @@
 package com.uranus.taskmanager.api.common;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public enum ColorPallete {
+public enum ColorPalette {
 
 	RED("#FF5733", "Red"),
 	PINK("#FF69B4", "Pink"),
@@ -35,4 +40,18 @@ public enum ColorPallete {
 
 	private final String hexCode;
 	private final String displayName;
+
+	private static final Random RANDOM = new Random();
+
+	public static ColorPalette getRandomUnusedColor(Set<ColorPalette> usedColors) {
+		List<ColorPalette> availableColors = Arrays.stream(ColorPalette.values())
+			.filter(color -> !usedColors.contains(color))
+			.toList();
+
+		if (availableColors.isEmpty()) {
+			availableColors = Arrays.asList(ColorPalette.values());
+		}
+
+		return availableColors.get(RANDOM.nextInt(availableColors.size()));
+	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/common/ColorPallete.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/ColorPallete.java
@@ -1,0 +1,38 @@
+package com.uranus.taskmanager.api.common;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public enum ColorPallete {
+
+	RED("#FF5733", "Red"),
+	PINK("#FF69B4", "Pink"),
+	ORANGE("#FF8C00", "Orange"),
+	YELLOW("#FFD700", "Yellow"),
+	LIGHT_YELLOW("#FFFACD", "Light Yellow"),
+	LIME("#32CD32", "Lime"),
+	GREEN("#008000", "Green"),
+	MINT("#98FF98", "Mint"),
+	TEAL("#008080", "Teal"),
+	CYAN("#00FFFF", "Cyan"),
+	LIGHT_BLUE("#ADD8E6", "Light Blue"),
+	BLUE("#0000FF", "Blue"),
+	NAVY("#000080", "Navy"),
+	INDIGO("#4B0082", "Indigo"),
+	PURPLE("#800080", "Purple"),
+	VIOLET("#EE82EE", "Violet"),
+	MAGENTA("#FF00FF", "Magenta"),
+	BROWN("#A52A2A", "Brown"),
+	TAN("#D2B48C", "Tan"),
+	OLIVE("#808000", "Olive"),
+	GOLD("#FFD700", "Gold"),
+	SILVER("#C0C0C0", "Silver"),
+	GRAY("#808080", "Gray"),
+	BLACK("#000000", "Black");
+
+	private final String hexCode;
+	private final String displayName;
+}

--- a/src/main/java/com/uranus/taskmanager/api/common/ColorType.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/ColorType.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public enum ColorPalette {
+public enum ColorType {
 
 	RED("#FF5733", "Red"),
 	PINK("#FF69B4", "Pink"),
@@ -43,13 +43,13 @@ public enum ColorPalette {
 
 	private static final Random RANDOM = new Random();
 
-	public static ColorPalette getRandomUnusedColor(Set<ColorPalette> usedColors) {
-		List<ColorPalette> availableColors = Arrays.stream(ColorPalette.values())
+	public static ColorType getRandomUnusedColor(Set<ColorType> usedColors) {
+		List<ColorType> availableColors = Arrays.stream(ColorType.values())
 			.filter(color -> !usedColors.contains(color))
 			.toList();
 
 		if (availableColors.isEmpty()) {
-			availableColors = Arrays.asList(ColorPalette.values());
+			availableColors = Arrays.asList(ColorType.values());
 		}
 
 		return availableColors.get(RANDOM.nextInt(availableColors.size()));

--- a/src/main/java/com/uranus/taskmanager/api/common/dto/PageInfo.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/dto/PageInfo.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.api.common;
+package com.uranus.taskmanager.api.common.dto;
 
 import org.springframework.data.domain.Page;
 

--- a/src/main/java/com/uranus/taskmanager/api/common/dto/PageResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/dto/PageResponse.java
@@ -1,4 +1,4 @@
-package com.uranus.taskmanager.api.common;
+package com.uranus.taskmanager.api.common.dto;
 
 import java.util.List;
 

--- a/src/main/java/com/uranus/taskmanager/api/common/exception/TissueException.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/exception/TissueException.java
@@ -5,15 +5,15 @@ import org.springframework.http.HttpStatus;
 import lombok.Getter;
 
 @Getter
-public class CommonException extends RuntimeException {
+public class TissueException extends RuntimeException {
 	private final HttpStatus httpStatus;
 
-	public CommonException(String message, HttpStatus httpStatus) {
+	public TissueException(String message, HttpStatus httpStatus) {
 		super(message);
 		this.httpStatus = httpStatus;
 	}
 
-	public CommonException(String message,
+	public TissueException(String message,
 		HttpStatus httpStatus, Throwable cause) {
 		super(message, cause);
 		this.httpStatus = httpStatus;

--- a/src/main/java/com/uranus/taskmanager/api/common/exception/domain/AuthenticationException.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/exception/domain/AuthenticationException.java
@@ -1,8 +1,10 @@
-package com.uranus.taskmanager.api.common.exception;
+package com.uranus.taskmanager.api.common.exception.domain;
 
 import org.springframework.http.HttpStatus;
 
-public abstract class AuthenticationException extends CommonException {
+import com.uranus.taskmanager.api.common.exception.TissueException;
+
+public abstract class AuthenticationException extends TissueException {
 
 	public AuthenticationException(String message, HttpStatus httpStatus) {
 		super(message, httpStatus);

--- a/src/main/java/com/uranus/taskmanager/api/common/exception/domain/AuthorizationException.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/exception/domain/AuthorizationException.java
@@ -1,8 +1,10 @@
-package com.uranus.taskmanager.api.common.exception;
+package com.uranus.taskmanager.api.common.exception.domain;
 
 import org.springframework.http.HttpStatus;
 
-public abstract class AuthorizationException extends CommonException {
+import com.uranus.taskmanager.api.common.exception.TissueException;
+
+public abstract class AuthorizationException extends TissueException {
 
 	public AuthorizationException(String message, HttpStatus httpStatus) {
 		super(message, httpStatus);

--- a/src/main/java/com/uranus/taskmanager/api/common/exception/domain/InvitationException.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/exception/domain/InvitationException.java
@@ -1,8 +1,10 @@
-package com.uranus.taskmanager.api.common.exception;
+package com.uranus.taskmanager.api.common.exception.domain;
 
 import org.springframework.http.HttpStatus;
 
-public class InvitationException extends CommonException {
+import com.uranus.taskmanager.api.common.exception.TissueException;
+
+public class InvitationException extends TissueException {
 
 	public InvitationException(String message, HttpStatus httpStatus) {
 		super(message, httpStatus);

--- a/src/main/java/com/uranus/taskmanager/api/common/exception/domain/MemberException.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/exception/domain/MemberException.java
@@ -1,8 +1,10 @@
-package com.uranus.taskmanager.api.common.exception;
+package com.uranus.taskmanager.api.common.exception.domain;
 
 import org.springframework.http.HttpStatus;
 
-public abstract class MemberException extends CommonException {
+import com.uranus.taskmanager.api.common.exception.TissueException;
+
+public abstract class MemberException extends TissueException {
 
 	public MemberException(String message, HttpStatus httpStatus) {
 		super(message, httpStatus);

--- a/src/main/java/com/uranus/taskmanager/api/common/exception/domain/PositionException.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/exception/domain/PositionException.java
@@ -1,8 +1,10 @@
-package com.uranus.taskmanager.api.common.exception;
+package com.uranus.taskmanager.api.common.exception.domain;
 
 import org.springframework.http.HttpStatus;
 
-public abstract class PositionException extends CommonException {
+import com.uranus.taskmanager.api.common.exception.TissueException;
+
+public abstract class PositionException extends TissueException {
 
 	public PositionException(String message, HttpStatus httpStatus) {
 		super(message, httpStatus);

--- a/src/main/java/com/uranus/taskmanager/api/common/exception/domain/WorkspaceException.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/exception/domain/WorkspaceException.java
@@ -1,8 +1,10 @@
-package com.uranus.taskmanager.api.common.exception;
+package com.uranus.taskmanager.api.common.exception.domain;
 
 import org.springframework.http.HttpStatus;
 
-public abstract class WorkspaceException extends CommonException {
+import com.uranus.taskmanager.api.common.exception.TissueException;
+
+public abstract class WorkspaceException extends TissueException {
 	public WorkspaceException(String message, HttpStatus httpStatus) {
 		super(message, httpStatus);
 	}

--- a/src/main/java/com/uranus/taskmanager/api/common/exception/domain/WorkspaceMemberException.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/exception/domain/WorkspaceMemberException.java
@@ -1,8 +1,10 @@
-package com.uranus.taskmanager.api.common.exception;
+package com.uranus.taskmanager.api.common.exception.domain;
 
 import org.springframework.http.HttpStatus;
 
-public abstract class WorkspaceMemberException extends CommonException {
+import com.uranus.taskmanager.api.common.exception.TissueException;
+
+public abstract class WorkspaceMemberException extends TissueException {
 
 	public WorkspaceMemberException(String message, HttpStatus httpStatus) {
 		super(message, httpStatus);

--- a/src/main/java/com/uranus/taskmanager/api/global/GlobalExceptionHandler.java
+++ b/src/main/java/com/uranus/taskmanager/api/global/GlobalExceptionHandler.java
@@ -14,12 +14,12 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.uranus.taskmanager.api.common.dto.ApiResponse;
 import com.uranus.taskmanager.api.common.dto.FieldErrorDto;
-import com.uranus.taskmanager.api.common.exception.AuthenticationException;
-import com.uranus.taskmanager.api.common.exception.AuthorizationException;
-import com.uranus.taskmanager.api.common.exception.InvitationException;
-import com.uranus.taskmanager.api.common.exception.MemberException;
-import com.uranus.taskmanager.api.common.exception.WorkspaceException;
-import com.uranus.taskmanager.api.common.exception.WorkspaceMemberException;
+import com.uranus.taskmanager.api.common.exception.domain.AuthenticationException;
+import com.uranus.taskmanager.api.common.exception.domain.AuthorizationException;
+import com.uranus.taskmanager.api.common.exception.domain.InvitationException;
+import com.uranus.taskmanager.api.common.exception.domain.MemberException;
+import com.uranus.taskmanager.api.common.exception.domain.WorkspaceException;
+import com.uranus.taskmanager.api.common.exception.domain.WorkspaceMemberException;
 
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/com/uranus/taskmanager/api/invitation/exception/InvalidInvitationStatusException.java
+++ b/src/main/java/com/uranus/taskmanager/api/invitation/exception/InvalidInvitationStatusException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.invitation.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.InvitationException;
+import com.uranus.taskmanager.api.common.exception.domain.InvitationException;
 
 public class InvalidInvitationStatusException extends InvitationException {
 	private static final String MESSAGE = "Invitation has already been processed";

--- a/src/main/java/com/uranus/taskmanager/api/invitation/exception/InvitationAlreadyExistsException.java
+++ b/src/main/java/com/uranus/taskmanager/api/invitation/exception/InvitationAlreadyExistsException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.invitation.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.InvitationException;
+import com.uranus.taskmanager.api.common.exception.domain.InvitationException;
 
 public class InvitationAlreadyExistsException extends InvitationException {
 	private static final String MESSAGE = "An invitation for this member is already pending";

--- a/src/main/java/com/uranus/taskmanager/api/invitation/exception/InvitationNotFoundException.java
+++ b/src/main/java/com/uranus/taskmanager/api/invitation/exception/InvitationNotFoundException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.invitation.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.InvitationException;
+import com.uranus.taskmanager.api.common.exception.domain.InvitationException;
 
 public class InvitationNotFoundException extends InvitationException {
 	private static final String MESSAGE = "Invitation was not found for the given code";

--- a/src/main/java/com/uranus/taskmanager/api/invitation/presentation/controller/InvitationController.java
+++ b/src/main/java/com/uranus/taskmanager/api/invitation/presentation/controller/InvitationController.java
@@ -11,8 +11,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.uranus.taskmanager.api.common.PageResponse;
 import com.uranus.taskmanager.api.common.dto.ApiResponse;
+import com.uranus.taskmanager.api.common.dto.PageResponse;
 import com.uranus.taskmanager.api.invitation.presentation.dto.InvitationSearchCondition;
 import com.uranus.taskmanager.api.invitation.presentation.dto.response.AcceptInvitationResponse;
 import com.uranus.taskmanager.api.invitation.presentation.dto.response.InvitationResponse;

--- a/src/main/java/com/uranus/taskmanager/api/member/exception/DuplicateEmailException.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/exception/DuplicateEmailException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.member.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.MemberException;
+import com.uranus.taskmanager.api.common.exception.domain.MemberException;
 
 public class DuplicateEmailException extends MemberException {
 

--- a/src/main/java/com/uranus/taskmanager/api/member/exception/DuplicateLoginIdException.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/exception/DuplicateLoginIdException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.member.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.MemberException;
+import com.uranus.taskmanager.api.common.exception.domain.MemberException;
 
 public class DuplicateLoginIdException extends MemberException {
 

--- a/src/main/java/com/uranus/taskmanager/api/member/exception/InvalidMemberPasswordException.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/exception/InvalidMemberPasswordException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.member.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.MemberException;
+import com.uranus.taskmanager.api.common.exception.domain.MemberException;
 
 public class InvalidMemberPasswordException extends MemberException {
 

--- a/src/main/java/com/uranus/taskmanager/api/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/exception/MemberNotFoundException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.member.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.MemberException;
+import com.uranus.taskmanager.api.common.exception.domain.MemberException;
 
 public class MemberNotFoundException extends MemberException {
 

--- a/src/main/java/com/uranus/taskmanager/api/member/exception/OwnedWorkspaceExistsException.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/exception/OwnedWorkspaceExistsException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.member.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.MemberException;
+import com.uranus.taskmanager.api.common.exception.domain.MemberException;
 
 public class OwnedWorkspaceExistsException extends MemberException {
 	private static final String MESSAGE = "You currently have one or more owned workspaces.";

--- a/src/main/java/com/uranus/taskmanager/api/position/domain/Position.java
+++ b/src/main/java/com/uranus/taskmanager/api/position/domain/Position.java
@@ -3,12 +3,15 @@ package com.uranus.taskmanager.api.position.domain;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.uranus.taskmanager.api.common.ColorPalette;
 import com.uranus.taskmanager.api.common.entity.BaseEntity;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -44,6 +47,10 @@ public class Position extends BaseEntity {
 	@Column(nullable = false)
 	private String description;
 
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private ColorPalette color;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "WORKSPACE_ID", nullable = false)
 	private Workspace workspace;
@@ -58,12 +65,14 @@ public class Position extends BaseEntity {
 	public Position(
 		String name,
 		String description,
-		Workspace workspace
+		Workspace workspace,
+		ColorPalette color
 	) {
 		this.name = name;
 		this.description = description;
 		this.workspace = workspace;
 		this.workspaceCode = workspace.getCode();
+		this.color = color;
 		workspace.getPositions().add(this);
 	}
 
@@ -73,5 +82,9 @@ public class Position extends BaseEntity {
 
 	public void updateDescription(String description) {
 		this.description = description;
+	}
+
+	public void updateColor(ColorPalette color) {
+		this.color = color;
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/position/domain/Position.java
+++ b/src/main/java/com/uranus/taskmanager/api/position/domain/Position.java
@@ -3,7 +3,7 @@ package com.uranus.taskmanager.api.position.domain;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.uranus.taskmanager.api.common.ColorPalette;
+import com.uranus.taskmanager.api.common.ColorType;
 import com.uranus.taskmanager.api.common.entity.BaseEntity;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
@@ -49,7 +49,7 @@ public class Position extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private ColorPalette color;
+	private ColorType color;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "WORKSPACE_ID", nullable = false)
@@ -66,7 +66,7 @@ public class Position extends BaseEntity {
 		String name,
 		String description,
 		Workspace workspace,
-		ColorPalette color
+		ColorType color
 	) {
 		this.name = name;
 		this.description = description;
@@ -84,7 +84,7 @@ public class Position extends BaseEntity {
 		this.description = description;
 	}
 
-	public void updateColor(ColorPalette color) {
+	public void updateColor(ColorType color) {
 		this.color = color;
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/position/exception/DuplicatePositionNameException.java
+++ b/src/main/java/com/uranus/taskmanager/api/position/exception/DuplicatePositionNameException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.position.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.PositionException;
+import com.uranus.taskmanager.api.common.exception.domain.PositionException;
 
 public class DuplicatePositionNameException extends PositionException {
 	private static final String MESSAGE = "The name for the position is duplicate in this workspace.";

--- a/src/main/java/com/uranus/taskmanager/api/position/exception/PositionInUseException.java
+++ b/src/main/java/com/uranus/taskmanager/api/position/exception/PositionInUseException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.position.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.PositionException;
+import com.uranus.taskmanager.api.common.exception.domain.PositionException;
 
 public class PositionInUseException extends PositionException {
 	private static final String MESSAGE = "Cannot delete position that is in use.";

--- a/src/main/java/com/uranus/taskmanager/api/position/exception/PositionNotFoundException.java
+++ b/src/main/java/com/uranus/taskmanager/api/position/exception/PositionNotFoundException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.position.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.PositionException;
+import com.uranus.taskmanager.api.common.exception.domain.PositionException;
 
 public class PositionNotFoundException extends PositionException {
 	private static final String MESSAGE = "Could not find the following position for the workspace.";

--- a/src/main/java/com/uranus/taskmanager/api/position/presentation/controller/PositionController.java
+++ b/src/main/java/com/uranus/taskmanager/api/position/presentation/controller/PositionController.java
@@ -39,13 +39,6 @@ public class PositionController {
 	private final PositionCommandService positionCommandService;
 	private final PositionQueryService positionQueryService;
 
-	/**
-	 * Todo
-	 *  - updatePositionColor 필요
-	 *  - 색상 필드에 대한 기능을 추가하면서 같이 추가
-	 *  - 색상 필드 적용 시, createPosition에는 초기에는 랜덤한 색상으로 설정하도록 만들 필요 있음
-	 */
-
 	@LoginRequired
 	@RoleRequired(roles = {WorkspaceRole.MANAGER})
 	@ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/com/uranus/taskmanager/api/position/presentation/controller/PositionController.java
+++ b/src/main/java/com/uranus/taskmanager/api/position/presentation/controller/PositionController.java
@@ -13,10 +13,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.uranus.taskmanager.api.common.dto.ApiResponse;
 import com.uranus.taskmanager.api.position.presentation.dto.request.CreatePositionRequest;
+import com.uranus.taskmanager.api.position.presentation.dto.request.UpdatePositionColorRequest;
 import com.uranus.taskmanager.api.position.presentation.dto.request.UpdatePositionRequest;
 import com.uranus.taskmanager.api.position.presentation.dto.response.CreatePositionResponse;
 import com.uranus.taskmanager.api.position.presentation.dto.response.DeletePositionResponse;
 import com.uranus.taskmanager.api.position.presentation.dto.response.GetPositionsResponse;
+import com.uranus.taskmanager.api.position.presentation.dto.response.UpdatePositionColorResponse;
 import com.uranus.taskmanager.api.position.presentation.dto.response.UpdatePositionResponse;
 import com.uranus.taskmanager.api.position.service.command.PositionCommandService;
 import com.uranus.taskmanager.api.position.service.query.PositionQueryService;
@@ -66,6 +68,18 @@ public class PositionController {
 	) {
 		UpdatePositionResponse response = positionCommandService.updatePosition(code, positionId, request);
 		return ApiResponse.ok("Position updated.", response);
+	}
+
+	@LoginRequired
+	@RoleRequired(roles = {WorkspaceRole.MANAGER})
+	@PatchMapping("/{positionId}/color")
+	public ApiResponse<UpdatePositionColorResponse> updatePositionColor(
+		@PathVariable String code,
+		@PathVariable Long positionId,
+		@Valid @RequestBody UpdatePositionColorRequest request
+	) {
+		UpdatePositionColorResponse response = positionCommandService.updatePositionColor(code, positionId, request);
+		return ApiResponse.ok("Position color updated.", response);
 	}
 
 	@LoginRequired

--- a/src/main/java/com/uranus/taskmanager/api/position/presentation/dto/request/UpdatePositionColorRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/position/presentation/dto/request/UpdatePositionColorRequest.java
@@ -1,0 +1,11 @@
+package com.uranus.taskmanager.api.position.presentation.dto.request;
+
+import com.uranus.taskmanager.api.common.ColorType;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdatePositionColorRequest(
+	@NotNull
+	ColorType colorType
+) {
+}

--- a/src/main/java/com/uranus/taskmanager/api/position/presentation/dto/response/CreatePositionResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/position/presentation/dto/response/CreatePositionResponse.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import com.uranus.taskmanager.api.position.domain.Position;
 
 public record CreatePositionResponse(
-	Long id,
+	Long positionId,
 	String name,
 	String description,
 	LocalDateTime createdAt

--- a/src/main/java/com/uranus/taskmanager/api/position/presentation/dto/response/DeletePositionResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/position/presentation/dto/response/DeletePositionResponse.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import com.uranus.taskmanager.api.position.domain.Position;
 
 public record DeletePositionResponse(
-	Long id,
+	Long positionId,
 	LocalDateTime deletedAt
 ) {
 	public static DeletePositionResponse from(Position position) {

--- a/src/main/java/com/uranus/taskmanager/api/position/presentation/dto/response/PositionDetail.java
+++ b/src/main/java/com/uranus/taskmanager/api/position/presentation/dto/response/PositionDetail.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 import com.uranus.taskmanager.api.position.domain.Position;
 
 public record PositionDetail(
-	Long id,
+	Long positionId,
 	String name,
 	String description,
 	LocalDateTime createdAt,

--- a/src/main/java/com/uranus/taskmanager/api/position/presentation/dto/response/UpdatePositionColorResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/position/presentation/dto/response/UpdatePositionColorResponse.java
@@ -2,19 +2,18 @@ package com.uranus.taskmanager.api.position.presentation.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.uranus.taskmanager.api.common.ColorType;
 import com.uranus.taskmanager.api.position.domain.Position;
 
-public record UpdatePositionResponse(
+public record UpdatePositionColorResponse(
 	Long positionId,
-	String name,
-	String description,
+	ColorType color,
 	LocalDateTime updatedAt
 ) {
-	public static UpdatePositionResponse from(Position position) {
-		return new UpdatePositionResponse(
+	public static UpdatePositionColorResponse from(Position position) {
+		return new UpdatePositionColorResponse(
 			position.getId(),
-			position.getName(),
-			position.getDescription(),
+			position.getColor(),
 			position.getLastModifiedDate()
 		);
 	}

--- a/src/main/java/com/uranus/taskmanager/api/security/authentication/exception/InvalidLoginIdentityException.java
+++ b/src/main/java/com/uranus/taskmanager/api/security/authentication/exception/InvalidLoginIdentityException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.security.authentication.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.AuthenticationException;
+import com.uranus.taskmanager.api.common.exception.domain.AuthenticationException;
 
 public class InvalidLoginIdentityException extends AuthenticationException {
 

--- a/src/main/java/com/uranus/taskmanager/api/security/authentication/exception/InvalidLoginPasswordException.java
+++ b/src/main/java/com/uranus/taskmanager/api/security/authentication/exception/InvalidLoginPasswordException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.security.authentication.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.AuthenticationException;
+import com.uranus.taskmanager.api.common.exception.domain.AuthenticationException;
 
 public class InvalidLoginPasswordException extends AuthenticationException {
 

--- a/src/main/java/com/uranus/taskmanager/api/security/authentication/exception/UserNotLoggedInException.java
+++ b/src/main/java/com/uranus/taskmanager/api/security/authentication/exception/UserNotLoggedInException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.security.authentication.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.AuthenticationException;
+import com.uranus.taskmanager.api.common.exception.domain.AuthenticationException;
 
 public class UserNotLoggedInException extends AuthenticationException {
 

--- a/src/main/java/com/uranus/taskmanager/api/security/authorization/exception/InsufficientWorkspaceRoleException.java
+++ b/src/main/java/com/uranus/taskmanager/api/security/authorization/exception/InsufficientWorkspaceRoleException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.security.authorization.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.AuthorizationException;
+import com.uranus.taskmanager.api.common.exception.domain.AuthorizationException;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceRole;
 
 /**

--- a/src/main/java/com/uranus/taskmanager/api/security/authorization/exception/InvalidWorkspaceCodeInUriException.java
+++ b/src/main/java/com/uranus/taskmanager/api/security/authorization/exception/InvalidWorkspaceCodeInUriException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.security.authorization.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.AuthorizationException;
+import com.uranus.taskmanager.api.common.exception.domain.AuthorizationException;
 
 public class InvalidWorkspaceCodeInUriException extends AuthorizationException {
 	private static final String MESSAGE = "The workspace code in the URI is invalid";

--- a/src/main/java/com/uranus/taskmanager/api/security/authorization/exception/UpdatePermissionException.java
+++ b/src/main/java/com/uranus/taskmanager/api/security/authorization/exception/UpdatePermissionException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.security.authorization.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.AuthorizationException;
+import com.uranus.taskmanager.api.common.exception.domain.AuthorizationException;
 
 public class UpdatePermissionException extends AuthorizationException {
 	private static final String MESSAGE = "You do not have authorization for update or the authorization has expired";

--- a/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
@@ -3,6 +3,7 @@ package com.uranus.taskmanager.api.workspace.domain;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.uranus.taskmanager.api.common.ColorPalette;
 import com.uranus.taskmanager.api.common.entity.BaseEntity;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
 import com.uranus.taskmanager.api.position.domain.Position;
@@ -79,10 +80,11 @@ public class Workspace extends BaseEntity {
 		this.password = password;
 	}
 
-	public Position createPosition(String name, String description) {
+	public Position createPosition(String name, String description, ColorPalette color) {
 		return Position.builder()
 			.name(name)
 			.description(description)
+			.color(color)
 			.workspace(this)
 			.build();
 	}

--- a/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
@@ -3,7 +3,7 @@ package com.uranus.taskmanager.api.workspace.domain;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.uranus.taskmanager.api.common.ColorPalette;
+import com.uranus.taskmanager.api.common.ColorType;
 import com.uranus.taskmanager.api.common.entity.BaseEntity;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
 import com.uranus.taskmanager.api.position.domain.Position;
@@ -80,7 +80,7 @@ public class Workspace extends BaseEntity {
 		this.password = password;
 	}
 
-	public Position createPosition(String name, String description, ColorPalette color) {
+	public Position createPosition(String name, String description, ColorType color) {
 		return Position.builder()
 			.name(name)
 			.description(description)

--- a/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
@@ -62,7 +62,6 @@ public class Workspace extends BaseEntity {
 	@Column(nullable = false)
 	private int memberCount = 0;
 
-	// Position과의 양방향 관계 추가
 	@OneToMany(mappedBy = "workspace", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Position> positions = new ArrayList<>();
 

--- a/src/main/java/com/uranus/taskmanager/api/workspace/exception/InvalidMemberCountException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/exception/InvalidMemberCountException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspace.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.WorkspaceException;
+import com.uranus.taskmanager.api.common.exception.domain.WorkspaceException;
 
 public class InvalidMemberCountException extends WorkspaceException {
 	private static final String MESSAGE = "The number of members in a workspace cannot go below zero.";

--- a/src/main/java/com/uranus/taskmanager/api/workspace/exception/InvalidWorkspacePasswordException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/exception/InvalidWorkspacePasswordException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspace.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.AuthenticationException;
+import com.uranus.taskmanager.api.common.exception.domain.AuthenticationException;
 
 public class InvalidWorkspacePasswordException extends AuthenticationException {
 	private static final String MESSAGE = "The given workspace password is invalid";

--- a/src/main/java/com/uranus/taskmanager/api/workspace/exception/WorkspaceCodeCollisionHandleException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/exception/WorkspaceCodeCollisionHandleException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspace.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.WorkspaceException;
+import com.uranus.taskmanager.api.common.exception.domain.WorkspaceException;
 
 public class WorkspaceCodeCollisionHandleException extends WorkspaceException {
 

--- a/src/main/java/com/uranus/taskmanager/api/workspace/exception/WorkspaceMemberLimitExceededException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/exception/WorkspaceMemberLimitExceededException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspace.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.WorkspaceException;
+import com.uranus.taskmanager.api.common.exception.domain.WorkspaceException;
 
 public class WorkspaceMemberLimitExceededException extends WorkspaceException {
 	private static final String MESSAGE = "Maximum number of members that can join this workspace reached.";

--- a/src/main/java/com/uranus/taskmanager/api/workspace/exception/WorkspaceNotFoundException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/exception/WorkspaceNotFoundException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspace.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.WorkspaceException;
+import com.uranus.taskmanager.api.common.exception.domain.WorkspaceException;
 
 public class WorkspaceNotFoundException extends WorkspaceException {
 

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/domain/WorkspaceMember.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/domain/WorkspaceMember.java
@@ -50,8 +50,7 @@ public class WorkspaceMember extends BaseEntity {
 
 	@Column(name = "WORKSPACE_CODE", nullable = false)
 	private String workspaceCode;
-
-	// Position과의 다대일 관계 추가
+	
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "POSITION_ID")
 	private Position position;

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/AlreadyJoinedWorkspaceException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/AlreadyJoinedWorkspaceException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspacemember.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.WorkspaceMemberException;
+import com.uranus.taskmanager.api.common.exception.domain.WorkspaceMemberException;
 
 public class AlreadyJoinedWorkspaceException extends WorkspaceMemberException {
 	private static final String MESSAGE = "Member already joined this Workspace";

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/DuplicateNicknameException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/DuplicateNicknameException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspacemember.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.WorkspaceMemberException;
+import com.uranus.taskmanager.api.common.exception.domain.WorkspaceMemberException;
 
 public class DuplicateNicknameException extends WorkspaceMemberException {
 	private static final String MESSAGE = "Nickname already exists in this workspace.";

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/InvalidRoleUpdateException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/InvalidRoleUpdateException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspacemember.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.WorkspaceMemberException;
+import com.uranus.taskmanager.api.common.exception.domain.WorkspaceMemberException;
 
 public class InvalidRoleUpdateException extends WorkspaceMemberException {
 	private static final String MESSAGE = "Invalid role selection for update";

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/InvalidWorkspaceCountException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/InvalidWorkspaceCountException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspacemember.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.WorkspaceMemberException;
+import com.uranus.taskmanager.api.common.exception.domain.WorkspaceMemberException;
 
 public class InvalidWorkspaceCountException extends WorkspaceMemberException {
 	private static final String MESSAGE = "The count for owned workspaces cannot go below zero.";

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/MemberNotInWorkspaceException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/MemberNotInWorkspaceException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspacemember.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.WorkspaceMemberException;
+import com.uranus.taskmanager.api.common.exception.domain.WorkspaceMemberException;
 
 public class MemberNotInWorkspaceException extends WorkspaceMemberException {
 	private static final String MESSAGE = "Member was not found in this workspace";

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/NoValidMembersToInviteException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/NoValidMembersToInviteException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspacemember.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.WorkspaceMemberException;
+import com.uranus.taskmanager.api.common.exception.domain.WorkspaceMemberException;
 
 public class NoValidMembersToInviteException extends WorkspaceMemberException {
 	private static final String MESSAGE = "No avaliable members were found for invitation.";

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/WorkspaceCreationLimitExceededException.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/exception/WorkspaceCreationLimitExceededException.java
@@ -2,7 +2,7 @@ package com.uranus.taskmanager.api.workspacemember.exception;
 
 import org.springframework.http.HttpStatus;
 
-import com.uranus.taskmanager.api.common.exception.WorkspaceMemberException;
+import com.uranus.taskmanager.api.common.exception.domain.WorkspaceMemberException;
 
 public class WorkspaceCreationLimitExceededException extends WorkspaceMemberException {
 	private static final String MESSAGE = "Maximum workspace creation limit reached.";

--- a/src/test/java/com/uranus/taskmanager/api/position/service/command/PositionCommandServiceIT.java
+++ b/src/test/java/com/uranus/taskmanager/api/position/service/command/PositionCommandServiceIT.java
@@ -7,14 +7,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import com.uranus.taskmanager.api.common.ColorPalette;
+import com.uranus.taskmanager.api.common.ColorType;
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.position.domain.Position;
 import com.uranus.taskmanager.api.position.exception.DuplicatePositionNameException;
 import com.uranus.taskmanager.api.position.exception.PositionInUseException;
 import com.uranus.taskmanager.api.position.presentation.dto.request.CreatePositionRequest;
+import com.uranus.taskmanager.api.position.presentation.dto.request.UpdatePositionColorRequest;
 import com.uranus.taskmanager.api.position.presentation.dto.request.UpdatePositionRequest;
 import com.uranus.taskmanager.api.position.presentation.dto.response.CreatePositionResponse;
+import com.uranus.taskmanager.api.position.presentation.dto.response.UpdatePositionColorResponse;
 import com.uranus.taskmanager.api.position.presentation.dto.response.UpdatePositionResponse;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspace.exception.WorkspaceNotFoundException;
@@ -71,10 +73,10 @@ class PositionCommandServiceIT extends ServiceIntegrationTestHelper {
 		CreatePositionResponse createResponse = positionCommandService.createPosition("TESTCODE", request);
 
 		// Then
-		Position findPosition = positionRepository.findById(createResponse.id()).orElseThrow();
+		Position findPosition = positionRepository.findById(createResponse.positionId()).orElseThrow();
 
 		assertThat(findPosition.getColor()).isNotNull();
-		assertThat(findPosition.getColor()).isInstanceOf(ColorPalette.class);
+		assertThat(findPosition.getColor()).isInstanceOf(ColorType.class);
 	}
 
 	@Test
@@ -105,7 +107,7 @@ class PositionCommandServiceIT extends ServiceIntegrationTestHelper {
 		Position position = workspace.createPosition(
 			"Developer",
 			"Backend Developer",
-			ColorPalette.BLACK
+			ColorType.BLACK
 		);
 		positionRepository.save(position);
 
@@ -127,13 +129,37 @@ class PositionCommandServiceIT extends ServiceIntegrationTestHelper {
 	}
 
 	@Test
+	@DisplayName("Position의 ColorType를 수정하면 수정 응답 반환")
+	void updatePositionColor() {
+		// given
+		Position position = workspace.createPosition(
+			"Developer",
+			"Backend Developer",
+			ColorType.BLACK
+		);
+		positionRepository.save(position);
+
+		UpdatePositionColorRequest request = new UpdatePositionColorRequest(ColorType.GREEN);
+
+		// when
+		UpdatePositionColorResponse response = positionCommandService.updatePositionColor(
+			"TESTCODE",
+			position.getId(),
+			request
+		);
+
+		// then
+		assertThat(response.color()).isEqualTo(ColorType.GREEN);
+	}
+
+	@Test
 	@DisplayName("사용 중인 Position 삭제를 시도하면 예외 발생")
 	void deletePosition_WhenInUse_ThrowsException() {
 		// Given
 		Position position = workspace.createPosition(
 			"Developer",
 			"Backend Developer",
-			ColorPalette.BLACK
+			ColorType.BLACK
 		);
 		positionRepository.save(position);
 

--- a/src/test/java/com/uranus/taskmanager/api/position/service/command/PositionCommandServiceIT.java
+++ b/src/test/java/com/uranus/taskmanager/api/position/service/command/PositionCommandServiceIT.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.uranus.taskmanager.api.common.ColorPalette;
 import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.position.domain.Position;
 import com.uranus.taskmanager.api.position.exception.DuplicatePositionNameException;
@@ -58,6 +59,25 @@ class PositionCommandServiceIT extends ServiceIntegrationTestHelper {
 	}
 
 	@Test
+	@DisplayName("Position을 생성하면 ColorPalette의 색상 중 랜덤한 색을 배정받는다")
+	void createPosition_assignedRandomColor() {
+		// Given
+		CreatePositionRequest request = new CreatePositionRequest(
+			"Developer",
+			"Backend Developer"
+		);
+
+		// When
+		CreatePositionResponse createResponse = positionCommandService.createPosition("TESTCODE", request);
+
+		// Then
+		Position findPosition = positionRepository.findById(createResponse.id()).orElseThrow();
+
+		assertThat(findPosition.getColor()).isNotNull();
+		assertThat(findPosition.getColor()).isInstanceOf(ColorPalette.class);
+	}
+
+	@Test
 	@DisplayName("이름이 중복되는 Position을 생성하면 예외 발생")
 	void createDuplicatePosition_throwsException() {
 		// given
@@ -82,7 +102,11 @@ class PositionCommandServiceIT extends ServiceIntegrationTestHelper {
 	@DisplayName("Position을 수정하면 수정 응답 반환")
 	void updatePosition() {
 		// Given
-		Position position = workspace.createPosition("Developer", "Backend Developer");
+		Position position = workspace.createPosition(
+			"Developer",
+			"Backend Developer",
+			ColorPalette.BLACK
+		);
 		positionRepository.save(position);
 
 		UpdatePositionRequest request = new UpdatePositionRequest(
@@ -106,7 +130,11 @@ class PositionCommandServiceIT extends ServiceIntegrationTestHelper {
 	@DisplayName("사용 중인 Position 삭제를 시도하면 예외 발생")
 	void deletePosition_WhenInUse_ThrowsException() {
 		// Given
-		Position position = workspace.createPosition("Developer", "Backend Developer");
+		Position position = workspace.createPosition(
+			"Developer",
+			"Backend Developer",
+			ColorPalette.BLACK
+		);
 		positionRepository.save(position);
 
 		// WorkspaceMember 생성 및 Position 할당


### PR DESCRIPTION
## 🚀 설명
- 24가지 색상을 정의한 `enum` 추가
- 포지션의 색과 관련된 기능들 구현

---
## ✅ 변경 사항
- [x] 색상 `enum`인 `ColorType` 구현
- [x] `Position` 생성 시 랜덤한 색 배정 로직 추가
- [x] `Position`의 `ColorType` 변경 기능 구현
- [x] 테스트 추가
- [x] 상위 공통 예외의 이름 변경 `CommonException` -> `TissueException`

---
## 🚩 관련 이슈, PR
- #121 

---
## 📖 참고