### PR TITLE
Feat/#133 `SessionAuditorAware`가 멤버의 id를 반환하도록 수정

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/common/entity/BaseEntity.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/entity/BaseEntity.java
@@ -16,7 +16,7 @@ public abstract class BaseEntity extends BaseDateEntity {
 
 	@CreatedBy
 	@Column(updatable = false)
-	private String createdBy;
+	private Long createdBy;
 	@LastModifiedBy
-	private String lastModifiedBy;
+	private Long lastModifiedBy;
 }

--- a/src/main/java/com/uranus/taskmanager/api/global/audit/SessionAuditorAware.java
+++ b/src/main/java/com/uranus/taskmanager/api/global/audit/SessionAuditorAware.java
@@ -12,12 +12,12 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class SessionAuditorAware implements AuditorAware<String> {
+public class SessionAuditorAware implements AuditorAware<Long> {
 	private final HttpSession session;
 
 	@Override
-	public Optional<String> getCurrentAuditor() {
-		String loginId = (String)session.getAttribute(SessionAttributes.LOGIN_MEMBER_LOGIN_ID);
-		return Optional.ofNullable(loginId);
+	public Optional<Long> getCurrentAuditor() {
+		Long loginMemberId = (Long)session.getAttribute(SessionAttributes.LOGIN_MEMBER_ID);
+		return Optional.ofNullable(loginMemberId);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/invitation/presentation/dto/response/InvitationResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/invitation/presentation/dto/response/InvitationResponse.java
@@ -8,7 +8,7 @@ import com.uranus.taskmanager.api.invitation.domain.InvitationStatus;
 public record InvitationResponse(
 	Long invitationId,
 	String workspaceCode,
-	String inviter,
+	Long invitedBy,
 	InvitationStatus status,
 	LocalDateTime invitedAt
 ) {

--- a/src/main/java/com/uranus/taskmanager/api/security/session/SessionAttributes.java
+++ b/src/main/java/com/uranus/taskmanager/api/security/session/SessionAttributes.java
@@ -14,6 +14,12 @@ public final class SessionAttributes {
 	public static final String UPDATE_AUTH = "UPDATE_AUTH";
 	public static final String UPDATE_AUTH_EXPIRES_AT = "UPDATE_AUTH_EXPIRES_AT";
 
+	/**
+	 * Session Audit related
+	 */
+	public static final String CURRENT_WORKSPACE_CODE = "CURRENT_WORKSPACE_CODE";
+	public static final String CURRENT_WORKSPACE_MEMBER_ID = "CURRENT_WORKSPACE_MEMBER_ID";
+
 	private SessionAttributes() {
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspace/presentation/controller/WorkspaceController.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/presentation/controller/WorkspaceController.java
@@ -110,4 +110,20 @@ public class WorkspaceController {
 		return ApiResponse.ok("Workspace found.", response);
 	}
 
+	// @LoginRequired
+	// @RoleRequired(roles = WorkspaceRole.VIEWER)
+	// @GetMapping("/{code}/switch")
+	// public ApiResponse<Void> switchWorkspace(
+	// 	@PathVariable String code,
+	// 	@ResolveLoginMember Long loginMemberId,
+	// 	HttpSession session
+	// ) {
+	// 	Long workspaceMemberId = workspaceQueryService.getWorkspaceMemberId(code, loginMemberId);
+	//
+	// 	session.setAttribute(SessionAttributes.CURRENT_WORKSPACE_CODE, code);
+	// 	session.setAttribute(SessionAttributes.CURRENT_WORKSPACE_MEMBER_ID, workspaceMemberId);
+	//
+	// 	return ApiResponse.okWithNoContent("Workspace switched to \"" + code + "\".");
+	// }
+
 }

--- a/src/main/java/com/uranus/taskmanager/api/workspace/presentation/dto/WorkspaceDetail.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/presentation/dto/WorkspaceDetail.java
@@ -17,9 +17,9 @@ public class WorkspaceDetail {
 	private String name;
 	private String description;
 	private int memberCount;
-	private String createdBy;
+	private Long createdBy;
 	private LocalDateTime createdAt;
-	private String updatedBy;
+	private Long updatedBy;
 	private LocalDateTime updatedAt;
 
 	@Builder
@@ -29,9 +29,9 @@ public class WorkspaceDetail {
 		String name,
 		String description,
 		int memberCount,
-		String createdBy,
+		Long createdBy,
 		LocalDateTime createdAt,
-		String updatedBy,
+		Long updatedBy,
 		LocalDateTime updatedAt
 	) {
 		this.id = id;

--- a/src/main/java/com/uranus/taskmanager/api/workspace/service/query/WorkspaceQueryService.java
+++ b/src/main/java/com/uranus/taskmanager/api/workspace/service/query/WorkspaceQueryService.java
@@ -7,6 +7,7 @@ import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspace.domain.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.exception.WorkspaceNotFoundException;
 import com.uranus.taskmanager.api.workspace.presentation.dto.WorkspaceDetail;
+import com.uranus.taskmanager.api.workspacemember.domain.repository.WorkspaceMemberRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 public class WorkspaceQueryService {
 
 	private final WorkspaceRepository workspaceRepository;
+	private final WorkspaceMemberRepository workspaceMemberRepository;
 
 	@Transactional(readOnly = true)
 	public WorkspaceDetail getWorkspaceDetail(String workspaceCode) {
@@ -26,4 +28,14 @@ public class WorkspaceQueryService {
 
 		return WorkspaceDetail.from(workspace);
 	}
+
+	// @Transactional(readOnly = true)
+	// public Long getWorkspaceMemberId(String code, Long id) {
+	//
+	// 	WorkspaceMember workspaceMember = workspaceMemberRepository
+	// 		.findByMemberIdAndWorkspaceCode(id, code)
+	// 		.orElseThrow(MemberNotInWorkspaceException::new);
+	//
+	// 	return workspaceMember.getId();
+	// }
 }

--- a/src/test/java/com/uranus/taskmanager/api/invitation/presentation/controller/InvitationControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/invitation/presentation/controller/InvitationControllerTest.java
@@ -117,14 +117,14 @@ class InvitationControllerTest extends ControllerTestHelper {
 		List<InvitationResponse> content = List.of(
 			new InvitationResponse(
 				1L, "TESTCODE1",
-				"inviter@test.com",
+				1L,
 				InvitationStatus.PENDING,
 				LocalDateTime.now()
 			),
 			new InvitationResponse(
 				2L,
 				"TESTCODE2",
-				"inviter@test.com",
+				1L,
 				InvitationStatus.PENDING,
 				LocalDateTime.now()
 			)
@@ -161,14 +161,14 @@ class InvitationControllerTest extends ControllerTestHelper {
 			new InvitationResponse(
 				1L,
 				"TESTCODE1",
-				"inviter@test.com",
+				1L,
 				InvitationStatus.ACCEPTED,
 				LocalDateTime.now()
 			),
 			new InvitationResponse(
 				2L,
 				"TESTCODE2",
-				"inviter@test.com",
+				1L,
 				InvitationStatus.REJECTED,
 				LocalDateTime.now()
 			)

--- a/src/test/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceParticipationControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/workspacemember/presentation/controller/WorkspaceParticipationControllerTest.java
@@ -115,9 +115,7 @@ class WorkspaceParticipationControllerTest extends ControllerTestHelper {
 			.code("WS001")
 			.name("Workspace 1")
 			.description("Description 1")
-			.createdBy("member1")
 			.createdAt(LocalDateTime.now().minusDays(5))
-			.updatedBy("updater1")
 			.updatedAt(LocalDateTime.now())
 			.build();
 
@@ -126,9 +124,7 @@ class WorkspaceParticipationControllerTest extends ControllerTestHelper {
 			.code("WS002")
 			.name("Workspace 2")
 			.description("Description 2")
-			.createdBy("member1")
 			.createdAt(LocalDateTime.now().minusDays(10))
-			.updatedBy("updater2")
 			.updatedAt(LocalDateTime.now())
 			.build();
 
@@ -174,9 +170,7 @@ class WorkspaceParticipationControllerTest extends ControllerTestHelper {
 			.code("WS001")
 			.name("Workspace 1")
 			.description("Description 1")
-			.createdBy("creator1")
 			.createdAt(LocalDateTime.now().minusDays(5))
-			.updatedBy("updater1")
 			.updatedAt(LocalDateTime.now())
 			.build();
 
@@ -185,9 +179,7 @@ class WorkspaceParticipationControllerTest extends ControllerTestHelper {
 			.code("WS002")
 			.name("Workspace 2")
 			.description("Description 2")
-			.createdBy("creator2")
 			.createdAt(LocalDateTime.now().minusDays(10))
-			.updatedBy("updater2")
 			.updatedAt(LocalDateTime.now())
 			.build();
 

--- a/src/test/java/com/uranus/taskmanager/integration/workspace/WorkspaceApiIntegrationTest.java
+++ b/src/test/java/com/uranus/taskmanager/integration/workspace/WorkspaceApiIntegrationTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.uranus.taskmanager.api.member.domain.Member;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspace.presentation.dto.request.CreateWorkspaceRequest;
 import com.uranus.taskmanager.helper.RestAssuredTestHelper;
@@ -109,12 +110,11 @@ class WorkspaceApiIntegrationTest extends RestAssuredTestHelper {
 			.statusCode(HttpStatus.CREATED.value())
 			.extract().response();
 
-		Optional<Workspace> optionalWorkspace = workspaceRepository.findById(1L);
+		Workspace workspace = workspaceRepository.findById(1L).get();
+		Member member = memberRepository.findByLoginId("user123").get();
 
 		// then
-		assertThat(optionalWorkspace).isPresent();
-		Workspace workspace = optionalWorkspace.get();
-		assertThat(workspace.getCreatedBy()).isEqualTo(loginId);
+		assertThat(workspace.getCreatedBy()).isEqualTo(member.getId());
 	}
 
 	@Test


### PR DESCRIPTION
## 🚀 설명
- `SessionAuditorAware`가 멤버의 id를 반환하도록 수정

---
## ✅ 변경 사항
- [x] 세션에서 로그인 멤버의 `id`를 읽어서 반환(생성자/수정자로 기록)
- [x] 관련 dto 수정
- [x] 관련 테스트 코드 수정

---
## 🚩 관련 이슈, PR
- #133 

---
## 📖 참고