### PR TITLE
Feat/#125 워크스페이스 권한 레벨 추가

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/member/presentation/controller/MemberController.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/presentation/controller/MemberController.java
@@ -40,8 +40,6 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
 	/**
 	 * Todo
-	 *  - 회원 정보 조회
-	 *    - 나의 이메일, 비밀번호, 가입 날짜
 	 *  - 비밀번호 찾기 (세션 불필요)
 	 * 	  - 가입한 이메일, 로그인 ID를 통한 비밀번호 찾기
 	 * 	  - 기입한 로그인 ID, 이메일이 일치하면 이메일로 임시 비밀번호 보내기

--- a/src/main/java/com/uranus/taskmanager/api/workspace/presentation/controller/WorkspaceController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/presentation/controller/WorkspaceController.java
@@ -49,7 +49,6 @@ public class WorkspaceController {
 		@ResolveLoginMember Long loginMemberId,
 		@RequestBody @Valid CreateWorkspaceRequest request
 	) {
-
 		CreateWorkspaceResponse response = workspaceCreateService.createWorkspace(
 			request,
 			loginMemberId
@@ -58,13 +57,12 @@ public class WorkspaceController {
 	}
 
 	@LoginRequired
-	@RoleRequired(roles = WorkspaceRole.MANAGER)
+	@RoleRequired(roles = WorkspaceRole.ADMIN)
 	@PatchMapping("/{code}/info")
 	public ApiResponse<UpdateWorkspaceInfoResponse> updateWorkspaceInfo(
 		@PathVariable String code,
 		@RequestBody @Valid UpdateWorkspaceInfoRequest request
 	) {
-
 		UpdateWorkspaceInfoResponse response = workspaceCommandService.updateWorkspaceInfo(
 			request,
 			code
@@ -73,13 +71,12 @@ public class WorkspaceController {
 	}
 
 	@LoginRequired
-	@RoleRequired(roles = WorkspaceRole.MANAGER)
+	@RoleRequired(roles = WorkspaceRole.ADMIN)
 	@PatchMapping("/{code}/password")
 	public ApiResponse<Void> updateWorkspacePassword(
 		@PathVariable String code,
 		@RequestBody @Valid UpdateWorkspacePasswordRequest request
 	) {
-
 		workspaceCommandService.updateWorkspacePassword(
 			request,
 			code
@@ -95,7 +92,6 @@ public class WorkspaceController {
 		@ResolveLoginMember Long loginMemberId,
 		@RequestBody DeleteWorkspaceRequest request
 	) {
-
 		DeleteWorkspaceResponse response = workspaceCommandService.deleteWorkspace(
 			request,
 			code,
@@ -110,7 +106,6 @@ public class WorkspaceController {
 	public ApiResponse<WorkspaceDetail> getWorkspaceDetail(
 		@PathVariable String code
 	) {
-
 		WorkspaceDetail response = workspaceQueryService.getWorkspaceDetail(code);
 		return ApiResponse.ok("Workspace found.", response);
 	}

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/domain/WorkspaceMember.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/domain/WorkspaceMember.java
@@ -122,9 +122,9 @@ public class WorkspaceMember extends BaseEntity {
 		this.role = role;
 	}
 
-	public void updateRoleFromOwnerToManager() {
+	public void updateRoleFromOwnerToAdmin() {
 		validateCurrentRoleIsOwner();
-		updateRole(WorkspaceRole.MANAGER);
+		updateRole(WorkspaceRole.ADMIN);
 		this.member.decreaseMyWorkspaceCount();
 	}
 

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/domain/WorkspaceRole.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/domain/WorkspaceRole.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum WorkspaceRole {
-	OWNER(4),
+	OWNER(5),
+	ADMIN(4),
 	MANAGER(3),
 	COLLABORATOR(2),
 	VIEWER(1);

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMembershipController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceMembershipController.java
@@ -43,7 +43,7 @@ public class WorkspaceMembershipController {
 	 */
 
 	@LoginRequired
-	@RoleRequired(roles = {WorkspaceRole.MANAGER})
+	@RoleRequired(roles = {WorkspaceRole.COLLABORATOR})
 	@PostMapping("/invite")
 	public ApiResponse<InviteMembersResponse> inviteMembers(
 		@PathVariable String code,
@@ -57,7 +57,7 @@ public class WorkspaceMembershipController {
 	}
 
 	@LoginRequired
-	@RoleRequired(roles = {WorkspaceRole.MANAGER})
+	@RoleRequired(roles = {WorkspaceRole.ADMIN})
 	@PatchMapping("/{memberId}/role")
 	public ApiResponse<UpdateRoleResponse> updateMemberRole(
 		@PathVariable String code,
@@ -91,7 +91,7 @@ public class WorkspaceMembershipController {
 	}
 
 	@LoginRequired
-	@RoleRequired(roles = {WorkspaceRole.MANAGER})
+	@RoleRequired(roles = {WorkspaceRole.ADMIN})
 	@DeleteMapping("/{memberId}")
 	public ApiResponse<RemoveWorkspaceMemberResponse> removeWorkspaceMember(
 		@PathVariable String code,

--- a/src/main/java/com/uranus/taskmanager/api/workspacemember/service/command/WorkspaceMemberCommandService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspacemember/service/command/WorkspaceMemberCommandService.java
@@ -102,7 +102,7 @@ public class WorkspaceMemberCommandService {
 		WorkspaceMember requester = findWorkspaceMember(code, requesterId);
 		WorkspaceMember target = findWorkspaceMember(code, targetId);
 
-		requester.updateRoleFromOwnerToManager();
+		requester.updateRoleFromOwnerToAdmin();
 		target.updateRoleToOwner();
 
 		return TransferOwnershipResponse.from(requester, target);


### PR DESCRIPTION
## 🚀 설명
- 권한을 더 세분화 하고 싶어서 `OWNER`와 `MANAGER` 사이에 `ADMIN` 권한 레벨 추가

---
## ✅ 변경 사항
- [x] `ADMIN` 권한 레벨 추가
- [x] 변경된 권한을 기준으로 다시 API 권한 정리

---
## 🚩 관련 이슈, PR
- #125 

---
## 📖 참고