### PR TITLE
Feat/#143 이슈 키(`issueKey`) 구현

### DIFF
--- a/backend/src/main/java/com/tissue/api/issue/domain/Issue.java
+++ b/backend/src/main/java/com/tissue/api/issue/domain/Issue.java
@@ -54,6 +54,13 @@ public abstract class Issue extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	/**
+	 * Todo
+	 *  - 이슈 키를 위해서 VO(@Embeddeble) 사용 고려
+	 *  - 동시성 문제 해결을 위해서 이슈 생성에 spring-retry 적용
+	 *  - Workspace에서 issueKeyPrefix와 nextIssueNumber를 관리하기 때문에,
+	 *  Workspace에 Optimistic locking을 적용한다
+	 */
 	@Column(nullable = false, unique = true)
 	private String issueKey;
 
@@ -120,6 +127,12 @@ public abstract class Issue extends BaseEntity {
 		this.dueDate = dueDate;
 	}
 
+	/**
+	 * Todo
+	 *  - 상태 업데이트는 도메인 이벤트(Domain Event) 발행으로 구현하는 것을 고려
+	 *  - 상태 변경과 관련된 부가 작업들(알림 발송, 감사 로그 기록 등)을
+	 *  이벤트 핸들러에서 처리할 수 있어 확장성이 좋아짐
+	 */
 	public void updateStatus(IssueStatus newStatus) {
 		validateStatusTransition(newStatus);
 		this.status = newStatus;
@@ -148,6 +161,11 @@ public abstract class Issue extends BaseEntity {
 		parentIssue.getChildIssues().add(this);
 	}
 
+	/**
+	 * Todo
+	 *  - 상태 패턴(State, State Machine Pattern)의 사용 고려
+	 *  - 상태 변경 규칙을 한 곳에서 명확하게 관리할 수 있고, 새로운 상태나 규칙을 추가하기도 쉬워짐
+	 */
 	protected void validateStatusTransition(IssueStatus newStatus) {
 		if (this.status == IssueStatus.IN_REVIEW) {
 			throw new UpdateIssueInReviewStatusException();

--- a/backend/src/main/java/com/tissue/api/issue/domain/Issue.java
+++ b/backend/src/main/java/com/tissue/api/issue/domain/Issue.java
@@ -9,9 +9,9 @@ import com.tissue.api.common.entity.BaseEntity;
 import com.tissue.api.issue.domain.enums.IssuePriority;
 import com.tissue.api.issue.domain.enums.IssueStatus;
 import com.tissue.api.issue.domain.enums.IssueType;
+import com.tissue.api.issue.exception.UpdateIssueInReviewStatusException;
 import com.tissue.api.issue.exception.UpdateStatusToInReviewException;
 import com.tissue.api.workspace.domain.Workspace;
-import com.tissue.api.issue.exception.UpdateIssueInReviewStatusException;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorColumn;
@@ -39,6 +39,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class Issue extends BaseEntity {
 
+	@OneToMany(mappedBy = "parentIssue")
+	private final List<Issue> childIssues = new ArrayList<>();
 	/**
 	 * Todo
 	 *  - 이슈 마다 코드를 부여하자
@@ -56,6 +58,9 @@ public abstract class Issue extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	// @Column(nullable = false, unique = true)
+	// private String key;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "type", insertable = false, updatable = false)
@@ -89,15 +94,11 @@ public abstract class Issue extends BaseEntity {
 
 	private LocalDateTime startedAt;
 	private LocalDateTime finishedAt;
-
 	private LocalDate dueDate;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "PARENT_ISSUE_ID")
 	private Issue parentIssue;
-
-	@OneToMany(mappedBy = "parentIssue")
-	private List<Issue> childIssues = new ArrayList<>();
 
 	protected Issue(
 		Workspace workspace,

--- a/backend/src/main/java/com/tissue/api/issue/domain/Issue.java
+++ b/backend/src/main/java/com/tissue/api/issue/domain/Issue.java
@@ -43,11 +43,6 @@ public abstract class Issue extends BaseEntity {
 	private final List<Issue> childIssues = new ArrayList<>();
 	/**
 	 * Todo
-	 *  - 이슈 마다 코드를 부여하자
-	 *    - 순서대로 증가
-	 *    - 워크스페이스 마다 고유
-	 *    - 예시: EPIC-3, STORY-333, TASK-456, BUG-77, SUBTASK-1004
-	 *    - 예시: ADMIN이상이 정하는 경우 -> TISSUE-1234
 	 *  - dueDate가 null인 경우의 처리가 필요
 	 * 	  - 예시: null이면 1주일 후의 날짜를 dueDate로 설정(생성자에서)
 	 *  - parentIssue 추가하는 경우 해당 parentIssue에는 현재의 이슈가 childIssue로 추가
@@ -59,8 +54,8 @@ public abstract class Issue extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	// @Column(nullable = false, unique = true)
-	// private String key;
+	@Column(nullable = false, unique = true)
+	private String issueKey;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "type", insertable = false, updatable = false)
@@ -109,6 +104,9 @@ public abstract class Issue extends BaseEntity {
 		IssuePriority priority,
 		LocalDate dueDate
 	) {
+		this.issueKey = workspace.getIssueKey();
+		workspace.increaseNextIssueNumber();
+
 		this.workspace = workspace;
 		this.workspaceCode = workspace.getCode();
 		workspace.getIssues().add(this);

--- a/backend/src/main/java/com/tissue/api/issue/domain/types/Story.java
+++ b/backend/src/main/java/com/tissue/api/issue/domain/types/Story.java
@@ -2,12 +2,12 @@ package com.tissue.api.issue.domain.types;
 
 import java.time.LocalDate;
 
-import com.tissue.api.issue.exception.ParentMustBeEpicException;
-import com.tissue.api.workspace.domain.Workspace;
 import com.tissue.api.issue.domain.Issue;
 import com.tissue.api.issue.domain.enums.Difficulty;
 import com.tissue.api.issue.domain.enums.IssuePriority;
 import com.tissue.api.issue.domain.enums.IssueType;
+import com.tissue.api.issue.exception.ParentMustBeEpicException;
+import com.tissue.api.workspace.domain.Workspace;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;

--- a/backend/src/main/java/com/tissue/api/issue/service/command/IssueCommandService.java
+++ b/backend/src/main/java/com/tissue/api/issue/service/command/IssueCommandService.java
@@ -5,16 +5,16 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.tissue.api.issue.presentation.dto.request.create.CreateIssueRequest;
-import com.tissue.api.issue.presentation.dto.response.create.CreateIssueResponse;
-import com.tissue.api.workspace.domain.Workspace;
-import com.tissue.api.workspace.domain.repository.WorkspaceRepository;
-import com.tissue.api.workspace.exception.WorkspaceNotFoundException;
 import com.tissue.api.issue.domain.Issue;
 import com.tissue.api.issue.domain.repository.IssueRepository;
 import com.tissue.api.issue.exception.IssueNotFoundException;
 import com.tissue.api.issue.presentation.dto.request.UpdateStatusRequest;
+import com.tissue.api.issue.presentation.dto.request.create.CreateIssueRequest;
 import com.tissue.api.issue.presentation.dto.response.UpdateStatusResponse;
+import com.tissue.api.issue.presentation.dto.response.create.CreateIssueResponse;
+import com.tissue.api.workspace.domain.Workspace;
+import com.tissue.api.workspace.domain.repository.WorkspaceRepository;
+import com.tissue.api.workspace.exception.WorkspaceNotFoundException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,7 +30,10 @@ public class IssueCommandService {
 	/*
 	 * Todo
 	 *  - 생각해보면, 이미 RoleRequired에 대한 인터셉터에서 Workspace를 검증하는데 여기서 또 검증이 필요한가?
-	 *  - RequestContextHolder에 대해 찾아보기
+	 *    - RequestContextHolder에 대해 찾아보기
+	 *  - 동시성 문제 해결을 위해서 이슈 생성에 spring-retry 적용
+	 *    - 반복문, try-catch문 적용으로 issueKey의 유일성 제약 위반 예외 잡아서 처리하는 방법보다 나은 듯
+	 *  - Workspace에서 issueKeyPrefix와 nextIssueNumber를 관리하기 때문에, Workspace에 Optimistic locking을 적용한다
 	 */
 	@Transactional
 	public CreateIssueResponse createIssue(

--- a/backend/src/main/java/com/tissue/api/security/session/SessionManager.java
+++ b/backend/src/main/java/com/tissue/api/security/session/SessionManager.java
@@ -8,8 +8,8 @@ import org.springframework.web.context.request.NativeWebRequest;
 
 import com.tissue.api.member.domain.Member;
 import com.tissue.api.member.domain.repository.MemberRepository;
-import com.tissue.api.security.authentication.exception.UserNotLoggedInException;
 import com.tissue.api.member.exception.MemberNotFoundException;
+import com.tissue.api.security.authentication.exception.UserNotLoggedInException;
 import com.tissue.api.security.authentication.presentation.dto.response.LoginResponse;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,8 +21,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Component
 public class SessionManager {
-	private final MemberRepository memberRepository;
 	private static final int UPDATE_PERMISSION_MINUTES = 5;
+	private final MemberRepository memberRepository;
 
 	// 로그인 세션 설정, 관리
 	public void createLoginSession(HttpSession session, LoginResponse loginResponse) {

--- a/backend/src/main/java/com/tissue/api/workspace/domain/Workspace.java
+++ b/backend/src/main/java/com/tissue/api/workspace/domain/Workspace.java
@@ -128,6 +128,14 @@ public class Workspace extends BaseEntity {
 		this.description = description;
 	}
 
+	public String getIssueKey() {
+		return keyPrefix + "-" + nextIssueNumber;
+	}
+
+	public void increaseNextIssueNumber() {
+		this.nextIssueNumber++;
+	}
+
 	public void increaseMemberCount() {
 		validateMemberLimit();
 		this.memberCount++;

--- a/backend/src/main/java/com/tissue/api/workspace/domain/Workspace.java
+++ b/backend/src/main/java/com/tissue/api/workspace/domain/Workspace.java
@@ -44,7 +44,8 @@ public class Workspace extends BaseEntity {
 	/**
 	 * Todo
 	 *  - memberCount에 캐시 적용 고려
-	 *  -> memberCount 증가/감소가 들어가는 로직은 전부 예외를 잡고 재수행 로직을 적용해야 한다
+	 *  -> memberCount 증가/감소가 들어가는 로직은 동시성 이슈를 고려해야 함
+	 *    -> 원자적 연산으로 해결하는 것이 더 좋을지도?
 	 *  -> spring-retry 사용(AOP로 직접 구현해도 되지만 귀찮음)
 	 */
 	@Id
@@ -129,7 +130,7 @@ public class Workspace extends BaseEntity {
 	}
 
 	public String getIssueKey() {
-		return keyPrefix + "-" + nextIssueNumber;
+		return String.format("%s-%d", keyPrefix, nextIssueNumber);
 	}
 
 	public void increaseNextIssueNumber() {

--- a/backend/src/main/java/com/tissue/api/workspace/presentation/controller/WorkspaceController.java
+++ b/backend/src/main/java/com/tissue/api/workspace/presentation/controller/WorkspaceController.java
@@ -11,22 +11,24 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.tissue.api.common.dto.ApiResponse;
+import com.tissue.api.security.authentication.interceptor.LoginRequired;
 import com.tissue.api.security.authentication.resolver.ResolveLoginMember;
 import com.tissue.api.security.authorization.interceptor.RoleRequired;
+import com.tissue.api.workspace.presentation.dto.WorkspaceDetail;
 import com.tissue.api.workspace.presentation.dto.request.CreateWorkspaceRequest;
 import com.tissue.api.workspace.presentation.dto.request.DeleteWorkspaceRequest;
+import com.tissue.api.workspace.presentation.dto.request.UpdateIssueKeyRequest;
 import com.tissue.api.workspace.presentation.dto.request.UpdateWorkspaceInfoRequest;
 import com.tissue.api.workspace.presentation.dto.request.UpdateWorkspacePasswordRequest;
 import com.tissue.api.workspace.presentation.dto.response.CreateWorkspaceResponse;
 import com.tissue.api.workspace.presentation.dto.response.DeleteWorkspaceResponse;
+import com.tissue.api.workspace.presentation.dto.response.UpdateIssueKeyResponse;
 import com.tissue.api.workspace.presentation.dto.response.UpdateWorkspaceInfoResponse;
 import com.tissue.api.workspace.service.command.WorkspaceCommandService;
 import com.tissue.api.workspace.service.command.create.WorkspaceCreateService;
-import com.tissue.api.workspacemember.domain.WorkspaceRole;
-import com.tissue.api.common.dto.ApiResponse;
-import com.tissue.api.security.authentication.interceptor.LoginRequired;
-import com.tissue.api.workspace.presentation.dto.WorkspaceDetail;
 import com.tissue.api.workspace.service.query.WorkspaceQueryService;
+import com.tissue.api.workspacemember.domain.WorkspaceRole;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -108,6 +110,20 @@ public class WorkspaceController {
 	) {
 		WorkspaceDetail response = workspaceQueryService.getWorkspaceDetail(code);
 		return ApiResponse.ok("Workspace found.", response);
+	}
+
+	@LoginRequired
+	@RoleRequired(roles = WorkspaceRole.ADMIN)
+	@PatchMapping("/{code}/key")
+	public ApiResponse<UpdateIssueKeyResponse> updateIssueKey(
+		@PathVariable String code,
+		@RequestBody @Valid UpdateIssueKeyRequest request
+	) {
+		UpdateIssueKeyResponse response = workspaceCommandService.updateIssueKey(
+			code,
+			request
+		);
+		return ApiResponse.ok("Issue key prefix updated.", response);
 	}
 
 	// @LoginRequired

--- a/backend/src/main/java/com/tissue/api/workspace/presentation/dto/request/CreateWorkspaceRequest.java
+++ b/backend/src/main/java/com/tissue/api/workspace/presentation/dto/request/CreateWorkspaceRequest.java
@@ -6,50 +6,32 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class CreateWorkspaceRequest {
-
+@Builder
+public record CreateWorkspaceRequest(
 	@Size(min = 2, max = 50, message = "Workspace name must be 2 ~ 50 characters long")
 	@NotBlank(message = "Workspace name must not be blank")
-	private String name;
+	String name,
 
 	@Size(min = 1, max = 255, message = "Workspace description must be 1 ~ 255 characters long")
 	@NotBlank(message = "Workspace description must not be blank")
-	private String description;
+	String description,
 
 	@Pattern(regexp = "^(?!.*[가-힣])(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,30}",
 		message = "The password must be alphanumeric"
 			+ " including at least one special character and must be between 8 and 30 characters")
-	private String password;
-
-	private String code;
-
-	@Builder
-	public CreateWorkspaceRequest(String name, String description, String password, String code) {
-		this.name = name;
-		this.description = description;
-		this.password = password;
-		this.code = code;
-	}
-
-	public void setCode(String code) {
-		this.code = code;
-	}
-
-	public void setPassword(String password) {
-		this.password = password;
-	}
+	String password,
+	
+	@Pattern(regexp = "^[a-zA-Z]+$", message = "Must contain only alphabetic characters.")
+	@Size(min = 3, max = 16, message = "A issue key must between 3 ~ 16 characters long.")
+	String keyPrefix
+) {
 
 	public static Workspace to(CreateWorkspaceRequest request) {
 		return Workspace.builder()
 			.name(request.name)
 			.description(request.description)
 			.password(request.password)
-			.code(request.code)
 			.build();
 	}
 

--- a/backend/src/main/java/com/tissue/api/workspace/presentation/dto/request/UpdateIssueKeyRequest.java
+++ b/backend/src/main/java/com/tissue/api/workspace/presentation/dto/request/UpdateIssueKeyRequest.java
@@ -1,0 +1,13 @@
+package com.tissue.api.workspace.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UpdateIssueKeyRequest(
+	@NotBlank(message = "Issue key must not be blank.")
+	@Pattern(regexp = "^[a-zA-Z]+$", message = "Must contain only alphabetic characters.")
+	@Size(min = 3, max = 16, message = "A issue key must between 3 ~ 16 characters long.")
+	String issueKeyPrefix
+) {
+}

--- a/backend/src/main/java/com/tissue/api/workspace/presentation/dto/response/CreateWorkspaceResponse.java
+++ b/backend/src/main/java/com/tissue/api/workspace/presentation/dto/response/CreateWorkspaceResponse.java
@@ -4,16 +4,25 @@ import java.time.LocalDateTime;
 
 import com.tissue.api.workspace.domain.Workspace;
 
+import lombok.Builder;
+
+@Builder
 public record CreateWorkspaceResponse(
 	Long id,
 	String code,
+	String name,
+	String description,
+	String keyPrefix,
 	LocalDateTime createdAt
 ) {
 	public static CreateWorkspaceResponse from(Workspace workspace) {
-		return new CreateWorkspaceResponse(
-			workspace.getId(),
-			workspace.getCode(),
-			workspace.getCreatedDate()
-		);
+		return CreateWorkspaceResponse.builder()
+			.id(workspace.getId())
+			.code(workspace.getCode())
+			.name(workspace.getName())
+			.description(workspace.getDescription())
+			.keyPrefix(workspace.getKeyPrefix())
+			.createdAt(workspace.getCreatedDate())
+			.build();
 	}
 }

--- a/backend/src/main/java/com/tissue/api/workspace/presentation/dto/response/UpdateIssueKeyResponse.java
+++ b/backend/src/main/java/com/tissue/api/workspace/presentation/dto/response/UpdateIssueKeyResponse.java
@@ -1,0 +1,20 @@
+package com.tissue.api.workspace.presentation.dto.response;
+
+import com.tissue.api.workspace.domain.Workspace;
+
+import lombok.Builder;
+
+@Builder
+public record UpdateIssueKeyResponse(
+	Long workspaceId,
+	String workspaceCode,
+	String keyPrefix
+) {
+	public static UpdateIssueKeyResponse from(Workspace workspace) {
+		return UpdateIssueKeyResponse.builder()
+			.workspaceId(workspace.getId())
+			.workspaceCode(workspace.getCode())
+			.keyPrefix(workspace.getKeyPrefix())
+			.build();
+	}
+}

--- a/backend/src/main/java/com/tissue/api/workspace/service/command/WorkspaceCommandService.java
+++ b/backend/src/main/java/com/tissue/api/workspace/service/command/WorkspaceCommandService.java
@@ -5,18 +5,20 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.tissue.api.security.PasswordEncoder;
-import com.tissue.api.workspace.presentation.dto.request.DeleteWorkspaceRequest;
-import com.tissue.api.workspace.presentation.dto.response.UpdateWorkspaceInfoResponse;
-import com.tissue.api.workspace.validator.WorkspaceValidator;
 import com.tissue.api.member.domain.Member;
 import com.tissue.api.member.domain.repository.MemberRepository;
+import com.tissue.api.security.PasswordEncoder;
 import com.tissue.api.workspace.domain.Workspace;
 import com.tissue.api.workspace.domain.repository.WorkspaceRepository;
 import com.tissue.api.workspace.exception.WorkspaceNotFoundException;
+import com.tissue.api.workspace.presentation.dto.request.DeleteWorkspaceRequest;
+import com.tissue.api.workspace.presentation.dto.request.UpdateIssueKeyRequest;
 import com.tissue.api.workspace.presentation.dto.request.UpdateWorkspaceInfoRequest;
 import com.tissue.api.workspace.presentation.dto.request.UpdateWorkspacePasswordRequest;
 import com.tissue.api.workspace.presentation.dto.response.DeleteWorkspaceResponse;
+import com.tissue.api.workspace.presentation.dto.response.UpdateIssueKeyResponse;
+import com.tissue.api.workspace.presentation.dto.response.UpdateWorkspaceInfoResponse;
+import com.tissue.api.workspace.validator.WorkspaceValidator;
 import com.tissue.api.workspacemember.exception.MemberNotInWorkspaceException;
 
 import lombok.RequiredArgsConstructor;
@@ -70,6 +72,18 @@ public class WorkspaceCommandService {
 		workspaceRepository.delete(workspace);
 
 		return DeleteWorkspaceResponse.from(workspace);
+	}
+
+	@Transactional
+	public UpdateIssueKeyResponse updateIssueKey(
+		String code,
+		UpdateIssueKeyRequest request
+	) {
+		Workspace workspace = findWorkspaceByCode(code);
+
+		workspace.updateKeyPrefix(request.issueKeyPrefix());
+
+		return UpdateIssueKeyResponse.from(workspace);
 	}
 
 	private Workspace findWorkspaceByCode(String code) {

--- a/backend/src/main/java/com/tissue/api/workspace/service/command/create/RetryCodeGenerationOnExceptionService.java
+++ b/backend/src/main/java/com/tissue/api/workspace/service/command/create/RetryCodeGenerationOnExceptionService.java
@@ -9,16 +9,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.tissue.api.member.domain.Member;
 import com.tissue.api.member.domain.repository.MemberRepository;
-import com.tissue.api.security.PasswordEncoder;
-import com.tissue.api.workspace.presentation.dto.request.CreateWorkspaceRequest;
-import com.tissue.api.workspace.presentation.dto.response.CreateWorkspaceResponse;
-import com.tissue.api.workspacemember.domain.WorkspaceMember;
-import com.tissue.api.workspacemember.domain.repository.WorkspaceMemberRepository;
 import com.tissue.api.member.exception.MemberNotFoundException;
+import com.tissue.api.security.PasswordEncoder;
 import com.tissue.api.util.WorkspaceCodeGenerator;
 import com.tissue.api.workspace.domain.Workspace;
 import com.tissue.api.workspace.domain.repository.WorkspaceRepository;
 import com.tissue.api.workspace.exception.WorkspaceCodeCollisionHandleException;
+import com.tissue.api.workspace.presentation.dto.request.CreateWorkspaceRequest;
+import com.tissue.api.workspace.presentation.dto.response.CreateWorkspaceResponse;
+import com.tissue.api.workspacemember.domain.WorkspaceMember;
+import com.tissue.api.workspacemember.domain.repository.WorkspaceMemberRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,16 +47,15 @@ public class RetryCodeGenerationOnExceptionService implements WorkspaceCreateSer
 
 		for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
 			try {
-				setWorkspaceCode(request);
-				setEncodedPasswordIfPresent(request);
+				Workspace workspace = CreateWorkspaceRequest.to(request);
+				setWorkspaceCode(workspace);
+				setEncodedPasswordIfPresent(request, workspace);
+				setKeyPrefix(request, workspace);
 
-				/*
-				 * 테스트 용이성을 위해서 saveWithNewTransaction의 사용을 고려하자
-				 */
-				Workspace workspace = workspaceRepository.saveAndFlush(CreateWorkspaceRequest.to(request));
-				addOwnerMemberToWorkspace(member, workspace);
+				Workspace savedWorkspace = workspaceRepository.saveAndFlush(workspace);
+				addOwnerMemberToWorkspace(member, savedWorkspace);
 
-				return CreateWorkspaceResponse.from(workspace);
+				return CreateWorkspaceResponse.from(savedWorkspace);
 			} catch (DataIntegrityViolationException | ConstraintViolationException e) {
 				log.error("Catched exception for workspace code collision.");
 				log.error("Exception: ", e);
@@ -66,20 +65,24 @@ public class RetryCodeGenerationOnExceptionService implements WorkspaceCreateSer
 		throw new WorkspaceCodeCollisionHandleException();
 	}
 
+	private void setKeyPrefix(CreateWorkspaceRequest request, Workspace workspace) {
+		workspace.updateKeyPrefix(request.keyPrefix());
+	}
+
 	private void addOwnerMemberToWorkspace(Member member, Workspace workspace) {
 		WorkspaceMember workspaceMember = WorkspaceMember.addOwnerWorkspaceMember(member, workspace);
 		workspaceMemberRepository.save(workspaceMember);
 	}
 
-	private void setWorkspaceCode(CreateWorkspaceRequest request) {
+	private void setWorkspaceCode(Workspace workspace) {
 		String generatedCode = workspaceCodeGenerator.generateWorkspaceCode();
-		request.setCode(generatedCode);
+		workspace.setCode(generatedCode);
 	}
 
-	private void setEncodedPasswordIfPresent(CreateWorkspaceRequest request) {
-		String encodedPassword = Optional.ofNullable(request.getPassword())
+	private void setEncodedPasswordIfPresent(CreateWorkspaceRequest request, Workspace workspace) {
+		String encodedPassword = Optional.ofNullable(request.password())
 			.map(passwordEncoder::encode)
 			.orElse(null);
-		request.setPassword(encodedPassword);
+		workspace.updatePassword(encodedPassword);
 	}
 }

--- a/backend/src/test/java/com/tissue/api/workspace/presentation/controller/WorkspaceControllerTest.java
+++ b/backend/src/test/java/com/tissue/api/workspace/presentation/controller/WorkspaceControllerTest.java
@@ -18,37 +18,19 @@ import org.mockito.ArgumentMatchers;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 
+import com.tissue.api.security.session.SessionAttributes;
 import com.tissue.api.workspace.domain.Workspace;
+import com.tissue.api.workspace.presentation.dto.WorkspaceDetail;
 import com.tissue.api.workspace.presentation.dto.request.CreateWorkspaceRequest;
 import com.tissue.api.workspace.presentation.dto.request.DeleteWorkspaceRequest;
+import com.tissue.api.workspace.presentation.dto.request.UpdateIssueKeyRequest;
 import com.tissue.api.workspace.presentation.dto.request.UpdateWorkspaceInfoRequest;
 import com.tissue.api.workspace.presentation.dto.response.DeleteWorkspaceResponse;
+import com.tissue.api.workspace.presentation.dto.response.UpdateIssueKeyResponse;
 import com.tissue.api.workspace.presentation.dto.response.UpdateWorkspaceInfoResponse;
 import com.tissue.helper.ControllerTestHelper;
-import com.tissue.api.security.session.SessionAttributes;
-import com.tissue.api.workspace.presentation.dto.WorkspaceDetail;
 
 class WorkspaceControllerTest extends ControllerTestHelper {
-
-	@Test
-	@DisplayName("POST /workspaces - 워크스페이스 생성을 성공하면 201을 응답한다")
-	void test1() throws Exception {
-
-		MockHttpSession session = new MockHttpSession();
-		session.setAttribute(SessionAttributes.LOGIN_MEMBER_ID, 1L);
-
-		CreateWorkspaceRequest request = CreateWorkspaceRequest.builder()
-			.name("Test Workspace")
-			.description("Test Description")
-			.build();
-
-		mockMvc.perform(post("/api/v1/workspaces")
-				.session(session)
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request)))
-			.andExpect(status().isCreated())
-			.andDo(print());
-	}
 
 	/**
 	 * Todo
@@ -65,21 +47,35 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 		);
 	}
 
+	@Test
+	@DisplayName("POST /workspaces - 워크스페이스 생성을 성공하면 201을 응답한다")
+	void test1() throws Exception {
+		// given
+		CreateWorkspaceRequest request = CreateWorkspaceRequest.builder()
+			.name("Test Workspace")
+			.description("Test Description")
+			.build();
+
+		// when & then
+		mockMvc.perform(post("/api/v1/workspaces")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isCreated())
+			.andDo(print());
+	}
+
 	@ParameterizedTest
 	@MethodSource("provideInvalidInputs")
 	@DisplayName("POST /workspaces - 워크스페이스 생성 요청에서 이름과 설명은 null, 빈 문자열 또는 공백이면 검증 오류가 발생한다")
 	void test2(String name, String description) throws Exception {
-
-		MockHttpSession session = new MockHttpSession();
-		session.setAttribute(SessionAttributes.LOGIN_MEMBER_ID, 1L);
-
+		// given
 		CreateWorkspaceRequest request = CreateWorkspaceRequest.builder()
 			.name(name)
 			.description(description)
 			.build();
 
+		// when & then
 		mockMvc.perform(post("/api/v1/workspaces")
-				.session(session)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isBadRequest())
@@ -95,9 +91,6 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 	@DisplayName("POST /workspaces - 워크스페이스 생성 요청에서 이름의 범위는 2~50자, 설명은 1~255자를 지키지 않으면 400을 응답한다")
 	void test3() throws Exception {
 		// given
-		MockHttpSession session = new MockHttpSession();
-		session.setAttribute(SessionAttributes.LOGIN_MEMBER_ID, 1L);
-
 		String longName = createLongString(51);
 		String longDescription = createLongString(256);
 		String nameValidMsg = "Workspace name must be 2 ~ 50 characters long";
@@ -110,7 +103,6 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 
 		// when & then
 		mockMvc.perform(post("/api/v1/workspaces")
-				.session(session)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isBadRequest())
@@ -123,9 +115,6 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 	@DisplayName("PATCH /workspaces/{code}/info - 워크스페이스 정보 수정 요청에 성공하면 200을 응답받는다")
 	void updateWorkspaceContent_shouldReturnUpdatedContent() throws Exception {
 		// given
-		MockHttpSession session = new MockHttpSession();
-		session.setAttribute(SessionAttributes.LOGIN_MEMBER_ID, 1L);
-
 		UpdateWorkspaceInfoRequest request = new UpdateWorkspaceInfoRequest("New Title", "New Description");
 
 		Workspace workspace = Workspace.builder()
@@ -143,7 +132,6 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 
 		// when & then
 		mockMvc.perform(patch("/api/v1/workspaces/{code}/info", "TESTCODE")
-				.session(session)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
@@ -159,9 +147,6 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 	@DisplayName("DELETE /workspaces/{code} - 워크스페이스 삭제 요청에 성공하면 200을 응답받는다")
 	void deleteWorkspace_shouldReturnSuccess() throws Exception {
 		// given
-		MockHttpSession session = new MockHttpSession();
-		session.setAttribute(SessionAttributes.LOGIN_MEMBER_ID, 1L);
-
 		DeleteWorkspaceRequest request = new DeleteWorkspaceRequest("password1234!");
 
 		Workspace workspace = Workspace.builder()
@@ -176,7 +161,6 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 
 		// when & then
 		mockMvc.perform(delete("/api/v1/workspaces/{code}", "TESTCODE")
-				.session(session)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
@@ -214,5 +198,48 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 			.andExpect(jsonPath("$.data.description").value("Test Description"))
 			.andDo(print());
 
+	}
+
+	@Test
+	@DisplayName("PATCH /workspaces/{code}/key - key prefix 수정에 성공하면 OK를 응답한다")
+	void updateWorkspaceIssueKeyPrefix_shouldReturnOK() throws Exception {
+		// given
+		UpdateIssueKeyRequest request = new UpdateIssueKeyRequest("TESTPREFIX");
+
+		UpdateIssueKeyResponse response = UpdateIssueKeyResponse.builder()
+			.workspaceId(1L)
+			.workspaceCode("TESTCODE")
+			.keyPrefix("TESTPREFIX")
+			.build();
+
+		when(workspaceCommandService.updateIssueKey("TESTCODE", request))
+			.thenReturn(response);
+
+		// when & then
+		mockMvc.perform(patch("/api/v1/workspaces/{code}/key", "TESTCODE")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("Issue key prefix updated."))
+			.andExpect(jsonPath("$.data.workspaceCode").value("TESTCODE"))
+			.andExpect(jsonPath("$.data.keyPrefix").value("TESTPREFIX"))
+			.andDo(print());
+
+		verify(workspaceCommandService, times(1))
+			.updateIssueKey("TESTCODE", request);
+	}
+
+	@Test
+	@DisplayName("PATCH /workspaces/{code}/key - key prefix 수정 요청에 영문자 외 사용하면 검증을 실패한다")
+	void updateWorkspaceIssueKeyPrefix_failsRequestValidation() throws Exception {
+		// given
+		UpdateIssueKeyRequest request = new UpdateIssueKeyRequest("잘못된접두사");
+
+		// when & then
+		mockMvc.perform(patch("/api/v1/workspaces/{code}/key", "TESTCODE")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(request)))
+			.andExpect(status().isBadRequest())
+			.andDo(print());
 	}
 }

--- a/backend/src/test/java/com/tissue/api/workspace/service/command/WorkspaceCommandServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/workspace/service/command/WorkspaceCommandServiceIT.java
@@ -13,9 +13,11 @@ import com.tissue.api.workspace.exception.InvalidWorkspacePasswordException;
 import com.tissue.api.workspace.exception.WorkspaceNotFoundException;
 import com.tissue.api.workspace.presentation.dto.request.CreateWorkspaceRequest;
 import com.tissue.api.workspace.presentation.dto.request.DeleteWorkspaceRequest;
+import com.tissue.api.workspace.presentation.dto.request.UpdateIssueKeyRequest;
 import com.tissue.api.workspace.presentation.dto.request.UpdateWorkspaceInfoRequest;
 import com.tissue.api.workspace.presentation.dto.request.UpdateWorkspacePasswordRequest;
 import com.tissue.api.workspace.presentation.dto.response.CreateWorkspaceResponse;
+import com.tissue.api.workspace.presentation.dto.response.UpdateIssueKeyResponse;
 import com.tissue.api.workspace.presentation.dto.response.UpdateWorkspaceInfoResponse;
 import com.tissue.api.workspacemember.domain.WorkspaceRole;
 import com.tissue.helper.ServiceIntegrationTestHelper;
@@ -31,7 +33,11 @@ class WorkspaceCommandServiceIT extends ServiceIntegrationTestHelper {
 	@DisplayName("유효한 워크스페이스 코드와 비밀번호로 워크스페이스를 삭제할 수 있다")
 	void test1() {
 		// given
-		Member member = memberRepositoryFixture.createAndSaveMember("member1", "member1@test.com", "member1password!");
+		Member member = memberRepositoryFixture.createAndSaveMember(
+			"member1",
+			"member1@test.com",
+			"member1password!"
+		);
 
 		CreateWorkspaceResponse response = workspaceCreateService.createWorkspace(CreateWorkspaceRequest.builder()
 			.name("workspace1")
@@ -51,7 +57,11 @@ class WorkspaceCommandServiceIT extends ServiceIntegrationTestHelper {
 	@DisplayName("워크스페이스 삭제 시도 시 비밀번호가 맞지 않으면 예외가 발생한다")
 	void test2() {
 		// given
-		Member member = memberRepositoryFixture.createAndSaveMember("member1", "member1@test.com", "member1password!");
+		Member member = memberRepositoryFixture.createAndSaveMember(
+			"member1",
+			"member1@test.com",
+			"member1password!"
+		);
 
 		CreateWorkspaceResponse response = workspaceCreateService.createWorkspace(CreateWorkspaceRequest.builder()
 			.name("workspace1")
@@ -73,16 +83,26 @@ class WorkspaceCommandServiceIT extends ServiceIntegrationTestHelper {
 	@DisplayName("워크스페이스 삭제 시도 시 코드가 유효하지 않으면 예외가 발생한다")
 	void test3() {
 		// given
-		Member member = memberRepositoryFixture.createAndSaveMember("member1", "member1@test.com", "member1password!");
-		Workspace workspace = workspaceRepositoryFixture.createAndSaveWorkspace("workspace1", "description1",
+		Member member = memberRepositoryFixture.createAndSaveMember(
+			"member1",
+			"member1@test.com",
+			"member1password!"
+		);
+
+		Workspace workspace = workspaceRepositoryFixture.createAndSaveWorkspace(
+			"workspace1",
+			"description1",
 			"TEST1111",
-			"password1234!");
+			"password1234!"
+		);
 		workspaceRepositoryFixture.addAndSaveMemberToWorkspace(member, workspace, WorkspaceRole.MANAGER);
 
 		// when & then
-		assertThatThrownBy(
-			() -> workspaceCommandService.deleteWorkspace(new DeleteWorkspaceRequest("password1234!"), "INVALIDCODE",
-				member.getId()))
+		assertThatThrownBy(() -> workspaceCommandService.deleteWorkspace(
+			new DeleteWorkspaceRequest("password1234!"),
+			"INVALIDCODE",
+			member.getId())
+		)
 			.isInstanceOf(WorkspaceNotFoundException.class);
 
 	}
@@ -92,7 +112,12 @@ class WorkspaceCommandServiceIT extends ServiceIntegrationTestHelper {
 	@DisplayName("유효한 워크스페이스 코드로 워크스페이스의 이름과 설명을 수정할 수 있다")
 	void test4() {
 		// given
-		workspaceRepositoryFixture.createAndSaveWorkspace("workspace1", "description1", "TEST1111", null);
+		workspaceRepositoryFixture.createAndSaveWorkspace(
+			"workspace1",
+			"description1",
+			"TEST1111",
+			null
+		);
 
 		UpdateWorkspaceInfoRequest request = UpdateWorkspaceInfoRequest.builder()
 			.name("Updated Name")
@@ -117,7 +142,12 @@ class WorkspaceCommandServiceIT extends ServiceIntegrationTestHelper {
 	@DisplayName("워크스페이스의 이름만 수정하면 해당 필드만 업데이트된다")
 	void test5() {
 		// given
-		workspaceRepositoryFixture.createAndSaveWorkspace("workspace1", "description1", "TEST1111", null);
+		workspaceRepositoryFixture.createAndSaveWorkspace(
+			"workspace1",
+			"description1",
+			"TEST1111",
+			null
+		);
 
 		UpdateWorkspaceInfoRequest request = UpdateWorkspaceInfoRequest.builder()
 			.name("Updated Name")
@@ -145,7 +175,12 @@ class WorkspaceCommandServiceIT extends ServiceIntegrationTestHelper {
 	@DisplayName("비밀번호 수정 요청의 원본 비밀번호가 유효하면 요청의 수정 비밀번호로 업데이트된다")
 	void test7() {
 		// given
-		workspaceRepositoryFixture.createAndSaveWorkspace("workspace1", "description1", "TEST1111", "password1234!");
+		workspaceRepositoryFixture.createAndSaveWorkspace(
+			"workspace1",
+			"description1",
+			"TEST1111",
+			"password1234!"
+		);
 
 		UpdateWorkspacePasswordRequest request = UpdateWorkspacePasswordRequest.builder()
 			.originalPassword("password1234!")
@@ -166,7 +201,12 @@ class WorkspaceCommandServiceIT extends ServiceIntegrationTestHelper {
 	@DisplayName("워크스페이스의 비밀번호가 null이면 비밀번호 수정 요청의 수정 비밀번호로 업데이트된다")
 	void test8() {
 		// given
-		workspaceRepositoryFixture.createAndSaveWorkspace("workspace1", "description1", "TEST1111", null);
+		workspaceRepositoryFixture.createAndSaveWorkspace(
+			"workspace1",
+			"description1",
+			"TEST1111",
+			null
+		);
 
 		UpdateWorkspacePasswordRequest request = UpdateWorkspacePasswordRequest.builder()
 			.updatePassword("updated1234!")
@@ -185,7 +225,12 @@ class WorkspaceCommandServiceIT extends ServiceIntegrationTestHelper {
 	@DisplayName("비밀번호 수정 요청의 원본 비밀번호가 유효하지 않으면 예외가 발생한다")
 	void test9() {
 		// given
-		workspaceRepositoryFixture.createAndSaveWorkspace("workspace1", "description1", "TEST1111", "password1234!");
+		workspaceRepositoryFixture.createAndSaveWorkspace(
+			"workspace1",
+			"description1",
+			"TEST1111",
+			"password1234!"
+		);
 
 		UpdateWorkspacePasswordRequest request = UpdateWorkspacePasswordRequest.builder()
 			.originalPassword("invalid1234!")
@@ -202,7 +247,12 @@ class WorkspaceCommandServiceIT extends ServiceIntegrationTestHelper {
 	@DisplayName("비밀번호 수정 요청의 수정 비밀번호를 제공하지 않으면 비밀번호는 null로 업데이트 된다")
 	void test10() {
 		// given
-		workspaceRepositoryFixture.createAndSaveWorkspace("workspace1", "description1", "TEST1111", "password1234!");
+		workspaceRepositoryFixture.createAndSaveWorkspace(
+			"workspace1",
+			"description1",
+			"TEST1111",
+			"password1234!"
+		);
 
 		UpdateWorkspacePasswordRequest request = UpdateWorkspacePasswordRequest.builder()
 			.originalPassword("password1234!")
@@ -215,7 +265,6 @@ class WorkspaceCommandServiceIT extends ServiceIntegrationTestHelper {
 		// then
 		String updatedPassword = workspaceRepository.findByCode("TEST1111").get().getPassword();
 		assertThat(updatedPassword).isNull();
-
 	}
 
 	@Transactional
@@ -223,7 +272,12 @@ class WorkspaceCommandServiceIT extends ServiceIntegrationTestHelper {
 	@DisplayName("비밀번호 수정 요청의 수정 비밀번호를 null로 제공하면 비밀번호는 null로 업데이트 된다")
 	void test11() {
 		// given
-		workspaceRepositoryFixture.createAndSaveWorkspace("workspace1", "description1", "TEST1111", "password1234!");
+		workspaceRepositoryFixture.createAndSaveWorkspace(
+			"workspace1",
+			"description1",
+			"TEST1111",
+			"password1234!"
+		);
 
 		UpdateWorkspacePasswordRequest request = UpdateWorkspacePasswordRequest.builder()
 			.originalPassword("password1234!")
@@ -237,6 +291,57 @@ class WorkspaceCommandServiceIT extends ServiceIntegrationTestHelper {
 		// then
 		String updatedPassword = workspaceRepository.findByCode("TEST1111").get().getPassword();
 		assertThat(updatedPassword).isNull();
+	}
 
+	@Test
+	@DisplayName("워크스페이스 생성 시, key prefix의 값을 제공하지 않으면 기본적으로 'ISSUE'로 설정된다")
+	void workspaceCreate_ifNoKeyPrefixProvided_setToDefaultPrefix() {
+		// given
+		Member member = memberRepositoryFixture.createAndSaveMember(
+			"member1",
+			"member1@test.com",
+			"password1234!"
+		);
+
+		CreateWorkspaceRequest request = CreateWorkspaceRequest.builder()
+			.name("workspace1")
+			.description("description1")
+			.build();
+
+		// when
+		CreateWorkspaceResponse response = workspaceCreateService.createWorkspace(request, member.getId());
+
+		// then
+		Workspace workspace = workspaceRepository.findById(response.id())
+			.orElseThrow();
+
+		assertThat(workspace.getKeyPrefix()).isEqualTo("ISSUE");
+	}
+
+	@Test
+	@DisplayName("key prefix를 요청을 통해 제공한 key prefix로 업데이트 할 수 있다")
+	void testUpdateKeyPrefix() {
+		// given
+		Member member = memberRepositoryFixture.createAndSaveMember(
+			"member1",
+			"member1@test.com",
+			"password1234!"
+		);
+
+		CreateWorkspaceRequest createRequest = CreateWorkspaceRequest.builder()
+			.name("workspace1")
+			.description("description1")
+			.build();
+
+		workspaceCreateService.createWorkspace(createRequest, member.getId());
+
+		UpdateIssueKeyRequest request = new UpdateIssueKeyRequest("UPDATEPREFIX");
+
+		// when
+		Workspace workspace = workspaceRepository.findById(1L).orElseThrow();
+		UpdateIssueKeyResponse response = workspaceCommandService.updateIssueKey(workspace.getCode(), request);
+
+		// then
+		assertThat(response.keyPrefix()).isEqualTo("UPDATEPREFIX");
 	}
 }


### PR DESCRIPTION
## 🚀 설명
- `Workspace` 엔티티 이슈 키 관련 필드 추가
- `Workspace`에서 관리하는 이슈 키 접두사 수정 API 구현
- 워크스페이스 생성 시, 이슈 키 접두사를 정할 수 있도록 변경
- 이슈 생성 시, 이슈 키를 조합해서 부여
- 추후에 동시성 문제를 해결하기 위한 낙관적 락 + Spring-retry 적용이 필요해 보임

---
## ✅ 변경 사항
- [x] `Workspace` 엔티티 이슈 키 관련 필드 추가
- [x] `Workspace`에서 관리하는 이슈 키 접두사 수정 API 구현
- [x] 워크스페이스 생성 시, 이슈 키 접두사를 정할 수 있도록 변경
- [x] 이슈 생성 시, 이슈 키를 조합해서 부여하도록 구현
- [x] 테스트 추가

---
## 🚩 관련 이슈, PR
- #143 

---
## 📖 참고