### PR TITLE
Feat/#162 URI에서 워크스페이스 코드 추출하는 메서드 분리

### DIFF
--- a/backend/src/main/java/com/tissue/api/util/WorkspaceCodeParser.java
+++ b/backend/src/main/java/com/tissue/api/util/WorkspaceCodeParser.java
@@ -1,0 +1,41 @@
+package com.tissue.api.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+
+import com.tissue.api.security.authorization.exception.InvalidWorkspaceCodeInUriException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class WorkspaceCodeParser {
+
+	private static final Pattern WORKSPACE_CODE_PATTERN =
+		Pattern.compile("/api/v1/workspaces/([A-Za-z0-9]{8})(?:/.*)?");
+
+	private final Matcher matcher;
+
+	public WorkspaceCodeParser() {
+		this.matcher = WORKSPACE_CODE_PATTERN.matcher("");
+	}
+
+	/**
+	 * URI에서 워크스페이스 코드를 추출한다.
+	 * 워크스페이스 코드는 8자리 영숫자로 구성되어야 한다.
+	 *
+	 * @param uri HTTP 요청의 URI
+	 * @return 추출된 워크스페이스 코드
+	 * @throws InvalidWorkspaceCodeInUriException URI가 올바르지 않거나 워크스페이스 코드가 패턴에 부합하지 않는 경우
+	 */
+	public String extractWorkspaceCode(String uri) {
+		matcher.reset(uri);
+
+		if (matcher.matches()) {
+			return matcher.group(1);
+		}
+		throw new InvalidWorkspaceCodeInUriException();
+	}
+}

--- a/backend/src/test/java/com/tissue/api/util/WorkspaceCodeGeneratorTest.java
+++ b/backend/src/test/java/com/tissue/api/util/WorkspaceCodeGeneratorTest.java
@@ -1,12 +1,10 @@
-package com.tissue.api.workspace.util;
+package com.tissue.api.util;
 
 import static org.assertj.core.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import com.tissue.api.util.WorkspaceCodeGenerator;
 
 class WorkspaceCodeGeneratorTest {
 

--- a/backend/src/test/java/com/tissue/api/util/WorkspaceCodeParserTest.java
+++ b/backend/src/test/java/com/tissue/api/util/WorkspaceCodeParserTest.java
@@ -1,0 +1,44 @@
+package com.tissue.api.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.tissue.api.security.authorization.exception.InvalidWorkspaceCodeInUriException;
+
+class WorkspaceCodeParserTest {
+	private WorkspaceCodeParser workspaceCodeParser;
+
+	@BeforeEach
+	void setUp() {
+		workspaceCodeParser = new WorkspaceCodeParser();
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+		"/api/v1/workspaces/WORKSPC1, WORKSPC1",
+		"/api/v1/workspaces/WORKSPC1/some/path, WORKSPC1",
+		"/api/v1/workspaces/ANOTHER1/, ANOTHER1"
+	})
+	@DisplayName("유효한 URI에서 워크스페이스 코드를 추출할 수 있다")
+	void extractValidWorkspaceCode(String uri, String expectedCode) {
+		assertThat(workspaceCodeParser.extractWorkspaceCode(uri)).isEqualTo(expectedCode);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+		"/api/v1/workspaces//",
+		"/api/v1/workspaces/",
+		"/api/v1/workspaces/ABC",  // 8자리가 아닌 경우
+		"/api/v1/workspaces/ABC@1234"  // 허용되지 않는 문자 포함
+	})
+	@DisplayName("잘못된 형식의 URI에서 코드 추출을 시도하면 예외가 발생한다")
+	void throwExceptionForInvalidUri(String uri) {
+		assertThatThrownBy(() -> workspaceCodeParser.extractWorkspaceCode(uri))
+			.isInstanceOf(InvalidWorkspaceCodeInUriException.class);
+	}
+}

--- a/backend/src/test/java/com/tissue/helper/ControllerTestHelper.java
+++ b/backend/src/test/java/com/tissue/helper/ControllerTestHelper.java
@@ -11,12 +11,6 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.tissue.api.position.domain.repository.PositionRepository;
-import com.tissue.api.position.service.command.PositionCommandService;
-import com.tissue.api.position.service.query.PositionQueryService;
-import com.tissue.api.workspace.service.command.WorkspaceCommandService;
-import com.tissue.api.workspacemember.service.command.WorkspaceMemberInviteService;
-import com.tissue.api.workspacemember.service.command.WorkspaceParticipationCommandService;
 import com.tissue.api.global.config.WebMvcConfig;
 import com.tissue.api.invitation.domain.repository.InvitationRepository;
 import com.tissue.api.invitation.presentation.controller.InvitationController;
@@ -29,13 +23,18 @@ import com.tissue.api.member.domain.repository.MemberRepository;
 import com.tissue.api.member.presentation.controller.MemberController;
 import com.tissue.api.member.service.command.MemberCommandService;
 import com.tissue.api.member.service.query.MemberQueryService;
+import com.tissue.api.position.domain.repository.PositionRepository;
 import com.tissue.api.position.presentation.controller.PositionController;
+import com.tissue.api.position.service.command.PositionCommandService;
+import com.tissue.api.position.service.query.PositionQueryService;
 import com.tissue.api.security.authentication.presentation.controller.AuthenticationController;
 import com.tissue.api.security.authentication.service.AuthenticationService;
 import com.tissue.api.security.session.SessionManager;
 import com.tissue.api.security.session.SessionValidator;
+import com.tissue.api.util.WorkspaceCodeParser;
 import com.tissue.api.workspace.domain.repository.WorkspaceRepository;
 import com.tissue.api.workspace.presentation.controller.WorkspaceController;
+import com.tissue.api.workspace.service.command.WorkspaceCommandService;
 import com.tissue.api.workspace.service.command.create.CheckCodeDuplicationService;
 import com.tissue.api.workspace.service.query.WorkspaceQueryService;
 import com.tissue.api.workspacemember.domain.repository.WorkspaceMemberRepository;
@@ -43,6 +42,8 @@ import com.tissue.api.workspacemember.presentation.controller.WorkspaceMemberInf
 import com.tissue.api.workspacemember.presentation.controller.WorkspaceMembershipController;
 import com.tissue.api.workspacemember.presentation.controller.WorkspaceParticipationController;
 import com.tissue.api.workspacemember.service.command.WorkspaceMemberCommandService;
+import com.tissue.api.workspacemember.service.command.WorkspaceMemberInviteService;
+import com.tissue.api.workspacemember.service.command.WorkspaceParticipationCommandService;
 import com.tissue.api.workspacemember.service.query.WorkspaceParticipationQueryService;
 import com.tissue.config.WebMvcTestConfig;
 
@@ -71,10 +72,14 @@ import lombok.extern.slf4j.Slf4j;
 )
 @Import(value = WebMvcTestConfig.class)
 public abstract class ControllerTestHelper {
+
 	@Autowired
 	protected MockMvc mockMvc;
 	@Autowired
 	protected ObjectMapper objectMapper;
+
+	@MockBean
+	protected WorkspaceCodeParser workspaceCodeParser;
 
 	/**
 	 * Session

--- a/backend/src/test/java/com/tissue/helper/ServiceIntegrationTestHelper.java
+++ b/backend/src/test/java/com/tissue/helper/ServiceIntegrationTestHelper.java
@@ -17,6 +17,7 @@ import com.tissue.api.position.domain.repository.PositionRepository;
 import com.tissue.api.position.service.command.PositionCommandService;
 import com.tissue.api.position.service.query.PositionQueryService;
 import com.tissue.api.security.PasswordEncoder;
+import com.tissue.api.util.WorkspaceCodeParser;
 import com.tissue.api.workspace.domain.repository.WorkspaceRepository;
 import com.tissue.api.workspace.service.command.WorkspaceCommandService;
 import com.tissue.api.workspace.service.command.create.RetryCodeGenerationOnExceptionService;
@@ -49,6 +50,8 @@ public abstract class ServiceIntegrationTestHelper {
 	protected DatabaseCleaner databaseCleaner;
 	@Autowired
 	protected PasswordEncoder passwordEncoder;
+	@Autowired
+	protected WorkspaceCodeParser workspaceCodeParser;
 	@Autowired
 	protected EntityManager entityManager;
 


### PR DESCRIPTION
## 🚀 설명
- `AuthorizationInterceptor`에서 정의해서 사용한 `extractWorkspaceCodeFromUri`를 `WorkspaceCodeParser` 클래스를 만들어서 분리
- 로직을 개선(`Matcher` 사용)

---
## ✅ 변경 사항
- [x] 워크스페이스 코드 추출하는 메서드를 새로운 유틸 클래스로 분리
- [x] 테스트 추가

---
## 🚩 관련 이슈, PR
- #162 

---
## 📖 참고