### PR TITLE
Feat/#130 `Issue` 엔티티 추가

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/issue/domain/Issue.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/domain/Issue.java
@@ -1,0 +1,120 @@
+package com.uranus.taskmanager.api.issue.domain;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.uranus.taskmanager.api.common.entity.BaseEntity;
+import com.uranus.taskmanager.api.workspace.domain.Workspace;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Issue extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "WORKSPACE_ID", nullable = false)
+	private Workspace workspace;
+
+	@Column(name = "WORKSPACE_CODE", nullable = false)
+	private String workspaceCode;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private IssueType type; // Default: TASK
+
+	@Column(nullable = false)
+	private String title;
+
+	@Lob
+	@Column(nullable = false)
+	private String description;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private IssueStatus status; // Default: TODO
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private IssuePriority priority;  // Default: Medium
+
+	private LocalDateTime startedAt; // different from createdAt, must be updated implicitly
+	private LocalDateTime finishedAt; // updated when status change to DONE
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "PARENT_ISSUE_ID")
+	private Issue parentIssue;  // Epic의 하위 Story, Task의 하위 Sub-Task 등
+
+	@OneToMany(mappedBy = "parentIssue")
+	private List<Issue> childIssues = new ArrayList<>();
+
+	@Builder
+	public Issue(
+		Workspace workspace,
+		IssueType type,
+		String title,
+		String description,
+		IssuePriority priority,
+		LocalDateTime startedAt,
+		LocalDateTime finishedAt,
+		Issue parentIssue
+	) {
+		this.workspace = workspace;
+		this.workspaceCode = workspace.getCode();
+		this.type = type != null ? type : IssueType.TASK;
+		this.title = title;
+		this.description = description;
+		this.status = IssueStatus.TODO;
+		this.priority = priority != null ? priority : IssuePriority.MEDIUM;
+		this.startedAt = startedAt;
+		this.finishedAt = finishedAt;
+		if (parentIssue != null) {
+			validateParentIssue(parentIssue);
+			this.parentIssue = parentIssue;
+			parentIssue.getChildIssues().add(this);
+		}
+	}
+
+	private void validateParentIssue(Issue parentIssue) {
+		// 동일한 워크스페이스에 속하는지 검증
+		if (!parentIssue.getWorkspaceCode().equals(this.workspaceCode)) {
+			// Todo: 커스텀 예외 만들기, ParentIssueNotSameWorkspaceException
+			throw new IllegalArgumentException("Parent issue must belong to the same workspace");
+		}
+
+		// 이슈 타입에 따른 부모-자식 관계 검증
+		if (this.type == IssueType.SUB_TASK
+			&& (parentIssue.getType() == IssueType.EPIC || parentIssue.getType() == IssueType.SUB_TASK)
+		) {
+			// Todo: SubTaskWrongParentTypeException
+			throw new IllegalArgumentException("Sub-tasks can only have Story, Task, or Bug as parent");
+		}
+
+		if (this.type != IssueType.SUB_TASK &&
+			parentIssue.getType() != IssueType.EPIC) {
+			// Todo: WrongChildIssueTypeException
+			throw new IllegalArgumentException("Only Epic can have non-subtask children");
+		}
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/issue/domain/IssuePriority.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/domain/IssuePriority.java
@@ -1,0 +1,17 @@
+package com.uranus.taskmanager.api.issue.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum IssuePriority {
+	EMERGENCY(6),
+	HIGHEST(5),
+	HIGH(4),
+	MEDIUM(3),
+	LOW(2),
+	LOWEST(1);
+
+	private final int level;
+}

--- a/src/main/java/com/uranus/taskmanager/api/issue/domain/IssueStatus.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/domain/IssueStatus.java
@@ -1,0 +1,9 @@
+package com.uranus.taskmanager.api.issue.domain;
+
+public enum IssueStatus {
+	TODO,
+	IN_PROGRESS,
+	IN_REVIEW,
+	DONE,
+	PAUSED
+}

--- a/src/main/java/com/uranus/taskmanager/api/issue/domain/IssueType.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/domain/IssueType.java
@@ -1,0 +1,9 @@
+package com.uranus.taskmanager.api.issue.domain;
+
+public enum IssueType {
+	EPIC,
+	STORY,
+	TASK,
+	BUG,
+	SUB_TASK
+}

--- a/src/main/java/com/uranus/taskmanager/api/member/presentation/controller/MemberController.java
+++ b/src/main/java/com/uranus/taskmanager/api/member/presentation/controller/MemberController.java
@@ -44,6 +44,8 @@ public class MemberController {
 	 * 	  - 가입한 이메일, 로그인 ID를 통한 비밀번호 찾기
 	 * 	  - 기입한 로그인 ID, 이메일이 일치하면 이메일로 임시 비밀번호 보내기
 	 * 	  - 또는 비밀번호 재설정 링크 보내기
+	 * 	- 회원 가입 시, 이메일 확인 로직 필요(이메일로 확인 이메일 보내기)
+	 *  - 이메일 업데이트 시, 이메일로 확인(검증) 이메일 보내기
 	 */
 	private final MemberCommandService memberCommandService;
 	private final MemberQueryService memberQueryService;

--- a/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/domain/Workspace.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.uranus.taskmanager.api.common.ColorType;
 import com.uranus.taskmanager.api.common.entity.BaseEntity;
 import com.uranus.taskmanager.api.invitation.domain.Invitation;
+import com.uranus.taskmanager.api.issue.domain.Issue;
 import com.uranus.taskmanager.api.position.domain.Position;
 import com.uranus.taskmanager.api.workspace.exception.InvalidMemberCountException;
 import com.uranus.taskmanager.api.workspace.exception.WorkspaceMemberLimitExceededException;
@@ -70,6 +71,9 @@ public class Workspace extends BaseEntity {
 
 	@OneToMany(mappedBy = "workspace", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Invitation> invitations = new ArrayList<>();
+
+	@OneToMany(mappedBy = "workspace", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Issue> issues = new ArrayList<>();
 
 	@Builder
 	public Workspace(String code, String name, String description, String password) {

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <!-- Development -->
+    <springProfile name="local">
+        <!-- ConsoleAppender -->
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss} [%-5level] [%thread] %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+    <!-- Development -->
     <springProfile name="dev">
         <!-- ConsoleAppender -->
         <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -9,7 +21,7 @@
             </encoder>
         </appender>
         <root level="INFO">
-            <appender-ref ref="CONSOLE" />
+            <appender-ref ref="CONSOLE"/>
         </root>
     </springProfile>
     <!-- Production -->
@@ -26,7 +38,7 @@
             </encoder>
         </appender>
         <root level="INFO">
-            <appender-ref ref="FILE" />
+            <appender-ref ref="FILE"/>
         </root>
     </springProfile>
 


### PR DESCRIPTION
## 🚀 설명
- `Issue` 엔티티 추가
- 필요한 `enum` 추가
  - `IssuePriority`: 우선순위
  - `IssueStatus`: 현재 상태
  - `IssueType`: 이슈의 종류(`EPIC`, `STORY`, `TASK`, `BUG`, `SUB_TASK`)
- `local` 프로필에서는 콘솔에 로그가 출력되도록 설정

---
## ✅ 변경 사항
- [x] `Issue` 추가
- [x] `IssuePriority` 추가
- [x] `IssueStatus` 추가
- [x] `IssueType` 추가
- [x] 콘솔에 로그가 출력되도록 설정

---
## 🚩 관련 이슈, PR
- #130 

---
## 📖 참고