### PR TITLE
Feat/#120 포지션(`Position`) 할당/해제 구현

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/domain/WorkspaceMember.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/domain/WorkspaceMember.java
@@ -50,7 +50,7 @@ public class WorkspaceMember extends BaseEntity {
 
 	@Column(name = "WORKSPACE_CODE", nullable = false)
 	private String workspaceCode;
-	
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "POSITION_ID")
 	private Position position;
@@ -108,6 +108,13 @@ public class WorkspaceMember extends BaseEntity {
 			validatePositionBelongsToWorkspace(position);
 		}
 		this.position = position;
+	}
+
+	public void removePosition() {
+		if (this.position != null) {
+			this.position.getWorkspaceMembers().remove(this);
+			this.position = null;
+		}
 	}
 
 	public void updateRole(WorkspaceRole role) {

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberInfoController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberInfoController.java
@@ -1,0 +1,99 @@
+package com.uranus.taskmanager.api.workspacemember.presentation.controller;
+
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.uranus.taskmanager.api.common.dto.ApiResponse;
+import com.uranus.taskmanager.api.security.authentication.interceptor.LoginRequired;
+import com.uranus.taskmanager.api.security.authentication.resolver.ResolveLoginMember;
+import com.uranus.taskmanager.api.security.authorization.interceptor.RoleRequired;
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceRole;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateNicknameRequest;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.AssignPositionResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateNicknameResponse;
+import com.uranus.taskmanager.api.workspacemember.service.command.WorkspaceMemberCommandService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/workspaces/{code}/members")
+public class WorkspaceMemberInfoController {
+
+	private final WorkspaceMemberCommandService workspaceMemberCommandService;
+
+	/*
+	 * Todo
+	 *  - udpateNickname: 내 별칭 수정 (VIEWER)
+	 *  - assignPosition: 내 포지션 할당 (VIEWER)
+	 *  - removePosition: 내 포지션 해제 (VIEWER)
+	 *  - assignMemberPosition: 특정 멤버의 포지션 할당 (MANAGER)
+	 *  - removeMemberPosition: 특정 멤버의 포지션 해제 (MANAGER)
+	 *  - <br>
+	 *  - 구현 예정
+	 *  - setNicknameSchema: 워크스페이스의 별칭 스키마 정하기 (OWNER)
+	 *    - 예시: [멤버의 소속 부서/팀][멤버의 포지션]멤버의 이름 -> 이렇게 정하는 것이 가능, 중복되는 경우 숫자 붙이기
+	 *    - 예시: [SearchTeam][BACKEND-DEV]HongGilDong
+	 *  - assignTeam: 내 팀(부서) 소속 할당 (VIEWER)
+	 *  - removeTeam: 내 팀(부서) 소속 해제 (VIEWER)
+	 *  - assignMemberTeam: 특정 멤버의 팀(부서) 소속 할당 (MANAGER)
+	 *  - removeMemberTeam: 특정 멤버의 팀(부서) 소속 해제 (MANAGER)
+	 *  - <br>
+	 *  - 필요한 도메인
+	 *  - Team(Department, 소속)
+	 *  - Level(경력)
+	 */
+
+	@LoginRequired
+	@RoleRequired(roles = {WorkspaceRole.VIEWER})
+	@PatchMapping("/nickname")
+	public ApiResponse<UpdateNicknameResponse> updateNickname(
+		@PathVariable String code,
+		@ResolveLoginMember Long loginMemberId,
+		@RequestBody @Valid UpdateNicknameRequest request
+	) {
+		UpdateNicknameResponse response = workspaceMemberCommandService.updateMemberNickname(
+			code,
+			loginMemberId,
+			request
+		);
+		return ApiResponse.ok("Nickname updated.", response);
+	}
+
+	@LoginRequired
+	@RoleRequired(roles = {WorkspaceRole.VIEWER})
+	@PatchMapping("/positions/{positionId}")
+	public ApiResponse<AssignPositionResponse> assignPosition(
+		@PathVariable String code,
+		@PathVariable Long positionId,
+		@ResolveLoginMember Long loginMemberId
+	) {
+		AssignPositionResponse response = workspaceMemberCommandService.assignPosition(
+			code,
+			positionId,
+			loginMemberId
+		);
+		return ApiResponse.ok("Position assigned to member.", response);
+	}
+
+	@LoginRequired
+	@RoleRequired(roles = {WorkspaceRole.VIEWER})
+	@PatchMapping("/positions")
+	public ApiResponse<Void> removePosition(
+		@PathVariable String code,
+		@ResolveLoginMember Long loginMemberId
+	) {
+		workspaceMemberCommandService.removePosition(
+			code,
+			loginMemberId
+		);
+		return ApiResponse.okWithNoContent("Position removed from member.");
+	}
+
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberInfoController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberInfoController.java
@@ -58,7 +58,7 @@ public class WorkspaceMemberInfoController {
 		@ResolveLoginMember Long loginMemberId,
 		@RequestBody @Valid UpdateNicknameRequest request
 	) {
-		UpdateNicknameResponse response = workspaceMemberCommandService.updateMemberNickname(
+		UpdateNicknameResponse response = workspaceMemberCommandService.updateNickname(
 			code,
 			loginMemberId,
 			request

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberInfoController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberInfoController.java
@@ -96,4 +96,33 @@ public class WorkspaceMemberInfoController {
 		return ApiResponse.okWithNoContent("Position removed from member.");
 	}
 
+	@LoginRequired
+	@RoleRequired(roles = {WorkspaceRole.MANAGER})
+	@PatchMapping("/{memberId}/positions/{positionId}")
+	public ApiResponse<AssignPositionResponse> assignMemberPosition(
+		@PathVariable String code,
+		@PathVariable Long memberId,
+		@PathVariable Long positionId
+	) {
+		AssignPositionResponse response = workspaceMemberCommandService.assignMemberPosition(
+			code,
+			positionId,
+			memberId
+		);
+		return ApiResponse.ok("Position assigned to member.", response);
+	}
+
+	@LoginRequired
+	@RoleRequired(roles = {WorkspaceRole.MANAGER})
+	@PatchMapping("/{memberId}/positions")
+	public ApiResponse<Void> removeMemberPosition(
+		@PathVariable String code,
+		@PathVariable Long memberId
+	) {
+		workspaceMemberCommandService.removeMemberPosition(
+			code,
+			memberId
+		);
+		return ApiResponse.okWithNoContent("Position removed from member.");
+	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMembershipController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMembershipController.java
@@ -59,7 +59,7 @@ public class WorkspaceMembershipController {
 	@LoginRequired
 	@RoleRequired(roles = {WorkspaceRole.MANAGER})
 	@PatchMapping("/{memberId}/role")
-	public ApiResponse<UpdateRoleResponse> updateWorkspaceMemberRole(
+	public ApiResponse<UpdateRoleResponse> updateMemberRole(
 		@PathVariable String code,
 		@PathVariable Long memberId,
 		@ResolveLoginMember Long loginMemberId,

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMembershipController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMembershipController.java
@@ -14,13 +14,11 @@ import com.uranus.taskmanager.api.security.authentication.resolver.ResolveLoginM
 import com.uranus.taskmanager.api.security.authorization.interceptor.RoleRequired;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceRole;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.InviteMembersRequest;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateMemberNicknameRequest;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateMemberRoleRequest;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateRoleRequest;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.InviteMembersResponse;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.RemoveMemberResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.RemoveWorkspaceMemberResponse;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.TransferOwnershipResponse;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateMemberNicknameResponse;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateMemberRoleResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateRoleResponse;
 import com.uranus.taskmanager.api.workspacemember.service.command.WorkspaceMemberCommandService;
 import com.uranus.taskmanager.api.workspacemember.service.command.WorkspaceMemberInviteService;
 
@@ -59,31 +57,15 @@ public class WorkspaceMembershipController {
 	}
 
 	@LoginRequired
-	@RoleRequired(roles = {WorkspaceRole.VIEWER})
-	@PatchMapping("/nickname")
-	public ApiResponse<UpdateMemberNicknameResponse> updateMemberNickname(
-		@PathVariable String code,
-		@ResolveLoginMember Long loginMemberId,
-		@RequestBody @Valid UpdateMemberNicknameRequest request
-	) {
-		UpdateMemberNicknameResponse response = workspaceMemberCommandService.updateWorkspaceMemberNickname(
-			code,
-			loginMemberId,
-			request
-		);
-		return ApiResponse.ok("Nickname updated.", response);
-	}
-
-	@LoginRequired
 	@RoleRequired(roles = {WorkspaceRole.MANAGER})
 	@PatchMapping("/{memberId}/role")
-	public ApiResponse<UpdateMemberRoleResponse> updateWorkspaceMemberRole(
+	public ApiResponse<UpdateRoleResponse> updateWorkspaceMemberRole(
 		@PathVariable String code,
 		@PathVariable Long memberId,
 		@ResolveLoginMember Long loginMemberId,
-		@RequestBody @Valid UpdateMemberRoleRequest request
+		@RequestBody @Valid UpdateRoleRequest request
 	) {
-		UpdateMemberRoleResponse response = workspaceMemberCommandService.updateWorkspaceMemberRole(
+		UpdateRoleResponse response = workspaceMemberCommandService.updateWorkspaceMemberRole(
 			code,
 			memberId,
 			loginMemberId,
@@ -111,12 +93,12 @@ public class WorkspaceMembershipController {
 	@LoginRequired
 	@RoleRequired(roles = {WorkspaceRole.MANAGER})
 	@DeleteMapping("/{memberId}")
-	public ApiResponse<RemoveMemberResponse> removeMember(
+	public ApiResponse<RemoveWorkspaceMemberResponse> removeWorkspaceMember(
 		@PathVariable String code,
 		@PathVariable Long memberId,
 		@ResolveLoginMember Long loginMemberId
 	) {
-		RemoveMemberResponse response = workspaceMemberCommandService.removeMember(
+		RemoveWorkspaceMemberResponse response = workspaceMemberCommandService.removeWorkspaceMember(
 			code,
 			memberId,
 			loginMemberId

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/request/UpdateNicknameRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/request/UpdateNicknameRequest.java
@@ -8,13 +8,13 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UpdateMemberNicknameRequest {
+public class UpdateNicknameRequest {
 
 	@NotBlank(message = "Nickname must not be blank.")
 	@Size(min = 2, max = 30, message = "Nickname must be between 2 and 30 characters.")
 	private String nickname;
 
-	public UpdateMemberNicknameRequest(String nickname) {
+	public UpdateNicknameRequest(String nickname) {
 		this.nickname = nickname;
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/request/UpdateRoleRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/request/UpdateRoleRequest.java
@@ -9,12 +9,12 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UpdateMemberRoleRequest {
+public class UpdateRoleRequest {
 
 	@NotNull(message = "Select a valid workspace role")
 	private WorkspaceRole updateWorkspaceRole;
 
-	public UpdateMemberRoleRequest(WorkspaceRole updateWorkspaceRole) {
+	public UpdateRoleRequest(WorkspaceRole updateWorkspaceRole) {
 		this.updateWorkspaceRole = updateWorkspaceRole;
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/response/AssignPositionResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/response/AssignPositionResponse.java
@@ -1,0 +1,19 @@
+package com.uranus.taskmanager.api.workspacemember.presentation.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
+
+public record AssignPositionResponse(
+	Long workspaceMemberId,
+	String assignedPosition,
+	LocalDateTime assignedAt
+) {
+	public static AssignPositionResponse from(WorkspaceMember workspaceMember) {
+		return new AssignPositionResponse(
+			workspaceMember.getId(),
+			workspaceMember.getPosition().getName(),
+			workspaceMember.getLastModifiedDate()
+		);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/response/RemoveWorkspaceMemberResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/response/RemoveWorkspaceMemberResponse.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 
-public record RemoveMemberResponse(
+public record RemoveWorkspaceMemberResponse(
 	/*
 	 * Todo
 	 *  - 추후에 포지션(Position)을 추가하면, 포지션도 응답으로 추가
@@ -13,8 +13,8 @@ public record RemoveMemberResponse(
 	Long workspaceMemberId,
 	LocalDateTime removedAt
 ) {
-	public static RemoveMemberResponse from(Long memberId, WorkspaceMember workspaceMember) {
-		return new RemoveMemberResponse(
+	public static RemoveWorkspaceMemberResponse from(Long memberId, WorkspaceMember workspaceMember) {
+		return new RemoveWorkspaceMemberResponse(
 			memberId,
 			workspaceMember.getId(),
 			workspaceMember.getLastModifiedDate()

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/response/UpdateNicknameResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/response/UpdateNicknameResponse.java
@@ -3,17 +3,16 @@ package com.uranus.taskmanager.api.workspacemember.presentation.dto.response;
 import java.time.LocalDateTime;
 
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
-import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceRole;
 
-public record UpdateMemberRoleResponse(
+public record UpdateNicknameResponse(
 	Long workspaceMemberId,
-	WorkspaceRole role,
+	String nickname,
 	LocalDateTime updatedAt
 ) {
-	public static UpdateMemberRoleResponse from(WorkspaceMember workspaceMember) {
-		return new UpdateMemberRoleResponse(
+	public static UpdateNicknameResponse from(WorkspaceMember workspaceMember) {
+		return new UpdateNicknameResponse(
 			workspaceMember.getId(),
-			workspaceMember.getRole(),
+			workspaceMember.getNickname(),
 			workspaceMember.getLastModifiedDate()
 		);
 	}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/response/UpdateRoleResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/dto/response/UpdateRoleResponse.java
@@ -3,16 +3,17 @@ package com.uranus.taskmanager.api.workspacemember.presentation.dto.response;
 import java.time.LocalDateTime;
 
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
+import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceRole;
 
-public record UpdateMemberNicknameResponse(
+public record UpdateRoleResponse(
 	Long workspaceMemberId,
-	String nickname,
+	WorkspaceRole role,
 	LocalDateTime updatedAt
 ) {
-	public static UpdateMemberNicknameResponse from(WorkspaceMember workspaceMember) {
-		return new UpdateMemberNicknameResponse(
+	public static UpdateRoleResponse from(WorkspaceMember workspaceMember) {
+		return new UpdateRoleResponse(
 			workspaceMember.getId(),
-			workspaceMember.getNickname(),
+			workspaceMember.getRole(),
 			workspaceMember.getLastModifiedDate()
 		);
 	}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/service/command/WorkspaceMemberCommandService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/service/command/WorkspaceMemberCommandService.java
@@ -94,6 +94,29 @@ public class WorkspaceMemberCommandService {
 	}
 
 	@Transactional
+	public AssignPositionResponse assignMemberPosition(
+		String code,
+		Long positionId,
+		Long targetMemberId
+	) {
+		Position position = findPosition(positionId);
+
+		WorkspaceMember target = findWorkspaceMember(code, targetMemberId);
+		target.changePosition(position);
+
+		return AssignPositionResponse.from(target);
+	}
+
+	@Transactional
+	public void removeMemberPosition(
+		String code,
+		Long targetMemberId
+	) {
+		WorkspaceMember target = findWorkspaceMember(code, targetMemberId);
+		target.removePosition();
+	}
+
+	@Transactional
 	public TransferOwnershipResponse transferWorkspaceOwnership(
 		String code,
 		Long targetId,

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/service/command/WorkspaceMemberCommandService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/service/command/WorkspaceMemberCommandService.java
@@ -34,7 +34,7 @@ public class WorkspaceMemberCommandService {
 	private final PositionRepository positionRepository;
 
 	@Transactional
-	public UpdateNicknameResponse updateMemberNickname(
+	public UpdateNicknameResponse updateNickname(
 		String code,
 		Long memberId,
 		UpdateNicknameRequest request

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/service/command/WorkspaceMemberCommandService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/service/command/WorkspaceMemberCommandService.java
@@ -5,16 +5,20 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.uranus.taskmanager.api.position.domain.Position;
+import com.uranus.taskmanager.api.position.domain.repository.PositionRepository;
+import com.uranus.taskmanager.api.position.exception.PositionNotFoundException;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 import com.uranus.taskmanager.api.workspacemember.domain.repository.WorkspaceMemberRepository;
 import com.uranus.taskmanager.api.workspacemember.exception.DuplicateNicknameException;
 import com.uranus.taskmanager.api.workspacemember.exception.MemberNotInWorkspaceException;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateMemberNicknameRequest;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateMemberRoleRequest;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.RemoveMemberResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateNicknameRequest;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateRoleRequest;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.AssignPositionResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.RemoveWorkspaceMemberResponse;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.TransferOwnershipResponse;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateMemberNicknameResponse;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateMemberRoleResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateNicknameResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateRoleResponse;
 import com.uranus.taskmanager.api.workspacemember.validator.WorkspaceMemberValidator;
 
 import lombok.RequiredArgsConstructor;
@@ -27,12 +31,13 @@ public class WorkspaceMemberCommandService {
 
 	private final WorkspaceMemberRepository workspaceMemberRepository;
 	private final WorkspaceMemberValidator workspaceMemberValidator;
+	private final PositionRepository positionRepository;
 
 	@Transactional
-	public UpdateMemberNicknameResponse updateWorkspaceMemberNickname(
+	public UpdateNicknameResponse updateMemberNickname(
 		String code,
 		Long memberId,
-		UpdateMemberNicknameRequest request
+		UpdateNicknameRequest request
 	) {
 		try {
 			WorkspaceMember workspaceMember = findWorkspaceMember(code, memberId);
@@ -40,7 +45,7 @@ public class WorkspaceMemberCommandService {
 			workspaceMember.updateNickname(request.getNickname());
 			workspaceMemberRepository.saveAndFlush(workspaceMember);
 
-			return UpdateMemberNicknameResponse.from(workspaceMember);
+			return UpdateNicknameResponse.from(workspaceMember);
 
 		} catch (DataIntegrityViolationException | ConstraintViolationException e) {
 			log.error("Exception: ", e);
@@ -49,11 +54,11 @@ public class WorkspaceMemberCommandService {
 	}
 
 	@Transactional
-	public UpdateMemberRoleResponse updateWorkspaceMemberRole(
+	public UpdateRoleResponse updateWorkspaceMemberRole(
 		String code,
 		Long targetId,
 		Long requesterId,
-		UpdateMemberRoleRequest request
+		UpdateRoleRequest request
 	) {
 		WorkspaceMember requester = findWorkspaceMember(code, requesterId);
 		WorkspaceMember target = findWorkspaceMember(code, targetId);
@@ -62,7 +67,30 @@ public class WorkspaceMemberCommandService {
 
 		target.updateRole(request.getUpdateWorkspaceRole());
 
-		return UpdateMemberRoleResponse.from(target);
+		return UpdateRoleResponse.from(target);
+	}
+
+	@Transactional
+	public AssignPositionResponse assignPosition(
+		String code,
+		Long positionId,
+		Long loginMemberId
+	) {
+		Position position = findPosition(positionId);
+
+		WorkspaceMember workspaceMember = findWorkspaceMember(code, loginMemberId);
+		workspaceMember.changePosition(position);
+
+		return AssignPositionResponse.from(workspaceMember);
+	}
+
+	@Transactional
+	public void removePosition(
+		String code,
+		Long loginMemberId
+	) {
+		WorkspaceMember workspaceMember = findWorkspaceMember(code, loginMemberId);
+		workspaceMember.removePosition();
 	}
 
 	@Transactional
@@ -81,7 +109,7 @@ public class WorkspaceMemberCommandService {
 	}
 
 	@Transactional
-	public RemoveMemberResponse removeMember(
+	public RemoveWorkspaceMemberResponse removeWorkspaceMember(
 		String code,
 		Long targetId,
 		Long requesterId
@@ -94,12 +122,18 @@ public class WorkspaceMemberCommandService {
 		target.remove();
 		workspaceMemberRepository.delete(target);
 
-		return RemoveMemberResponse.from(targetId, target);
+		return RemoveWorkspaceMemberResponse.from(targetId, target);
 	}
 
 	private WorkspaceMember findWorkspaceMember(String code, Long memberId) {
 		return workspaceMemberRepository
 			.findByMemberIdAndWorkspaceCode(memberId, code)
 			.orElseThrow(MemberNotInWorkspaceException::new);
+	}
+
+	private Position findPosition(Long positionId) {
+		return positionRepository
+			.findById(positionId)
+			.orElseThrow(PositionNotFoundException::new);
 	}
 }

--- a/src/test/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberInfoControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberInfoControllerTest.java
@@ -17,7 +17,7 @@ class WorkspaceMemberInfoControllerTest extends ControllerTestHelper {
 	private static final String BASE_URL = "/api/v1/workspaces/{code}/members";
 
 	@Test
-	@DisplayName("PATCH /workspaces/{code}/members/positions/{positionId} - Position 할당을 성공하면 OK 응답")
+	@DisplayName("PATCH /workspaces/{code}/members/positions/{positionId} - 내 Position 할당을 성공하면 OK 응답")
 	void assignPosition_Success() throws Exception {
 		// Given
 		String workspaceCode = "TESTCODE";
@@ -46,7 +46,7 @@ class WorkspaceMemberInfoControllerTest extends ControllerTestHelper {
 	}
 
 	@Test
-	@DisplayName("PATCH /workspaces/{code}/members/positions - Position 해제를 성공하면 OK 응답, 응답 데이터 없음")
+	@DisplayName("PATCH /workspaces/{code}/members/positions - 내 Position 해제를 성공하면 OK 응답, 응답 데이터 없음")
 	void removePosition_Success() throws Exception {
 		// Given
 		String workspaceCode = "TESTCODE";
@@ -59,5 +59,36 @@ class WorkspaceMemberInfoControllerTest extends ControllerTestHelper {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.message").value("Position removed from member."))
 			.andExpect(jsonPath("$.data").doesNotExist());
+	}
+
+	@Test
+	@DisplayName("PATCH /workspaces/{code}/members/{memberId}/positions/{positionId} - 다른 멤버의 Position 할당을 성공하면 OK 응답")
+	void assignMemberPosition_Success() throws Exception {
+		// Given
+		String workspaceCode = "TESTCODE";
+		Long positionId = 1L;
+
+		Long targetMemberId = 2L;
+
+		AssignPositionResponse response = new AssignPositionResponse(
+			2L,
+			"Developer",
+			LocalDateTime.now()
+		);
+
+		when(workspaceMemberCommandService.assignMemberPosition(
+			workspaceCode,
+			positionId,
+			targetMemberId
+		))
+			.thenReturn(response);
+
+		// When & Then
+		mockMvc.perform(
+				patch(BASE_URL + "/{memberId}/positions/{positionId}", workspaceCode, targetMemberId, positionId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("Position assigned to member."))
+			.andExpect(jsonPath("$.data.workspaceMemberId").value(2))
+			.andExpect(jsonPath("$.data.assignedPosition").value("Developer"));
 	}
 }

--- a/src/test/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberInfoControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberInfoControllerTest.java
@@ -1,0 +1,63 @@
+package com.uranus.taskmanager.api.workspacemember.presentation.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.AssignPositionResponse;
+import com.uranus.taskmanager.helper.ControllerTestHelper;
+
+class WorkspaceMemberInfoControllerTest extends ControllerTestHelper {
+
+	private static final String BASE_URL = "/api/v1/workspaces/{code}/members";
+
+	@Test
+	@DisplayName("PATCH /workspaces/{code}/members/positions/{positionId} - Position 할당을 성공하면 OK 응답")
+	void assignPosition_Success() throws Exception {
+		// Given
+		String workspaceCode = "TESTCODE";
+		Long loginMemberId = 1L;
+		Long positionId = 1L;
+
+		AssignPositionResponse response = new AssignPositionResponse(
+			1L,
+			"Developer",
+			LocalDateTime.now()
+		);
+
+		when(workspaceMemberCommandService.assignPosition(
+			workspaceCode,
+			positionId,
+			loginMemberId
+		))
+			.thenReturn(response);
+
+		// When & Then
+		mockMvc.perform(patch(BASE_URL + "/positions/{positionId}", workspaceCode, positionId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("Position assigned to member."))
+			.andExpect(jsonPath("$.data.workspaceMemberId").value(1))
+			.andExpect(jsonPath("$.data.assignedPosition").value("Developer"));
+	}
+
+	@Test
+	@DisplayName("PATCH /workspaces/{code}/members/positions - Position 해제를 성공하면 OK 응답, 응답 데이터 없음")
+	void removePosition_Success() throws Exception {
+		// Given
+		String workspaceCode = "TESTCODE";
+		Long loginMemberId = 1L;
+
+		doNothing().when(workspaceMemberCommandService).removePosition(workspaceCode, loginMemberId);
+
+		// When & Then
+		mockMvc.perform(patch(BASE_URL + "/positions", workspaceCode))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("Position removed from member."))
+			.andExpect(jsonPath("$.data").doesNotExist());
+	}
+}

--- a/src/test/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMembershipControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMembershipControllerTest.java
@@ -24,12 +24,12 @@ import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceMember;
 import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceRole;
 import com.uranus.taskmanager.api.workspacemember.exception.NoValidMembersToInviteException;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.InviteMembersRequest;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateMemberNicknameRequest;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateMemberRoleRequest;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateNicknameRequest;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateRoleRequest;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.InviteMembersResponse;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.RemoveMemberResponse;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateMemberNicknameResponse;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateMemberRoleResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.RemoveWorkspaceMemberResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateNicknameResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateRoleResponse;
 import com.uranus.taskmanager.fixture.entity.MemberEntityFixture;
 import com.uranus.taskmanager.fixture.entity.WorkspaceEntityFixture;
 import com.uranus.taskmanager.fixture.entity.WorkspaceMemberEntityFixture;
@@ -63,9 +63,9 @@ class WorkspaceMembershipControllerTest extends ControllerTestHelper {
 		WorkspaceMember workspaceMember = workspaceMemberEntityFixture
 			.createCollaboratorWorkspaceMember(member, workspace);
 
-		RemoveMemberResponse response = RemoveMemberResponse.from(2L, workspaceMember);
+		RemoveWorkspaceMemberResponse response = RemoveWorkspaceMemberResponse.from(2L, workspaceMember);
 
-		when(workspaceMemberCommandService.removeMember(eq(workspaceCode), eq(2L), anyLong()))
+		when(workspaceMemberCommandService.removeWorkspaceMember(eq(workspaceCode), eq(2L), anyLong()))
 			.thenReturn(response);
 
 		// when & then
@@ -99,12 +99,12 @@ class WorkspaceMembershipControllerTest extends ControllerTestHelper {
 		);
 		workspaceMember.updateNickname("newNickname");
 
-		UpdateMemberNicknameResponse response = UpdateMemberNicknameResponse.from(workspaceMember);
+		UpdateNicknameResponse response = UpdateNicknameResponse.from(workspaceMember);
 
-		when(workspaceMemberCommandService.updateWorkspaceMemberNickname(
+		when(workspaceMemberCommandService.updateNickname(
 			eq(workspaceCode),
 			eq(1L),
-			any(UpdateMemberNicknameRequest.class))
+			any(UpdateNicknameRequest.class))
 		)
 			.thenReturn(response);
 
@@ -112,7 +112,7 @@ class WorkspaceMembershipControllerTest extends ControllerTestHelper {
 		mockMvc.perform(patch("/api/v1/workspaces/{code}/members/nickname", workspaceCode)
 				.session(session)
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(new UpdateMemberNicknameRequest("newNickname"))))
+				.content(objectMapper.writeValueAsString(new UpdateNicknameRequest("newNickname"))))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.message").value("Nickname updated."))
 			.andExpect(jsonPath("$.data.nickname").value("newNickname"))
@@ -129,7 +129,7 @@ class WorkspaceMembershipControllerTest extends ControllerTestHelper {
 		// given
 		String workspaceCode = "TESTCODE";
 
-		UpdateMemberRoleRequest request = new UpdateMemberRoleRequest(WorkspaceRole.MANAGER);
+		UpdateRoleRequest request = new UpdateRoleRequest(WorkspaceRole.MANAGER);
 
 		WorkspaceMember target = workspaceMemberEntityFixture.createManagerWorkspaceMember(
 			Member.builder()
@@ -140,13 +140,13 @@ class WorkspaceMembershipControllerTest extends ControllerTestHelper {
 				.build()
 		);
 
-		UpdateMemberRoleResponse response = UpdateMemberRoleResponse.from(target);
+		UpdateRoleResponse response = UpdateRoleResponse.from(target);
 
 		when(workspaceMemberCommandService.updateWorkspaceMemberRole(
 			eq(workspaceCode),
 			anyLong(),
 			anyLong(),
-			any(UpdateMemberRoleRequest.class))
+			any(UpdateRoleRequest.class))
 		).thenReturn(response);
 
 		// when & then
@@ -169,7 +169,7 @@ class WorkspaceMembershipControllerTest extends ControllerTestHelper {
 		// given
 		String workspaceCode = "TESTCODE";
 
-		UpdateMemberRoleRequest request = new UpdateMemberRoleRequest(WorkspaceRole.MANAGER);
+		UpdateRoleRequest request = new UpdateRoleRequest(WorkspaceRole.MANAGER);
 
 		WorkspaceMember target = workspaceMemberEntityFixture.createManagerWorkspaceMember(
 			Member.builder()
@@ -181,13 +181,13 @@ class WorkspaceMembershipControllerTest extends ControllerTestHelper {
 				.build()
 		);
 
-		UpdateMemberRoleResponse response = UpdateMemberRoleResponse.from(target);
+		UpdateRoleResponse response = UpdateRoleResponse.from(target);
 
 		when(workspaceMemberCommandService.updateWorkspaceMemberRole(
 			eq(workspaceCode),
 			anyLong(),
 			anyLong(),
-			any(UpdateMemberRoleRequest.class))
+			any(UpdateRoleRequest.class))
 		).thenReturn(response);
 
 		// when & then

--- a/src/test/java/com/uranus/taskmanager/api/workspacemember/service/command/WorkspaceMemberCommandServiceIT.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspacemember/service/command/WorkspaceMemberCommandServiceIT.java
@@ -14,12 +14,12 @@ import com.uranus.taskmanager.api.workspacemember.domain.WorkspaceRole;
 import com.uranus.taskmanager.api.workspacemember.exception.DuplicateNicknameException;
 import com.uranus.taskmanager.api.workspacemember.exception.InvalidRoleUpdateException;
 import com.uranus.taskmanager.api.workspacemember.exception.MemberNotInWorkspaceException;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateMemberNicknameRequest;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateMemberRoleRequest;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.RemoveMemberResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateNicknameRequest;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.request.UpdateRoleRequest;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.RemoveWorkspaceMemberResponse;
 import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.TransferOwnershipResponse;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateMemberNicknameResponse;
-import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateMemberRoleResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateNicknameResponse;
+import com.uranus.taskmanager.api.workspacemember.presentation.dto.response.UpdateRoleResponse;
 import com.uranus.taskmanager.helper.ServiceIntegrationTestHelper;
 
 class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
@@ -64,7 +64,8 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 		workspaceRepositoryFixture.addAndSaveMemberToWorkspace(target, workspace, WorkspaceRole.COLLABORATOR);
 
 		// when
-		RemoveMemberResponse response = workspaceMemberCommandService.removeMember("TESTCODE", target.getId(),
+		RemoveWorkspaceMemberResponse response = workspaceMemberCommandService.removeWorkspaceMember("TESTCODE",
+			target.getId(),
 			requester.getId());
 
 		// then
@@ -97,7 +98,7 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceMemberCommandService.removeMember("TESTCODE", nonExistMemberId, requester.getId()))
+			() -> workspaceMemberCommandService.removeWorkspaceMember("TESTCODE", nonExistMemberId, requester.getId()))
 			.isInstanceOf(MemberNotInWorkspaceException.class);
 	}
 
@@ -127,7 +128,8 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 
 		// when & then
 		assertThatThrownBy(
-			() -> workspaceMemberCommandService.removeMember("TESTCODE", nonWorkspaceMember.getId(), requester.getId()))
+			() -> workspaceMemberCommandService.removeWorkspaceMember("TESTCODE", nonWorkspaceMember.getId(),
+				requester.getId()))
 			.isInstanceOf(MemberNotInWorkspaceException.class);
 	}
 
@@ -171,10 +173,10 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 		);
 		workspaceMemberRepository.save(targetWorkspaceMember);
 
-		UpdateMemberRoleRequest request = new UpdateMemberRoleRequest(WorkspaceRole.MANAGER);
+		UpdateRoleRequest request = new UpdateRoleRequest(WorkspaceRole.MANAGER);
 
 		// when
-		UpdateMemberRoleResponse response = workspaceMemberCommandService.updateWorkspaceMemberRole(
+		UpdateRoleResponse response = workspaceMemberCommandService.updateWorkspaceMemberRole(
 			"TESTCODE",
 			targetMember.getId(),
 			requester.getId(),
@@ -212,7 +214,7 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 		workspaceMemberRepository.save(requesterWorkspaceMember);
 
 		// when & then
-		UpdateMemberRoleRequest request = new UpdateMemberRoleRequest(WorkspaceRole.MANAGER);
+		UpdateRoleRequest request = new UpdateRoleRequest(WorkspaceRole.MANAGER);
 
 		assertThatThrownBy(() -> workspaceMemberCommandService.updateWorkspaceMemberRole(
 			"TESTCODE",
@@ -264,7 +266,7 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 		workspaceMemberRepository.save(targetWorkspaceMember);
 
 		// when & then
-		UpdateMemberRoleRequest request = new UpdateMemberRoleRequest(WorkspaceRole.OWNER);
+		UpdateRoleRequest request = new UpdateRoleRequest(WorkspaceRole.OWNER);
 
 		assertThatThrownBy(() ->
 			workspaceMemberCommandService.updateWorkspaceMemberRole(
@@ -317,7 +319,7 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 		workspaceMemberRepository.save(targetWorkspaceMember);
 
 		// when & then
-		UpdateMemberRoleRequest request = new UpdateMemberRoleRequest(WorkspaceRole.MANAGER);
+		UpdateRoleRequest request = new UpdateRoleRequest(WorkspaceRole.MANAGER);
 
 		assertThatThrownBy(() ->
 			workspaceMemberCommandService.updateWorkspaceMemberRole(
@@ -370,7 +372,7 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 		workspaceMemberRepository.save(targetWorkspaceMember);
 
 		// when & then
-		UpdateMemberRoleRequest request = new UpdateMemberRoleRequest(WorkspaceRole.OWNER);
+		UpdateRoleRequest request = new UpdateRoleRequest(WorkspaceRole.OWNER);
 
 		assertThatThrownBy(() ->
 			workspaceMemberCommandService.updateWorkspaceMemberRole(
@@ -453,10 +455,10 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 		);
 
 		String newNickname = "newNickname";
-		UpdateMemberNicknameRequest request = new UpdateMemberNicknameRequest(newNickname);
+		UpdateNicknameRequest request = new UpdateNicknameRequest(newNickname);
 
 		// when
-		UpdateMemberNicknameResponse response = workspaceMemberCommandService.updateWorkspaceMemberNickname(
+		UpdateNicknameResponse response = workspaceMemberCommandService.updateNickname(
 			workspace.getCode(),
 			tester.getId(),
 			request
@@ -507,10 +509,10 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 		);
 
 		String existingNickname = "existingNickname";
-		UpdateMemberNicknameRequest request = new UpdateMemberNicknameRequest(existingNickname);
+		UpdateNicknameRequest request = new UpdateNicknameRequest(existingNickname);
 
 		// when & then
-		assertThatThrownBy(() -> workspaceMemberCommandService.updateWorkspaceMemberNickname(
+		assertThatThrownBy(() -> workspaceMemberCommandService.updateNickname(
 			workspace.getCode(),
 			tester.getId(),
 			request

--- a/src/test/java/com/uranus/taskmanager/fixture/repository/PositionRepositoryFixture.java
+++ b/src/test/java/com/uranus/taskmanager/fixture/repository/PositionRepositoryFixture.java
@@ -1,0 +1,28 @@
+package com.uranus.taskmanager.fixture.repository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.uranus.taskmanager.api.common.ColorType;
+import com.uranus.taskmanager.api.position.domain.Position;
+import com.uranus.taskmanager.api.position.domain.repository.PositionRepository;
+import com.uranus.taskmanager.api.workspace.domain.Workspace;
+
+@Component
+@Transactional
+public class PositionRepositoryFixture {
+
+	@Autowired
+	private PositionRepository positionRepository;
+
+	public Position createAndSavePosition(String name, Workspace workspace) {
+		Position position = Position.builder()
+			.name(name)
+			.color(ColorType.BLACK)
+			.description("This is a test position")
+			.workspace(workspace)
+			.build();
+		return positionRepository.save(position);
+	}
+}

--- a/src/test/java/com/uranus/taskmanager/helper/ControllerTestHelper.java
+++ b/src/test/java/com/uranus/taskmanager/helper/ControllerTestHelper.java
@@ -34,6 +34,7 @@ import com.uranus.taskmanager.api.workspace.service.command.WorkspaceCommandServ
 import com.uranus.taskmanager.api.workspace.service.command.create.CheckCodeDuplicationService;
 import com.uranus.taskmanager.api.workspace.service.query.WorkspaceQueryService;
 import com.uranus.taskmanager.api.workspacemember.domain.repository.WorkspaceMemberRepository;
+import com.uranus.taskmanager.api.workspacemember.presentation.controller.WorkspaceMemberInfoController;
 import com.uranus.taskmanager.api.workspacemember.presentation.controller.WorkspaceMembershipController;
 import com.uranus.taskmanager.api.workspacemember.presentation.controller.WorkspaceParticipationController;
 import com.uranus.taskmanager.api.workspacemember.service.command.WorkspaceMemberCommandService;
@@ -52,6 +53,7 @@ import lombok.extern.slf4j.Slf4j;
 		WorkspaceController.class,
 		WorkspaceMembershipController.class,
 		WorkspaceParticipationController.class,
+		WorkspaceMemberInfoController.class,
 		MemberController.class,
 		PositionController.class
 	},

--- a/src/test/java/com/uranus/taskmanager/helper/ServiceIntegrationTestHelper.java
+++ b/src/test/java/com/uranus/taskmanager/helper/ServiceIntegrationTestHelper.java
@@ -26,6 +26,7 @@ import com.uranus.taskmanager.api.workspacemember.service.query.WorkspacePartici
 import com.uranus.taskmanager.fixture.dto.SignupRequestDtoFixture;
 import com.uranus.taskmanager.fixture.repository.InvitationRepositoryFixture;
 import com.uranus.taskmanager.fixture.repository.MemberRepositoryFixture;
+import com.uranus.taskmanager.fixture.repository.PositionRepositoryFixture;
 import com.uranus.taskmanager.fixture.repository.WorkspaceRepositoryFixture;
 import com.uranus.taskmanager.util.DatabaseCleaner;
 
@@ -101,5 +102,7 @@ public abstract class ServiceIntegrationTestHelper {
 	protected InvitationRepositoryFixture invitationRepositoryFixture;
 	@Autowired
 	protected SignupRequestDtoFixture signupRequestDtoFixture;
+	@Autowired
+	protected PositionRepositoryFixture positionRepositoryFixture;
 
 }


### PR DESCRIPTION
## 🚀 설명
- 워크스페이스 멤버의 포지션을 할당/해제하는 기능을 구현한다
- 자기의 포지션 할당/해제
- 특정 권한 이상을 가진 워크스페이스 멤버가 다른 워크스페이스 멤버의 포지션을 할당/해제

---
## ✅ 변경 사항
- [x] 내 포지션 할당/해제
- [x] 남의 포지션 할당/해제
- [x] 테스트 추가

---
## 🚩 관련 이슈, PR
- #120 

---
## 📖 참고