### PR TITLE
Feat/#138 이슈 상태(`IssueStatus`) 업데이트 구현

### DIFF
--- a/src/main/java/com/uranus/taskmanager/api/common/exception/domain/IssueException.java
+++ b/src/main/java/com/uranus/taskmanager/api/common/exception/domain/IssueException.java
@@ -4,13 +4,12 @@ import org.springframework.http.HttpStatus;
 
 import com.uranus.taskmanager.api.common.exception.TissueException;
 
-public abstract class InvitationException extends TissueException {
-
-	public InvitationException(String message, HttpStatus httpStatus) {
+public abstract class IssueException extends TissueException {
+	public IssueException(String message, HttpStatus httpStatus) {
 		super(message, httpStatus);
 	}
 
-	public InvitationException(String message, HttpStatus httpStatus, Throwable cause) {
+	public IssueException(String message, HttpStatus httpStatus, Throwable cause) {
 		super(message, httpStatus, cause);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/invitation/exception/InvitationNotFoundException.java
+++ b/src/main/java/com/uranus/taskmanager/api/invitation/exception/InvitationNotFoundException.java
@@ -11,8 +11,4 @@ public class InvitationNotFoundException extends InvitationException {
 	public InvitationNotFoundException() {
 		super(MESSAGE, HTTP_STATUS);
 	}
-
-	public InvitationNotFoundException(Throwable cause) {
-		super(MESSAGE, HTTP_STATUS, cause);
-	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/issue/domain/Issue.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/domain/Issue.java
@@ -8,7 +8,7 @@ import java.util.List;
 import com.uranus.taskmanager.api.common.entity.BaseEntity;
 import com.uranus.taskmanager.api.issue.exception.DirectUpdateToInReviewException;
 import com.uranus.taskmanager.api.issue.exception.ParentIssueNotSameWorkspaceException;
-import com.uranus.taskmanager.api.issue.exception.SubTaskParentIssueException;
+import com.uranus.taskmanager.api.issue.exception.ParentIssueTypeSubTaskException;
 import com.uranus.taskmanager.api.issue.exception.SubTaskWrongParentTypeException;
 import com.uranus.taskmanager.api.issue.exception.UpdateIssueInReviewStatusException;
 import com.uranus.taskmanager.api.issue.exception.WrongChildIssueTypeException;
@@ -202,7 +202,7 @@ public class Issue extends BaseEntity {
 		}
 
 		if (issueTypeIsSubTask(parentIssue)) {
-			throw new SubTaskParentIssueException();
+			throw new ParentIssueTypeSubTaskException();
 		}
 
 		// 이슈 타입에 따른 부모-자식 관계 검증

--- a/src/main/java/com/uranus/taskmanager/api/issue/domain/repository/IssueRepository.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/domain/repository/IssueRepository.java
@@ -12,4 +12,6 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
 
 	@Query("SELECT i FROM Issue i JOIN FETCH i.workspace WHERE i.id = :id")
 	Optional<Issue> findByIdWithWorkspace(@Param("id") Long id);
+
+	Optional<Issue> findByIdAndWorkspaceCode(Long id, String workspaceCode);
 }

--- a/src/main/java/com/uranus/taskmanager/api/issue/exception/DirectUpdateToInReviewException.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/exception/DirectUpdateToInReviewException.java
@@ -1,0 +1,20 @@
+package com.uranus.taskmanager.api.issue.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.common.exception.domain.IssueException;
+
+public class DirectUpdateToInReviewException extends IssueException {
+
+	private static final String MESSAGE = "Cannot directly change status to IN_REVIEW. "
+		+ "Status will be automatically updated when reviews are pending.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public DirectUpdateToInReviewException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public DirectUpdateToInReviewException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/issue/exception/IssueNotFoundException.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/exception/IssueNotFoundException.java
@@ -1,0 +1,19 @@
+package com.uranus.taskmanager.api.issue.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.common.exception.domain.IssueException;
+
+public class IssueNotFoundException extends IssueException {
+
+	private static final String MESSAGE = "Issue was not found.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
+
+	public IssueNotFoundException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public IssueNotFoundException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/issue/exception/ParentIssueNotSameWorkspaceException.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/exception/ParentIssueNotSameWorkspaceException.java
@@ -1,0 +1,19 @@
+package com.uranus.taskmanager.api.issue.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.common.exception.domain.IssueException;
+
+public class ParentIssueNotSameWorkspaceException extends IssueException {
+
+	private static final String MESSAGE = "Parent issue must belong to the same workspace of child issue.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public ParentIssueNotSameWorkspaceException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public ParentIssueNotSameWorkspaceException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/issue/exception/ParentIssueTypeSubTaskException.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/exception/ParentIssueTypeSubTaskException.java
@@ -4,16 +4,16 @@ import org.springframework.http.HttpStatus;
 
 import com.uranus.taskmanager.api.common.exception.domain.IssueException;
 
-public class SubTaskParentIssueException extends IssueException {
+public class ParentIssueTypeSubTaskException extends IssueException {
 
 	private static final String MESSAGE = "Parent issue cannot be a SUB_TASK.";
 	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
 
-	public SubTaskParentIssueException() {
+	public ParentIssueTypeSubTaskException() {
 		super(MESSAGE, HTTP_STATUS);
 	}
 
-	public SubTaskParentIssueException(String message) {
+	public ParentIssueTypeSubTaskException(String message) {
 		super(message, HTTP_STATUS);
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/issue/exception/SubTaskParentIssueException.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/exception/SubTaskParentIssueException.java
@@ -1,0 +1,19 @@
+package com.uranus.taskmanager.api.issue.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.common.exception.domain.IssueException;
+
+public class SubTaskParentIssueException extends IssueException {
+
+	private static final String MESSAGE = "Parent issue cannot be a SUB_TASK.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public SubTaskParentIssueException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public SubTaskParentIssueException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/issue/exception/SubTaskWrongParentTypeException.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/exception/SubTaskWrongParentTypeException.java
@@ -1,0 +1,19 @@
+package com.uranus.taskmanager.api.issue.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.common.exception.domain.IssueException;
+
+public class SubTaskWrongParentTypeException extends IssueException {
+
+	private static final String MESSAGE = "SUB_TASK can only have STORY, TASK, or BUG type as the parent issue.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public SubTaskWrongParentTypeException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public SubTaskWrongParentTypeException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/issue/exception/UpdateIssueInReviewStatusException.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/exception/UpdateIssueInReviewStatusException.java
@@ -1,0 +1,18 @@
+package com.uranus.taskmanager.api.issue.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.common.exception.domain.IssueException;
+
+public class UpdateIssueInReviewStatusException extends IssueException {
+	private static final String MESSAGE = "Cannot update status while issue is under review.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public UpdateIssueInReviewStatusException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public UpdateIssueInReviewStatusException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/issue/exception/WrongChildIssueTypeException.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/exception/WrongChildIssueTypeException.java
@@ -6,7 +6,7 @@ import com.uranus.taskmanager.api.common.exception.domain.IssueException;
 
 public class WrongChildIssueTypeException extends IssueException {
 
-	private static final String MESSAGE = "Only EPIC type issues can have non SUB_TASK children.";
+	private static final String MESSAGE = "Only EPIC type issues can have STORY, TASK, BUG type children.";
 	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
 
 	public WrongChildIssueTypeException() {

--- a/src/main/java/com/uranus/taskmanager/api/issue/exception/WrongChildIssueTypeException.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/exception/WrongChildIssueTypeException.java
@@ -1,0 +1,19 @@
+package com.uranus.taskmanager.api.issue.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.uranus.taskmanager.api.common.exception.domain.IssueException;
+
+public class WrongChildIssueTypeException extends IssueException {
+
+	private static final String MESSAGE = "Only EPIC type issues can have non SUB_TASK children.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public WrongChildIssueTypeException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public WrongChildIssueTypeException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/issue/presentation/controller/IssueController.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/presentation/controller/IssueController.java
@@ -1,6 +1,7 @@
 package com.uranus.taskmanager.api.issue.presentation.controller;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,7 +11,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.uranus.taskmanager.api.common.dto.ApiResponse;
 import com.uranus.taskmanager.api.issue.presentation.dto.request.CreateIssueRequest;
+import com.uranus.taskmanager.api.issue.presentation.dto.request.UpdateStatusRequest;
 import com.uranus.taskmanager.api.issue.presentation.dto.response.CreateIssueResponse;
+import com.uranus.taskmanager.api.issue.presentation.dto.response.UpdateStatusResponse;
 import com.uranus.taskmanager.api.issue.service.IssueCommandService;
 import com.uranus.taskmanager.api.security.authentication.interceptor.LoginRequired;
 import com.uranus.taskmanager.api.security.authorization.interceptor.RoleRequired;
@@ -23,12 +26,11 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/v1/workspaces/{code}")
+@RequestMapping("/api/v1/workspaces/{code}/issues")
 public class IssueController {
 
 	/**
 	 * Todo
-	 *  - 이슈 생성
 	 *  - 이슈 상태 변경
 	 *    - DONE으로 변경하는 경우 끝난 날짜(finishedDate) 업데이트 됨
 	 *    - 처음으로 IN_PROGRESS로 변경하면 현재 날짜 시간으로 startDate가 설정 됨
@@ -79,7 +81,7 @@ public class IssueController {
 	@LoginRequired
 	@RoleRequired(roles = WorkspaceRole.COLLABORATOR)
 	@ResponseStatus(HttpStatus.CREATED)
-	@PostMapping("/issues")
+	@PostMapping
 	public ApiResponse<CreateIssueResponse> createIssue(
 		@PathVariable String code,
 		@RequestBody @Valid CreateIssueRequest request
@@ -91,4 +93,19 @@ public class IssueController {
 		return ApiResponse.ok("Issue created.", response);
 	}
 
+	@LoginRequired
+	@RoleRequired(roles = WorkspaceRole.COLLABORATOR)
+	@PatchMapping("/{issueId}/status")
+	public ApiResponse<UpdateStatusResponse> updateIssueStatus(
+		@PathVariable String code,
+		@PathVariable Long issueId,
+		@RequestBody @Valid UpdateStatusRequest request
+	) {
+		UpdateStatusResponse response = issueCommandService.updateIssueStatus(
+			issueId,
+			code,
+			request
+		);
+		return ApiResponse.ok("Issue status was updated to " + response.status(), response);
+	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/issue/presentation/controller/IssueController.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/presentation/controller/IssueController.java
@@ -1,9 +1,9 @@
 package com.uranus.taskmanager.api.issue.presentation.controller;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -95,7 +95,7 @@ public class IssueController {
 
 	@LoginRequired
 	@RoleRequired(roles = WorkspaceRole.COLLABORATOR)
-	@PatchMapping("/{issueId}/status")
+	@PutMapping("/{issueId}/status")
 	public ApiResponse<UpdateStatusResponse> updateIssueStatus(
 		@PathVariable String code,
 		@PathVariable Long issueId,

--- a/src/main/java/com/uranus/taskmanager/api/issue/presentation/dto/request/UpdateStatusRequest.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/presentation/dto/request/UpdateStatusRequest.java
@@ -1,0 +1,11 @@
+package com.uranus.taskmanager.api.issue.presentation.dto.request;
+
+import com.uranus.taskmanager.api.issue.domain.IssueStatus;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateStatusRequest(
+	@NotNull
+	IssueStatus status
+) {
+}

--- a/src/main/java/com/uranus/taskmanager/api/issue/presentation/dto/response/UpdateStatusResponse.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/presentation/dto/response/UpdateStatusResponse.java
@@ -1,0 +1,20 @@
+package com.uranus.taskmanager.api.issue.presentation.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.uranus.taskmanager.api.issue.domain.Issue;
+import com.uranus.taskmanager.api.issue.domain.IssueStatus;
+
+public record UpdateStatusResponse(
+	Long issueId,
+	IssueStatus status,
+	LocalDateTime updatedAt
+) {
+	public static UpdateStatusResponse from(Issue issue) {
+		return new UpdateStatusResponse(
+			issue.getId(),
+			issue.getStatus(),
+			issue.getLastModifiedDate()
+		);
+	}
+}

--- a/src/main/java/com/uranus/taskmanager/api/issue/service/IssueCommandService.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/service/IssueCommandService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.uranus.taskmanager.api.issue.domain.Issue;
 import com.uranus.taskmanager.api.issue.domain.repository.IssueRepository;
+import com.uranus.taskmanager.api.issue.exception.IssueNotFoundException;
 import com.uranus.taskmanager.api.issue.presentation.dto.request.CreateIssueRequest;
 import com.uranus.taskmanager.api.issue.presentation.dto.request.UpdateStatusRequest;
 import com.uranus.taskmanager.api.issue.presentation.dto.response.CreateIssueResponse;
@@ -56,7 +57,7 @@ public class IssueCommandService {
 		UpdateStatusRequest request
 	) {
 		Issue issue = issueRepository.findByIdAndWorkspaceCode(issueId, code)
-			.orElseThrow(() -> new RuntimeException("Issue not found.")); // Todo: IssueNotFoundException 만들기
+			.orElseThrow(IssueNotFoundException::new);
 
 		issue.updateStatus(request.status());
 
@@ -66,6 +67,6 @@ public class IssueCommandService {
 	private Optional<Issue> findParentIssue(Long parentIssueId, String workspaceCode) {
 		return Optional.ofNullable(parentIssueId)
 			.map(id -> issueRepository.findByIdAndWorkspaceCode(id, workspaceCode)
-				.orElseThrow(() -> new IllegalArgumentException("Issue does not exist in this workspace.")));
+				.orElseThrow(() -> new IssueNotFoundException("Issue does not exist in this workspace.")));
 	}
 }

--- a/src/main/java/com/uranus/taskmanager/api/issue/service/IssueCommandService.java
+++ b/src/main/java/com/uranus/taskmanager/api/issue/service/IssueCommandService.java
@@ -8,7 +8,9 @@ import org.springframework.transaction.annotation.Transactional;
 import com.uranus.taskmanager.api.issue.domain.Issue;
 import com.uranus.taskmanager.api.issue.domain.repository.IssueRepository;
 import com.uranus.taskmanager.api.issue.presentation.dto.request.CreateIssueRequest;
+import com.uranus.taskmanager.api.issue.presentation.dto.request.UpdateStatusRequest;
 import com.uranus.taskmanager.api.issue.presentation.dto.response.CreateIssueResponse;
+import com.uranus.taskmanager.api.issue.presentation.dto.response.UpdateStatusResponse;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.api.workspace.domain.repository.WorkspaceRepository;
 import com.uranus.taskmanager.api.workspace.exception.WorkspaceNotFoundException;
@@ -39,7 +41,7 @@ public class IssueCommandService {
 
 		Issue issue = request.to(
 			workspace,
-			findParentIssue(request.parentIssueId()).orElse(null)
+			findParentIssue(request.parentIssueId(), code).orElse(null)
 		);
 
 		issueRepository.save(issue);
@@ -47,9 +49,23 @@ public class IssueCommandService {
 		return CreateIssueResponse.from(issue);
 	}
 
-	private Optional<Issue> findParentIssue(Long parentIssueId) {
+	@Transactional
+	public UpdateStatusResponse updateIssueStatus(
+		Long issueId,
+		String code,
+		UpdateStatusRequest request
+	) {
+		Issue issue = issueRepository.findByIdAndWorkspaceCode(issueId, code)
+			.orElseThrow(() -> new RuntimeException("Issue not found.")); // Todo: IssueNotFoundException 만들기
+
+		issue.updateStatus(request.status());
+
+		return UpdateStatusResponse.from(issue);
+	}
+
+	private Optional<Issue> findParentIssue(Long parentIssueId, String workspaceCode) {
 		return Optional.ofNullable(parentIssueId)
-			.map(id -> issueRepository.findByIdWithWorkspace(id)
-				.orElseThrow(() -> new IllegalArgumentException("Issue does not exist.")));
+			.map(id -> issueRepository.findByIdAndWorkspaceCode(id, workspaceCode)
+				.orElseThrow(() -> new IllegalArgumentException("Issue does not exist in this workspace.")));
 	}
 }

--- a/src/test/java/com/uranus/taskmanager/api/issue/presentation/controller/IssueControllerTest.java
+++ b/src/test/java/com/uranus/taskmanager/api/issue/presentation/controller/IssueControllerTest.java
@@ -16,7 +16,9 @@ import com.uranus.taskmanager.api.issue.domain.IssuePriority;
 import com.uranus.taskmanager.api.issue.domain.IssueStatus;
 import com.uranus.taskmanager.api.issue.domain.IssueType;
 import com.uranus.taskmanager.api.issue.presentation.dto.request.CreateIssueRequest;
+import com.uranus.taskmanager.api.issue.presentation.dto.request.UpdateStatusRequest;
 import com.uranus.taskmanager.api.issue.presentation.dto.response.CreateIssueResponse;
+import com.uranus.taskmanager.api.issue.presentation.dto.response.UpdateStatusResponse;
 import com.uranus.taskmanager.helper.ControllerTestHelper;
 
 class IssueControllerTest extends ControllerTestHelper {
@@ -117,6 +119,27 @@ class IssueControllerTest extends ControllerTestHelper {
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("$.data.dueDate").isEmpty())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("PUT /workspaces/{code}/issues/{issueId}/status - 이슈 상태 업데이트에 성공하면 OK를 응답한다")
+	void updateIssueStatus_success() throws Exception {
+		// given
+		String code = "ABCDEFGH";
+
+		UpdateStatusRequest request = new UpdateStatusRequest(IssueStatus.IN_PROGRESS);
+		UpdateStatusResponse response = new UpdateStatusResponse(1L, IssueStatus.IN_PROGRESS, LocalDateTime.now());
+
+		when(issueCommandService.updateIssueStatus(1L, code, request))
+			.thenReturn(response);
+
+		// when & then
+		mockMvc.perform(put("/api/v1/workspaces/{code}/issues/{issueId}/status", code, 1L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.status").value("IN_PROGRESS"))
 			.andDo(print());
 	}
 }

--- a/src/test/java/com/uranus/taskmanager/api/issue/service/IssueCommandServiceIT.java
+++ b/src/test/java/com/uranus/taskmanager/api/issue/service/IssueCommandServiceIT.java
@@ -13,6 +13,9 @@ import org.springframework.transaction.annotation.Transactional;
 import com.uranus.taskmanager.api.issue.domain.Issue;
 import com.uranus.taskmanager.api.issue.domain.IssuePriority;
 import com.uranus.taskmanager.api.issue.domain.IssueType;
+import com.uranus.taskmanager.api.issue.exception.SubTaskParentIssueException;
+import com.uranus.taskmanager.api.issue.exception.SubTaskWrongParentTypeException;
+import com.uranus.taskmanager.api.issue.exception.WrongChildIssueTypeException;
 import com.uranus.taskmanager.api.issue.presentation.dto.request.CreateIssueRequest;
 import com.uranus.taskmanager.api.issue.presentation.dto.response.CreateIssueResponse;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
@@ -130,7 +133,7 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 
 		// when & then
 		assertThatThrownBy(() -> issueCommandService.createIssue("TESTCODE", request))
-			.isInstanceOf(IllegalArgumentException.class); // Todo: 커스텀 예외 만들면 수정
+			.isInstanceOf(SubTaskParentIssueException.class);
 	}
 
 	@Transactional
@@ -160,7 +163,7 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 
 		// when & then
 		assertThatThrownBy(() -> issueCommandService.createIssue("TESTCODE", request))
-			.isInstanceOf(IllegalArgumentException.class); // Todo: 커스텀 예외 만들면 수정
+			.isInstanceOf(SubTaskWrongParentTypeException.class);
 	}
 
 	@Transactional
@@ -190,7 +193,7 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 
 		// when & then
 		assertThatThrownBy(() -> issueCommandService.createIssue("TESTCODE", request))
-			.isInstanceOf(IllegalArgumentException.class); // Todo: 커스텀 예외 만들면 수정
+			.isInstanceOf(WrongChildIssueTypeException.class);
 	}
 
 }

--- a/src/test/java/com/uranus/taskmanager/api/issue/service/IssueCommandServiceIT.java
+++ b/src/test/java/com/uranus/taskmanager/api/issue/service/IssueCommandServiceIT.java
@@ -16,7 +16,7 @@ import com.uranus.taskmanager.api.issue.domain.IssuePriority;
 import com.uranus.taskmanager.api.issue.domain.IssueStatus;
 import com.uranus.taskmanager.api.issue.domain.IssueType;
 import com.uranus.taskmanager.api.issue.exception.DirectUpdateToInReviewException;
-import com.uranus.taskmanager.api.issue.exception.SubTaskParentIssueException;
+import com.uranus.taskmanager.api.issue.exception.ParentIssueTypeSubTaskException;
 import com.uranus.taskmanager.api.issue.exception.SubTaskWrongParentTypeException;
 import com.uranus.taskmanager.api.issue.exception.WrongChildIssueTypeException;
 import com.uranus.taskmanager.api.issue.presentation.dto.request.CreateIssueRequest;
@@ -69,8 +69,7 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 		assertThat(response.type()).isEqualTo(IssueType.TASK);
 		assertThat(response.parentIssueId()).isNull();
 
-		Issue savedIssue = issueRepository.findById(response.issueId())
-			.orElseThrow();
+		Issue savedIssue = issueRepository.findById(response.issueId()).orElseThrow();
 		assertThat(savedIssue.getWorkspace().getCode()).isEqualTo("TESTCODE");
 	}
 
@@ -138,7 +137,7 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 
 		// when & then
 		assertThatThrownBy(() -> issueCommandService.createIssue("TESTCODE", request))
-			.isInstanceOf(SubTaskParentIssueException.class);
+			.isInstanceOf(ParentIssueTypeSubTaskException.class);
 	}
 
 	@Transactional

--- a/src/test/java/com/uranus/taskmanager/api/issue/service/IssueCommandServiceIT.java
+++ b/src/test/java/com/uranus/taskmanager/api/issue/service/IssueCommandServiceIT.java
@@ -3,6 +3,7 @@ package com.uranus.taskmanager.api.issue.service;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,12 +13,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.uranus.taskmanager.api.issue.domain.Issue;
 import com.uranus.taskmanager.api.issue.domain.IssuePriority;
+import com.uranus.taskmanager.api.issue.domain.IssueStatus;
 import com.uranus.taskmanager.api.issue.domain.IssueType;
+import com.uranus.taskmanager.api.issue.exception.DirectUpdateToInReviewException;
 import com.uranus.taskmanager.api.issue.exception.SubTaskParentIssueException;
 import com.uranus.taskmanager.api.issue.exception.SubTaskWrongParentTypeException;
 import com.uranus.taskmanager.api.issue.exception.WrongChildIssueTypeException;
 import com.uranus.taskmanager.api.issue.presentation.dto.request.CreateIssueRequest;
+import com.uranus.taskmanager.api.issue.presentation.dto.request.UpdateStatusRequest;
 import com.uranus.taskmanager.api.issue.presentation.dto.response.CreateIssueResponse;
+import com.uranus.taskmanager.api.issue.presentation.dto.response.UpdateStatusResponse;
 import com.uranus.taskmanager.api.workspace.domain.Workspace;
 import com.uranus.taskmanager.helper.ServiceIntegrationTestHelper;
 
@@ -196,4 +201,102 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 			.isInstanceOf(WrongChildIssueTypeException.class);
 	}
 
+	@Test
+	@DisplayName("이슈 상태 업데이트를 성공하면 이슈 상태 업데이트 응답을 반환한다")
+	void updateIssueStatus_success_returnUpdateStatusResponse() {
+		// given
+		CreateIssueRequest createRequest = new CreateIssueRequest(
+			IssueType.TASK,
+			"Test Issue",
+			"Test issue content",
+			IssuePriority.HIGH,
+			LocalDate.now(),
+			null
+		);
+		issueCommandService.createIssue("TESTCODE", createRequest);
+
+		UpdateStatusRequest updateStatusRequest = new UpdateStatusRequest(IssueStatus.IN_PROGRESS);
+
+		// when
+		UpdateStatusResponse response = issueCommandService.updateIssueStatus(1L, "TESTCODE", updateStatusRequest);
+
+		// then
+		assertThat(response.issueId()).isEqualTo(1L);
+		assertThat(response.status()).isEqualTo(IssueStatus.IN_PROGRESS);
+	}
+
+	@Test
+	@DisplayName("이슈 상태를 IN_REVIEW로 직접 업데이트 시도하는 경우 예외가 발생한다")
+	void updateIssueStatus_fails_ifUpdateDirectlyToInReview() {
+		// given
+		CreateIssueRequest createRequest = new CreateIssueRequest(
+			IssueType.TASK,
+			"Test Issue",
+			"Test issue content",
+			IssuePriority.HIGH,
+			LocalDate.now(),
+			null
+		);
+		issueCommandService.createIssue("TESTCODE", createRequest);
+
+		UpdateStatusRequest updateStatusRequest = new UpdateStatusRequest(IssueStatus.IN_REVIEW);
+
+		// when & then
+		assertThatThrownBy(() -> issueCommandService.updateIssueStatus(1L, "TESTCODE", updateStatusRequest))
+			.isInstanceOf(DirectUpdateToInReviewException.class);
+	}
+
+	@Test
+	@DisplayName("이슈 상태를 처음으로 IN_PROGRESS로 업데이트하는 경우, startedAt이 현재 날짜와 시간으로 기록된다")
+	void updateIssueStatus_toInProgress_startedAtIsRecorded() {
+		// given
+		CreateIssueRequest createRequest = new CreateIssueRequest(
+			IssueType.TASK,
+			"Test Issue",
+			"Test issue content",
+			IssuePriority.HIGH,
+			LocalDate.now(),
+			null
+		);
+		issueCommandService.createIssue("TESTCODE", createRequest);
+
+		UpdateStatusRequest updateStatusRequest = new UpdateStatusRequest(IssueStatus.IN_PROGRESS);
+
+		// when
+		LocalDateTime timeBeforeUpdate = LocalDateTime.now();
+		issueCommandService.updateIssueStatus(1L, "TESTCODE", updateStatusRequest);
+
+		// then
+		Issue issue = issueRepository.findById(1L).orElseThrow();
+
+		assertThat(issue.getStartedAt()).isAfter(timeBeforeUpdate);
+		assertThat(issue.getStartedAt()).isBefore(timeBeforeUpdate.plusMinutes(1));
+	}
+
+	@Test
+	@DisplayName("이슈 상태를 DONE으로 업데이트하는 경우 finishedAt이 현재 날짜와 시간으로 기록된다")
+	void updateIssueStatus_toDone_finishedAtIsRecorded() {
+		// given
+		CreateIssueRequest createRequest = new CreateIssueRequest(
+			IssueType.TASK,
+			"Test Issue",
+			"Test issue content",
+			IssuePriority.HIGH,
+			LocalDate.now(),
+			null
+		);
+		issueCommandService.createIssue("TESTCODE", createRequest);
+
+		UpdateStatusRequest updateStatusRequest = new UpdateStatusRequest(IssueStatus.DONE);
+
+		// when
+		LocalDateTime timeBeforeUpdate = LocalDateTime.now();
+		issueCommandService.updateIssueStatus(1L, "TESTCODE", updateStatusRequest);
+
+		// then
+		Issue issue = issueRepository.findById(1L).orElseThrow();
+
+		assertThat(issue.getFinishedAt()).isAfter(timeBeforeUpdate);
+		assertThat(issue.getFinishedAt()).isBefore(timeBeforeUpdate.plusMinutes(1));
+	}
 }


### PR DESCRIPTION
## 🚀 설명
- 이슈 상태(`IssueStatus`) 업데이트 구현
- 이슈와 관련된 커스텀 예외 구현

---
## ✅ 변경 사항
- [x] 이슈 상태 업데이트 API 구현
- [x] 이슈 관련 커스텀 예외 구현
- [x] 테스트 추가

---
## 🚩 관련 이슈, PR
- #138 

---
## 📖 참고