### PR TITLE
Refactor/#126 `assign/removePosition`을 재사용하도록 수정

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberInfoController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberInfoController.java
@@ -104,7 +104,7 @@ public class WorkspaceMemberInfoController {
 		@PathVariable Long memberId,
 		@PathVariable Long positionId
 	) {
-		AssignPositionResponse response = workspaceMemberCommandService.assignMemberPosition(
+		AssignPositionResponse response = workspaceMemberCommandService.assignPosition(
 			code,
 			positionId,
 			memberId
@@ -119,7 +119,7 @@ public class WorkspaceMemberInfoController {
 		@PathVariable String code,
 		@PathVariable Long memberId
 	) {
-		workspaceMemberCommandService.removeMemberPosition(
+		workspaceMemberCommandService.removePosition(
 			code,
 			memberId
 		);

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/service/command/WorkspaceMemberCommandService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/service/command/WorkspaceMemberCommandService.java
@@ -74,11 +74,11 @@ public class WorkspaceMemberCommandService {
 	public AssignPositionResponse assignPosition(
 		String code,
 		Long positionId,
-		Long loginMemberId
+		Long memberId
 	) {
 		Position position = findPosition(positionId);
 
-		WorkspaceMember workspaceMember = findWorkspaceMember(code, loginMemberId);
+		WorkspaceMember workspaceMember = findWorkspaceMember(code, memberId);
 		workspaceMember.changePosition(position);
 
 		return AssignPositionResponse.from(workspaceMember);
@@ -87,33 +87,10 @@ public class WorkspaceMemberCommandService {
 	@Transactional
 	public void removePosition(
 		String code,
-		Long loginMemberId
+		Long memberId
 	) {
-		WorkspaceMember workspaceMember = findWorkspaceMember(code, loginMemberId);
+		WorkspaceMember workspaceMember = findWorkspaceMember(code, memberId);
 		workspaceMember.removePosition();
-	}
-
-	@Transactional
-	public AssignPositionResponse assignMemberPosition(
-		String code,
-		Long positionId,
-		Long targetMemberId
-	) {
-		Position position = findPosition(positionId);
-
-		WorkspaceMember target = findWorkspaceMember(code, targetMemberId);
-		target.changePosition(position);
-
-		return AssignPositionResponse.from(target);
-	}
-
-	@Transactional
-	public void removeMemberPosition(
-		String code,
-		Long targetMemberId
-	) {
-		WorkspaceMember target = findWorkspaceMember(code, targetMemberId);
-		target.removePosition();
 	}
 
 	@Transactional

--- a/src/test/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberInfoControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMemberInfoControllerTest.java
@@ -76,7 +76,7 @@ class WorkspaceMemberInfoControllerTest extends ControllerTestHelper {
 			LocalDateTime.now()
 		);
 
-		when(workspaceMemberCommandService.assignMemberPosition(
+		when(workspaceMemberCommandService.assignPosition(
 			workspaceCode,
 			positionId,
 			targetMemberId


### PR DESCRIPTION
## 🚀 설명
- `assign/removePosition` 서비스 메서드 재사용
- `assign/removeMemberPosition`은 삭제

---
## ✅ 변경 사항
- [x] `assign/removePosition` 서비스 메서드 재사용

---
## 🚩 관련 이슈, PR
- #126 

---
## 📖 참고