### PR TITLE
Feat/#145 DTO에 레코드 적용, 레코드에는 `@Builder` 적용

### DIFF
--- a/backend/src/main/java/com/tissue/api/invitation/presentation/dto/response/AcceptInvitationResponse.java
+++ b/backend/src/main/java/com/tissue/api/invitation/presentation/dto/response/AcceptInvitationResponse.java
@@ -4,16 +4,19 @@ import java.time.LocalDateTime;
 
 import com.tissue.api.invitation.domain.Invitation;
 
+import lombok.Builder;
+
+@Builder
 public record AcceptInvitationResponse(
 	Long invitationId,
 	String workspaceCode,
 	LocalDateTime acceptedAt
 ) {
 	public static AcceptInvitationResponse from(Invitation invitation) {
-		return new AcceptInvitationResponse(
-			invitation.getId(),
-			invitation.getWorkspaceCode(),
-			invitation.getLastModifiedDate()
-		);
+		return AcceptInvitationResponse.builder()
+			.invitationId(invitation.getId())
+			.workspaceCode(invitation.getWorkspaceCode())
+			.acceptedAt(invitation.getLastModifiedDate())
+			.build();
 	}
 }

--- a/backend/src/main/java/com/tissue/api/invitation/presentation/dto/response/InvitationResponse.java
+++ b/backend/src/main/java/com/tissue/api/invitation/presentation/dto/response/InvitationResponse.java
@@ -5,6 +5,9 @@ import java.time.LocalDateTime;
 import com.tissue.api.invitation.domain.Invitation;
 import com.tissue.api.invitation.domain.InvitationStatus;
 
+import lombok.Builder;
+
+@Builder
 public record InvitationResponse(
 	Long invitationId,
 	String workspaceCode,
@@ -13,12 +16,12 @@ public record InvitationResponse(
 	LocalDateTime invitedAt
 ) {
 	public static InvitationResponse from(Invitation invitation) {
-		return new InvitationResponse(
-			invitation.getId(),
-			invitation.getWorkspaceCode(),
-			invitation.getCreatedBy(),
-			invitation.getStatus(),
-			invitation.getCreatedDate()
-		);
+		return InvitationResponse.builder()
+			.invitationId(invitation.getId())
+			.workspaceCode(invitation.getWorkspaceCode())
+			.invitedBy(invitation.getCreatedBy())
+			.status(invitation.getStatus())
+			.invitedAt(invitation.getCreatedDate())
+			.build();
 	}
 }

--- a/backend/src/main/java/com/tissue/api/invitation/presentation/dto/response/RejectInvitationResponse.java
+++ b/backend/src/main/java/com/tissue/api/invitation/presentation/dto/response/RejectInvitationResponse.java
@@ -4,16 +4,19 @@ import java.time.LocalDateTime;
 
 import com.tissue.api.invitation.domain.Invitation;
 
+import lombok.Builder;
+
+@Builder
 public record RejectInvitationResponse(
 	Long invitationId,
 	String workspaceCode,
 	LocalDateTime rejectedAt
 ) {
 	public static RejectInvitationResponse from(Invitation invitation) {
-		return new RejectInvitationResponse(
-			invitation.getId(),
-			invitation.getWorkspaceCode(),
-			invitation.getLastModifiedDate()
-		);
+		return RejectInvitationResponse.builder()
+			.invitationId(invitation.getId())
+			.workspaceCode(invitation.getWorkspaceCode())
+			.rejectedAt(invitation.getLastModifiedDate())
+			.build();
 	}
 }

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateBugResponse.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateBugResponse.java
@@ -17,6 +17,7 @@ import lombok.Builder;
 @Builder
 public record CreateBugResponse(
 	Long issueId,
+	String issueKey,
 	String workspaceCode,
 	Long reporterId, // Todo: workspaceMemberDetail 사용 고려, SessionAuditorAware에서 workspaceMemberId 반환하는 형태로 변경
 	String title,
@@ -32,14 +33,10 @@ public record CreateBugResponse(
 	Long parentIssueId
 ) implements CreateIssueResponse {
 
-	@Override
-	public IssueType getType() {
-		return IssueType.BUG;
-	}
-
 	public static CreateBugResponse from(Bug bug) {
 		return CreateBugResponse.builder()
 			.issueId(bug.getId())
+			.issueKey(bug.getIssueKey())
 			.workspaceCode(bug.getWorkspaceCode())
 			.reporterId(bug.getCreatedBy())
 			.title(bug.getTitle())
@@ -56,5 +53,10 @@ public record CreateBugResponse(
 				.map(Issue::getId)
 				.orElse(null))
 			.build();
+	}
+
+	@Override
+	public IssueType getType() {
+		return IssueType.BUG;
 	}
 }

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateEpicResponse.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateEpicResponse.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 @Builder
 public record CreateEpicResponse(
 	Long issueId,
+	String issueKey,
 	String workspaceCode,
 	Long reporterId,
 	String title,
@@ -24,14 +25,10 @@ public record CreateEpicResponse(
 	Long parentIssueId
 ) implements CreateIssueResponse {
 
-	@Override
-	public IssueType getType() {
-		return IssueType.EPIC;
-	}
-
 	public static CreateEpicResponse from(Epic epic) {
 		return CreateEpicResponse.builder()
 			.issueId(epic.getId())
+			.issueKey(epic.getIssueKey())
 			.workspaceCode(epic.getWorkspaceCode())
 			.reporterId(epic.getCreatedBy())
 			.title(epic.getTitle())
@@ -44,5 +41,10 @@ public record CreateEpicResponse(
 			.hardDeadLine(epic.getHardDeadLine())
 			.parentIssueId(epic.getParentIssue().getId())
 			.build();
+	}
+
+	@Override
+	public IssueType getType() {
+		return IssueType.EPIC;
 	}
 }

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateStoryResponse.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateStoryResponse.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 @Builder
 public record CreateStoryResponse(
 	Long issueId,
+	String issueKey,
 	String workspaceCode,
 	Long reporterId,
 	String title,
@@ -27,14 +28,10 @@ public record CreateStoryResponse(
 	Long parentIssueId
 ) implements CreateIssueResponse {
 
-	@Override
-	public IssueType getType() {
-		return IssueType.STORY;
-	}
-
 	public static CreateStoryResponse from(Story story) {
 		return CreateStoryResponse.builder()
 			.issueId(story.getId())
+			.issueKey(story.getIssueKey())
 			.workspaceCode(story.getWorkspaceCode())
 			.reporterId(story.getCreatedBy())
 			.title(story.getTitle())
@@ -49,5 +46,10 @@ public record CreateStoryResponse(
 				.map(Issue::getId)
 				.orElse(null))
 			.build();
+	}
+
+	@Override
+	public IssueType getType() {
+		return IssueType.STORY;
 	}
 }

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateSubTaskResponse.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateSubTaskResponse.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 @Builder
 public record CreateSubTaskResponse(
 	Long issueId,
+	String issueKey,
 	String workspaceCode,
 	Long reporterId,
 	String title,
@@ -25,14 +26,10 @@ public record CreateSubTaskResponse(
 	Long parentIssueId
 ) implements CreateIssueResponse {
 
-	@Override
-	public IssueType getType() {
-		return IssueType.SUB_TASK;
-	}
-
 	public static CreateSubTaskResponse from(SubTask subTask) {
 		return CreateSubTaskResponse.builder()
 			.issueId(subTask.getId())
+			.issueKey(subTask.getIssueKey())
 			.workspaceCode(subTask.getWorkspaceCode())
 			.reporterId(subTask.getCreatedBy())
 			.title(subTask.getTitle())
@@ -45,5 +42,10 @@ public record CreateSubTaskResponse(
 				.map(Issue::getId)
 				.orElse(null))
 			.build();
+	}
+
+	@Override
+	public IssueType getType() {
+		return IssueType.SUB_TASK;
 	}
 }

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateTaskResponse.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateTaskResponse.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 @Builder
 public record CreateTaskResponse(
 	Long issueId,
+	String issueKey,
 	String workspaceCode,
 	Long reporterId,
 	String title,
@@ -25,14 +26,10 @@ public record CreateTaskResponse(
 	Long parentIssueId
 ) implements CreateIssueResponse {
 
-	@Override
-	public IssueType getType() {
-		return IssueType.TASK;
-	}
-
 	public static CreateTaskResponse from(Task task) {
 		return CreateTaskResponse.builder()
 			.issueId(task.getId())
+			.issueKey(task.getIssueKey())
 			.workspaceCode(task.getWorkspaceCode())
 			.reporterId(task.getCreatedBy())
 			.title(task.getTitle())
@@ -45,5 +42,10 @@ public record CreateTaskResponse(
 				.map(Issue::getId)
 				.orElse(null))
 			.build();
+	}
+
+	@Override
+	public IssueType getType() {
+		return IssueType.TASK;
 	}
 }

--- a/backend/src/main/java/com/tissue/api/position/presentation/dto/response/CreatePositionResponse.java
+++ b/backend/src/main/java/com/tissue/api/position/presentation/dto/response/CreatePositionResponse.java
@@ -5,6 +5,9 @@ import java.time.LocalDateTime;
 import com.tissue.api.common.ColorType;
 import com.tissue.api.position.domain.Position;
 
+import lombok.Builder;
+
+@Builder
 public record CreatePositionResponse(
 	Long positionId,
 	String name,
@@ -13,12 +16,12 @@ public record CreatePositionResponse(
 	LocalDateTime createdAt
 ) {
 	public static CreatePositionResponse from(Position position) {
-		return new CreatePositionResponse(
-			position.getId(),
-			position.getName(),
-			position.getDescription(),
-			position.getColor(),
-			position.getCreatedDate()
-		);
+		return CreatePositionResponse.builder()
+			.positionId(position.getId())
+			.name(position.getName())
+			.description(position.getDescription())
+			.color(position.getColor())
+			.createdAt(position.getCreatedDate())
+			.build();
 	}
 }

--- a/backend/src/main/java/com/tissue/api/position/presentation/dto/response/PositionDetail.java
+++ b/backend/src/main/java/com/tissue/api/position/presentation/dto/response/PositionDetail.java
@@ -5,6 +5,9 @@ import java.time.LocalDateTime;
 import com.tissue.api.common.ColorType;
 import com.tissue.api.position.domain.Position;
 
+import lombok.Builder;
+
+@Builder
 public record PositionDetail(
 	Long positionId,
 	String name,
@@ -14,13 +17,13 @@ public record PositionDetail(
 	LocalDateTime updatedAt
 ) {
 	public static PositionDetail from(Position position) {
-		return new PositionDetail(
-			position.getId(),
-			position.getName(),
-			position.getDescription(),
-			position.getColor(),
-			position.getCreatedDate(),
-			position.getLastModifiedDate()
-		);
+		return PositionDetail.builder()
+			.positionId(position.getId())
+			.name(position.getName())
+			.description(position.getDescription())
+			.color(position.getColor())
+			.createdAt(position.getCreatedDate())
+			.updatedAt(position.getLastModifiedDate())
+			.build();
 	}
 }

--- a/backend/src/main/java/com/tissue/api/position/presentation/dto/response/UpdatePositionResponse.java
+++ b/backend/src/main/java/com/tissue/api/position/presentation/dto/response/UpdatePositionResponse.java
@@ -4,6 +4,9 @@ import java.time.LocalDateTime;
 
 import com.tissue.api.position.domain.Position;
 
+import lombok.Builder;
+
+@Builder
 public record UpdatePositionResponse(
 	Long positionId,
 	String name,
@@ -11,11 +14,11 @@ public record UpdatePositionResponse(
 	LocalDateTime updatedAt
 ) {
 	public static UpdatePositionResponse from(Position position) {
-		return new UpdatePositionResponse(
-			position.getId(),
-			position.getName(),
-			position.getDescription(),
-			position.getLastModifiedDate()
-		);
+		return UpdatePositionResponse.builder()
+			.positionId(position.getId())
+			.name(position.getName())
+			.description(position.getDescription())
+			.updatedAt(position.getLastModifiedDate())
+			.build();
 	}
 }

--- a/backend/src/main/java/com/tissue/api/workspace/presentation/dto/request/UpdateWorkspaceInfoRequest.java
+++ b/backend/src/main/java/com/tissue/api/workspace/presentation/dto/request/UpdateWorkspaceInfoRequest.java
@@ -2,24 +2,14 @@ package com.tissue.api.workspace.presentation.dto.request;
 
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class UpdateWorkspaceInfoRequest {
-
+@Builder
+public record UpdateWorkspaceInfoRequest(
 	@Size(min = 2, max = 50, message = "Workspace name must be 2 ~ 50 characters long")
-	private String name;
+	String name,
 	@Size(min = 1, max = 255, message = "Workspace description must be 1 ~ 255 characters long")
-	private String description;
-
-	@Builder
-	public UpdateWorkspaceInfoRequest(String name, String description) {
-		this.name = name;
-		this.description = description;
-	}
-
+	String description
+) {
 	public boolean hasName() {
 		return isNotBlank(name);
 	}

--- a/backend/src/main/java/com/tissue/api/workspace/service/command/WorkspaceCommandService.java
+++ b/backend/src/main/java/com/tissue/api/workspace/service/command/WorkspaceCommandService.java
@@ -98,10 +98,10 @@ public class WorkspaceCommandService {
 
 	private void updateWorkspaceInfoIfPresent(UpdateWorkspaceInfoRequest request, Workspace workspace) {
 		if (request.hasName()) {
-			workspace.updateName(request.getName());
+			workspace.updateName(request.name());
 		}
 		if (request.hasDescription()) {
-			workspace.updateDescription(request.getDescription());
+			workspace.updateDescription(request.description());
 		}
 	}
 

--- a/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/WorkspaceMemberDetail.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/WorkspaceMemberDetail.java
@@ -6,32 +6,15 @@ import com.tissue.api.workspacemember.domain.WorkspaceMember;
 import com.tissue.api.workspacemember.domain.WorkspaceRole;
 
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-public class WorkspaceMemberDetail {
-
-	private Long workspaceMemberId;
-	private String nickname;
-	private WorkspaceRole workspaceRole;
-	private LocalDateTime joinedWorkspaceAt;
-	private LocalDateTime updatedAt;
-
-	@Builder
-	public WorkspaceMemberDetail(
-		Long workspaceMemberId,
-		String nickname,
-		WorkspaceRole workspaceRole,
-		LocalDateTime joinedWorkspaceAt,
-		LocalDateTime updatedAt
-	) {
-		this.workspaceMemberId = workspaceMemberId;
-		this.nickname = nickname;
-		this.workspaceRole = workspaceRole;
-		this.joinedWorkspaceAt = joinedWorkspaceAt;
-		this.updatedAt = updatedAt;
-	}
-
+@Builder
+public record WorkspaceMemberDetail(
+	Long workspaceMemberId,
+	String nickname,
+	WorkspaceRole workspaceRole,
+	LocalDateTime joinedWorkspaceAt,
+	LocalDateTime updatedAt
+) {
 	public static WorkspaceMemberDetail from(WorkspaceMember workspaceMember) {
 		return WorkspaceMemberDetail.builder()
 			.workspaceMemberId(workspaceMember.getId())

--- a/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/request/InviteMembersRequest.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/request/InviteMembersRequest.java
@@ -3,22 +3,11 @@ package com.tissue.api.workspacemember.presentation.dto.request;
 import java.util.Set;
 
 import jakarta.validation.constraints.NotEmpty;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@EqualsAndHashCode
-public class InviteMembersRequest {
-
+public record InviteMembersRequest(
 	@NotEmpty(message = "Member identifiers must not be empty")
-	private Set<String> memberIdentifiers;
-
-	private InviteMembersRequest(Set<String> memberIdentifiers) {
-		this.memberIdentifiers = memberIdentifiers;
-	}
-
+	Set<String> memberIdentifiers
+) {
 	public static InviteMembersRequest of(Set<String> memberIdentifiers) {
 		return new InviteMembersRequest(memberIdentifiers);
 	}

--- a/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/request/JoinWorkspaceRequest.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/request/JoinWorkspaceRequest.java
@@ -1,21 +1,10 @@
 package com.tissue.api.workspacemember.presentation.dto.request;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
-
-@ToString
-@Getter
-@NoArgsConstructor
-public class JoinWorkspaceRequest {
-
-	/**
+public record JoinWorkspaceRequest(
+	/*
 	 * Todo
 	 * 	- 비밀번호 필드 패턴 검증
 	 */
-	private String password;
-
-	public JoinWorkspaceRequest(String password) {
-		this.password = password;
-	}
+	String password
+) {
 }

--- a/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/request/UpdateNicknameRequest.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/request/UpdateNicknameRequest.java
@@ -2,19 +2,10 @@ package com.tissue.api.workspacemember.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UpdateNicknameRequest {
-
+public record UpdateNicknameRequest(
 	@NotBlank(message = "Nickname must not be blank.")
 	@Size(min = 2, max = 30, message = "Nickname must be between 2 and 30 characters.")
-	private String nickname;
-
-	public UpdateNicknameRequest(String nickname) {
-		this.nickname = nickname;
-	}
+	String nickname
+) {
 }

--- a/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/request/UpdateRoleRequest.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/request/UpdateRoleRequest.java
@@ -3,18 +3,9 @@ package com.tissue.api.workspacemember.presentation.dto.request;
 import com.tissue.api.workspacemember.domain.WorkspaceRole;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UpdateRoleRequest {
-
+public record UpdateRoleRequest(
 	@NotNull(message = "Select a valid workspace role")
-	private WorkspaceRole updateWorkspaceRole;
-
-	public UpdateRoleRequest(WorkspaceRole updateWorkspaceRole) {
-		this.updateWorkspaceRole = updateWorkspaceRole;
-	}
+	WorkspaceRole updateWorkspaceRole
+) {
 }

--- a/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/response/RemoveWorkspaceMemberResponse.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/response/RemoveWorkspaceMemberResponse.java
@@ -5,17 +5,11 @@ import java.time.LocalDateTime;
 import com.tissue.api.workspacemember.domain.WorkspaceMember;
 
 public record RemoveWorkspaceMemberResponse(
-	/*
-	 * Todo
-	 *  - 추후에 포지션(Position)을 추가하면, 포지션도 응답으로 추가
-	 */
-	Long memberId,
-	Long workspaceMemberId,
+	Long removedWorkspaceMemberId,
 	LocalDateTime removedAt
 ) {
-	public static RemoveWorkspaceMemberResponse from(Long memberId, WorkspaceMember workspaceMember) {
+	public static RemoveWorkspaceMemberResponse from(WorkspaceMember workspaceMember) {
 		return new RemoveWorkspaceMemberResponse(
-			memberId,
 			workspaceMember.getId(),
 			workspaceMember.getLastModifiedDate()
 		);

--- a/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/response/UpdateNicknameResponse.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/response/UpdateNicknameResponse.java
@@ -6,7 +6,7 @@ import com.tissue.api.workspacemember.domain.WorkspaceMember;
 
 public record UpdateNicknameResponse(
 	Long workspaceMemberId,
-	String nickname,
+	String updatedNickname,
 	LocalDateTime updatedAt
 ) {
 	public static UpdateNicknameResponse from(WorkspaceMember workspaceMember) {

--- a/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/response/UpdateRoleResponse.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/response/UpdateRoleResponse.java
@@ -7,7 +7,7 @@ import com.tissue.api.workspacemember.domain.WorkspaceRole;
 
 public record UpdateRoleResponse(
 	Long workspaceMemberId,
-	WorkspaceRole role,
+	WorkspaceRole updatedRole,
 	LocalDateTime updatedAt
 ) {
 	public static UpdateRoleResponse from(WorkspaceMember workspaceMember) {

--- a/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceMemberCommandService.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceMemberCommandService.java
@@ -42,7 +42,7 @@ public class WorkspaceMemberCommandService {
 		try {
 			WorkspaceMember workspaceMember = findWorkspaceMember(code, memberId);
 
-			workspaceMember.updateNickname(request.getNickname());
+			workspaceMember.updateNickname(request.nickname());
 			workspaceMemberRepository.saveAndFlush(workspaceMember);
 
 			return UpdateNicknameResponse.from(workspaceMember);
@@ -65,7 +65,7 @@ public class WorkspaceMemberCommandService {
 
 		workspaceMemberValidator.validateRoleUpdate(requester, target);
 
-		target.updateRole(request.getUpdateWorkspaceRole());
+		target.updateRole(request.updateWorkspaceRole());
 
 		return UpdateRoleResponse.from(target);
 	}
@@ -122,7 +122,7 @@ public class WorkspaceMemberCommandService {
 		target.remove();
 		workspaceMemberRepository.delete(target);
 
-		return RemoveWorkspaceMemberResponse.from(targetId, target);
+		return RemoveWorkspaceMemberResponse.from(target);
 	}
 
 	private WorkspaceMember findWorkspaceMember(String code, Long memberId) {

--- a/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceMemberInviteService.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceMemberInviteService.java
@@ -33,7 +33,7 @@ public class WorkspaceMemberInviteService {
 			.orElseThrow(WorkspaceNotFoundException::new);
 
 		// 1. 초대 가능한 멤버 필터링
-		List<Member> membersToInvite = filterInvitableMembers(workspace.getId(), request.getMemberIdentifiers());
+		List<Member> membersToInvite = filterInvitableMembers(workspace.getId(), request.memberIdentifiers());
 
 		// 2. 초대장 생성 및 초대된 멤버 정보 수집
 		List<InviteMembersResponse.InvitedMember> invitedMembers = membersToInvite.stream()

--- a/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceParticipationCommandService.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceParticipationCommandService.java
@@ -52,7 +52,7 @@ public class WorkspaceParticipationCommandService {
 			throw new AlreadyJoinedWorkspaceException();
 		}
 
-		workspaceValidator.validatePasswordIfExists(workspace.getPassword(), request.getPassword());
+		workspaceValidator.validatePasswordIfExists(workspace.getPassword(), request.password());
 
 		WorkspaceMember workspaceMember = WorkspaceMember.addCollaboratorWorkspaceMember(member, workspace);
 		workspaceMemberRepository.save(workspaceMember);

--- a/backend/src/test/java/com/tissue/api/workspace/service/query/WorkspaceQueryServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/workspace/service/query/WorkspaceQueryServiceIT.java
@@ -12,10 +12,10 @@ import com.tissue.api.member.domain.Member;
 import com.tissue.api.member.presentation.dto.request.SignupMemberRequest;
 import com.tissue.api.workspace.domain.Workspace;
 import com.tissue.api.workspace.exception.WorkspaceNotFoundException;
+import com.tissue.api.workspace.presentation.dto.WorkspaceDetail;
 import com.tissue.api.workspacemember.domain.WorkspaceRole;
 import com.tissue.api.workspacemember.presentation.dto.request.JoinWorkspaceRequest;
 import com.tissue.helper.ServiceIntegrationTestHelper;
-import com.tissue.api.workspace.presentation.dto.WorkspaceDetail;
 
 class WorkspaceQueryServiceIT extends ServiceIntegrationTestHelper {
 
@@ -44,8 +44,8 @@ class WorkspaceQueryServiceIT extends ServiceIntegrationTestHelper {
 		);
 
 		// member1은 workspace1,2에 참여
-		workspaceParticipationCommandService.joinWorkspace("TEST1111", new JoinWorkspaceRequest(), 1L);
-		workspaceParticipationCommandService.joinWorkspace("TEST2222", new JoinWorkspaceRequest(), 1L);
+		workspaceParticipationCommandService.joinWorkspace("TEST1111", new JoinWorkspaceRequest(null), 1L);
+		workspaceParticipationCommandService.joinWorkspace("TEST2222", new JoinWorkspaceRequest(null), 1L);
 	}
 
 	@AfterEach
@@ -67,7 +67,7 @@ class WorkspaceQueryServiceIT extends ServiceIntegrationTestHelper {
 
 		workspaceParticipationCommandService.joinWorkspace(
 			"TEST1111",
-			new JoinWorkspaceRequest(),
+			new JoinWorkspaceRequest(null),
 			2L
 		);
 

--- a/backend/src/test/java/com/tissue/api/workspacemember/presentation/controller/WorkspaceMembershipControllerTest.java
+++ b/backend/src/test/java/com/tissue/api/workspacemember/presentation/controller/WorkspaceMembershipControllerTest.java
@@ -48,13 +48,15 @@ class WorkspaceMembershipControllerTest extends ControllerTestHelper {
 		workspaceMemberEntityFixture = new WorkspaceMemberEntityFixture();
 	}
 
+	/**
+	 * Todo
+	 *  - API 설계 개선 필요(리소스 접근 방법 변경)
+	 *  - /workspaces/{code}/members/{memberId} -> /workspaces/{code}/members/{workspaceMemberId}
+	 */
+
 	@Test
 	@DisplayName("DELETE /workspaces/{code}/members/{memberId} - 워크스페이스에서 멤버를 추방하는데 성공하면 200을 응답받는다")
 	void test13() throws Exception {
-		// Session 모킹
-		MockHttpSession session = new MockHttpSession();
-		session.setAttribute(SessionAttributes.LOGIN_MEMBER_ID, 1L);
-
 		// given
 		String workspaceCode = "TESTCODE";
 
@@ -63,18 +65,16 @@ class WorkspaceMembershipControllerTest extends ControllerTestHelper {
 		WorkspaceMember workspaceMember = workspaceMemberEntityFixture
 			.createCollaboratorWorkspaceMember(member, workspace);
 
-		RemoveWorkspaceMemberResponse response = RemoveWorkspaceMemberResponse.from(2L, workspaceMember);
+		RemoveWorkspaceMemberResponse response = RemoveWorkspaceMemberResponse.from(workspaceMember);
 
 		when(workspaceMemberCommandService.removeWorkspaceMember(eq(workspaceCode), eq(2L), anyLong()))
 			.thenReturn(response);
 
 		// when & then
 		mockMvc.perform(delete("/api/v1/workspaces/{code}/members/{memberId}", workspaceCode, 2L)
-				.session(session)
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.message").value("Member was removed from this workspace"))
-			.andExpect(jsonPath("$.data.memberId").value(2L))
 			.andDo(print());
 
 	}
@@ -115,7 +115,7 @@ class WorkspaceMembershipControllerTest extends ControllerTestHelper {
 				.content(objectMapper.writeValueAsString(new UpdateNicknameRequest("newNickname"))))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.message").value("Nickname updated."))
-			.andExpect(jsonPath("$.data.nickname").value("newNickname"))
+			.andExpect(jsonPath("$.data.updatedNickname").value("newNickname"))
 			.andDo(print());
 	}
 
@@ -197,7 +197,7 @@ class WorkspaceMembershipControllerTest extends ControllerTestHelper {
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.message").value("Member's role for this workspace was updated"))
-			.andExpect(jsonPath("$.data.role").value("MANAGER"))
+			.andExpect(jsonPath("$.data.updatedRole").value("MANAGER"))
 			.andDo(print());
 	}
 

--- a/backend/src/test/java/com/tissue/api/workspacemember/presentation/controller/WorkspaceParticipationControllerTest.java
+++ b/backend/src/test/java/com/tissue/api/workspacemember/presentation/controller/WorkspaceParticipationControllerTest.java
@@ -61,7 +61,7 @@ class WorkspaceParticipationControllerTest extends ControllerTestHelper {
 		Member member = memberEntityFixture.createMember(loginId, email);
 		WorkspaceMember workspaceMember = workspaceMemberEntityFixture.createCollaboratorWorkspaceMember(member,
 			workspace);
-		JoinWorkspaceRequest request = new JoinWorkspaceRequest();
+		JoinWorkspaceRequest request = new JoinWorkspaceRequest(null);
 
 		JoinWorkspaceResponse response = JoinWorkspaceResponse.from(workspaceMember);
 

--- a/backend/src/test/java/com/tissue/api/workspacemember/service/command/WorkspaceMemberCommandServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/workspacemember/service/command/WorkspaceMemberCommandServiceIT.java
@@ -2,7 +2,6 @@ package com.tissue.api.workspacemember.service.command;
 
 import static org.assertj.core.api.Assertions.*;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,14 +16,13 @@ import com.tissue.api.workspacemember.domain.WorkspaceRole;
 import com.tissue.api.workspacemember.exception.DuplicateNicknameException;
 import com.tissue.api.workspacemember.exception.InvalidRoleUpdateException;
 import com.tissue.api.workspacemember.exception.MemberNotInWorkspaceException;
-import com.tissue.api.workspacemember.presentation.dto.response.TransferOwnershipResponse;
-import com.tissue.helper.ServiceIntegrationTestHelper;
 import com.tissue.api.workspacemember.presentation.dto.request.UpdateNicknameRequest;
 import com.tissue.api.workspacemember.presentation.dto.request.UpdateRoleRequest;
 import com.tissue.api.workspacemember.presentation.dto.response.AssignPositionResponse;
-import com.tissue.api.workspacemember.presentation.dto.response.RemoveWorkspaceMemberResponse;
+import com.tissue.api.workspacemember.presentation.dto.response.TransferOwnershipResponse;
 import com.tissue.api.workspacemember.presentation.dto.response.UpdateNicknameResponse;
 import com.tissue.api.workspacemember.presentation.dto.response.UpdateRoleResponse;
+import com.tissue.helper.ServiceIntegrationTestHelper;
 
 class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 
@@ -68,13 +66,12 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 		workspaceRepositoryFixture.addAndSaveMemberToWorkspace(target, workspace, WorkspaceRole.COLLABORATOR);
 
 		// when
-		RemoveWorkspaceMemberResponse response = workspaceMemberCommandService.removeWorkspaceMember("TESTCODE",
+		workspaceMemberCommandService.removeWorkspaceMember("TESTCODE",
 			target.getId(),
 			requester.getId());
 
 		// then
-		assertThat(response.memberId()).isEqualTo(target.getId());
-		Assertions.assertThat(
+		assertThat(
 			workspaceMemberRepository.findByMemberIdAndWorkspaceCode(target.getId(), "TESTCODE")
 		).isEmpty();
 	}
@@ -188,7 +185,7 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 		);
 
 		// then
-		assertThat(response.role()).isEqualTo(WorkspaceRole.MANAGER);
+		assertThat(response.updatedRole()).isEqualTo(WorkspaceRole.MANAGER);
 	}
 
 	@Transactional
@@ -469,7 +466,7 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 		);
 
 		// then
-		assertThat(response.nickname()).isEqualTo(newNickname);
+		assertThat(response.updatedNickname()).isEqualTo(newNickname);
 
 		WorkspaceMember updatedMember = workspaceMemberRepository
 			.findByMemberIdAndWorkspaceCode(tester.getId(), workspace.getCode())
@@ -558,7 +555,7 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 		assertThat(response.assignedPosition()).isEqualTo(position.getName());
 
 		WorkspaceMember updatedMember = workspaceMemberRepository.findById(workspaceMember.getId()).get();
-		Assertions.assertThat(updatedMember.getPosition()).isEqualTo(position);
+		assertThat(updatedMember.getPosition()).isEqualTo(position);
 	}
 
 	@Test

--- a/backend/src/test/java/com/tissue/api/workspacemember/service/query/WorkspaceParticipationQueryServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/workspacemember/service/query/WorkspaceParticipationQueryServiceIT.java
@@ -50,8 +50,8 @@ class WorkspaceParticipationQueryServiceIT extends ServiceIntegrationTestHelper 
 		);
 
 		// member1은 workspace1,2에 참여
-		workspaceParticipationCommandService.joinWorkspace("TEST1111", new JoinWorkspaceRequest(), 1L);
-		workspaceParticipationCommandService.joinWorkspace("TEST2222", new JoinWorkspaceRequest(), 1L);
+		workspaceParticipationCommandService.joinWorkspace("TEST1111", new JoinWorkspaceRequest(null), 1L);
+		workspaceParticipationCommandService.joinWorkspace("TEST2222", new JoinWorkspaceRequest(null), 1L);
 	}
 
 	@AfterEach
@@ -87,7 +87,7 @@ class WorkspaceParticipationQueryServiceIT extends ServiceIntegrationTestHelper 
 
 		workspaceParticipationCommandService.joinWorkspace(
 			"TEST1111",
-			new JoinWorkspaceRequest(),
+			new JoinWorkspaceRequest(null),
 			2L
 		);
 


### PR DESCRIPTION
## 🚀 설명
- DTO들 일반 클래스에서 레코드로 변경
- 필드가 4개 이상이면 무조건 `@Builder` 적용
- 일부는 기능을 수정하면서 적용할 예정
---
## ✅ 변경 사항
- [x] 레코드로 변경
- [x] `@Builder` 붙이기

---
## 🚩 관련 이슈, PR
- #145 
- #100 

---
## 📖 참고