### PR TITLE
Feat/#166 컨트롤러에서 패스워드 검증 진행

### DIFF
--- a/backend/src/main/java/com/tissue/api/member/presentation/dto/request/UpdateMemberEmailRequest.java
+++ b/backend/src/main/java/com/tissue/api/member/presentation/dto/request/UpdateMemberEmailRequest.java
@@ -3,20 +3,13 @@ package com.tissue.api.member.presentation.dto.request;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UpdateMemberEmailRequest {
+public record UpdateMemberEmailRequest(
+	String password,
 
 	@NotBlank(message = "Email must not be blank")
 	@Size(min = 5, max = 254, message = "Email must be between 5 and 254 characters")
 	@Email(message = "Email should be in a valid format")
-	private String newEmail;
-
-	public UpdateMemberEmailRequest(String newEmail) {
-		this.newEmail = newEmail;
-	}
+	String newEmail
+) {
 }

--- a/backend/src/main/java/com/tissue/api/member/presentation/dto/request/UpdateMemberInfoRequest.java
+++ b/backend/src/main/java/com/tissue/api/member/presentation/dto/request/UpdateMemberInfoRequest.java
@@ -5,35 +5,20 @@ import java.time.LocalDate;
 import com.tissue.api.member.domain.JobType;
 
 import jakarta.validation.constraints.Past;
-import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UpdateMemberInfoRequest {
-
-	/**
-	 * Todo
-	 *  - size 검증 필요
-	 */
+/**
+ * Todo
+ *  - size 검증 필요
+ */
+@Builder
+public record UpdateMemberInfoRequest(
 	@Past(message = "Birth date must be in the past")
-	private LocalDate birthDate;
-	private JobType jobType;
-	private String introduction;
+	LocalDate birthDate,
+	JobType jobType,
+	String introduction
 
-	@Builder
-	public UpdateMemberInfoRequest(
-		LocalDate birthDate,
-		JobType jobType,
-		String introduction
-	) {
-		this.birthDate = birthDate;
-		this.jobType = jobType;
-		this.introduction = introduction;
-	}
-
+) {
 	public boolean hasBirthDate() {
 		return birthDate != null;
 	}

--- a/backend/src/main/java/com/tissue/api/member/presentation/dto/request/UpdateMemberNameRequest.java
+++ b/backend/src/main/java/com/tissue/api/member/presentation/dto/request/UpdateMemberNameRequest.java
@@ -2,26 +2,16 @@ package com.tissue.api.member.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.AccessLevel;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UpdateMemberNameRequest {
-
+@Builder
+public record UpdateMemberNameRequest(
 	@NotBlank(message = "First name must not be blank")
 	@Size(min = 1, max = 50, message = "First name must be between 1 and 50 characters")
-	private String firstName;
+	String firstName,
 
 	@NotBlank(message = "Last name must not be blank")
 	@Size(min = 1, max = 50, message = "Last name must be between 1 and 50 characters")
-	private String lastName;
-
-	@Builder
-	public UpdateMemberNameRequest(String firstName, String lastName) {
-		this.firstName = firstName;
-		this.lastName = lastName;
-	}
+	String lastName
+) {
 }

--- a/backend/src/main/java/com/tissue/api/member/presentation/dto/request/UpdateMemberPasswordRequest.java
+++ b/backend/src/main/java/com/tissue/api/member/presentation/dto/request/UpdateMemberPasswordRequest.java
@@ -2,21 +2,14 @@ package com.tissue.api.member.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UpdateMemberPasswordRequest {
+public record UpdateMemberPasswordRequest(
+	String originalPassword,
 
 	@NotBlank(message = "Password must not be blank")
 	@Pattern(regexp = "^(?!.*[가-힣])(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,30}",
 		message = "The password must be alphanumeric"
 			+ " including at least one special character and must be between 8 and 30 characters")
-	private String newPassword;
-
-	public UpdateMemberPasswordRequest(String newPassword) {
-		this.newPassword = newPassword;
-	}
+	String newPassword
+) {
 }

--- a/backend/src/main/java/com/tissue/api/member/validator/MemberValidator.java
+++ b/backend/src/main/java/com/tissue/api/member/validator/MemberValidator.java
@@ -33,7 +33,7 @@ public class MemberValidator {
 		validateEmailIsUnique(email);
 	}
 
-	public void validateMemberPasswordForPermission(String password, Long memberId) {
+	public void validateMemberPassword(String password, Long memberId) {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(MemberNotFoundException::new);
 

--- a/backend/src/main/java/com/tissue/api/workspace/presentation/dto/request/UpdateWorkspacePasswordRequest.java
+++ b/backend/src/main/java/com/tissue/api/workspace/presentation/dto/request/UpdateWorkspacePasswordRequest.java
@@ -3,10 +3,11 @@ package com.tissue.api.workspace.presentation.dto.request;
 import jakarta.validation.constraints.Pattern;
 
 public record UpdateWorkspacePasswordRequest(
+	String originalPassword,
 	@Pattern(
 		regexp = "^(?!.*[가-힣])(?=.*[0-9])(?=.*[a-zA-Z])(?=\\S+$).{8,30}",
 		message = "The password must be alphanumeric and must be between 4 and 30 characters"
 	)
-	String updatePassword
+	String newPassword
 ) {
 }

--- a/backend/src/main/java/com/tissue/api/workspace/service/command/WorkspaceCommandService.java
+++ b/backend/src/main/java/com/tissue/api/workspace/service/command/WorkspaceCommandService.java
@@ -11,7 +11,6 @@ import com.tissue.api.security.PasswordEncoder;
 import com.tissue.api.workspace.domain.Workspace;
 import com.tissue.api.workspace.domain.repository.WorkspaceRepository;
 import com.tissue.api.workspace.exception.WorkspaceNotFoundException;
-import com.tissue.api.workspace.presentation.dto.request.DeleteWorkspaceRequest;
 import com.tissue.api.workspace.presentation.dto.request.UpdateIssueKeyRequest;
 import com.tissue.api.workspace.presentation.dto.request.UpdateWorkspaceInfoRequest;
 import com.tissue.api.workspace.presentation.dto.request.UpdateWorkspacePasswordRequest;
@@ -51,13 +50,12 @@ public class WorkspaceCommandService {
 	) {
 		Workspace workspace = findWorkspaceByCode(code);
 
-		String encodedUpdatePassword = encodePasswordIfPresent(request.updatePassword());
+		String encodedUpdatePassword = encodePasswordIfPresent(request.newPassword());
 		workspace.updatePassword(encodedUpdatePassword);
 	}
 
 	@Transactional
 	public DeleteWorkspaceResponse deleteWorkspace(
-		DeleteWorkspaceRequest request,
 		String code,
 		Long memberId
 	) {
@@ -66,7 +64,6 @@ public class WorkspaceCommandService {
 		Member member = findMemberById(memberId);
 		member.decreaseMyWorkspaceCount();
 
-		workspaceValidator.validatePasswordIfExists(workspace.getPassword(), request.getPassword());
 		workspaceRepository.delete(workspace);
 
 		return DeleteWorkspaceResponse.from(workspace);

--- a/backend/src/main/java/com/tissue/api/workspacemember/presentation/controller/WorkspaceParticipationController.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/presentation/controller/WorkspaceParticipationController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.tissue.api.common.dto.ApiResponse;
 import com.tissue.api.security.authentication.interceptor.LoginRequired;
 import com.tissue.api.security.authentication.resolver.ResolveLoginMember;
+import com.tissue.api.workspace.validator.WorkspaceValidator;
 import com.tissue.api.workspacemember.presentation.dto.request.JoinWorkspaceRequest;
 import com.tissue.api.workspacemember.presentation.dto.response.JoinWorkspaceResponse;
 import com.tissue.api.workspacemember.presentation.dto.response.MyWorkspacesResponse;
@@ -29,6 +30,7 @@ public class WorkspaceParticipationController {
 
 	private final WorkspaceParticipationQueryService workspaceParticipationQueryService;
 	private final WorkspaceParticipationCommandService workspaceParticipationCommandService;
+	private final WorkspaceValidator workspaceValidator;
 
 	/**
 	 * Todo
@@ -44,12 +46,8 @@ public class WorkspaceParticipationController {
 		@ResolveLoginMember Long loginMemberId,
 		@RequestBody @Valid JoinWorkspaceRequest request
 	) {
-
-		JoinWorkspaceResponse response = workspaceParticipationCommandService.joinWorkspace(
-			code,
-			request,
-			loginMemberId
-		);
+		workspaceValidator.validateWorkspacePassword(request.password(), code);
+		JoinWorkspaceResponse response = workspaceParticipationCommandService.joinWorkspace(code, loginMemberId);
 		return ApiResponse.ok("Joined workspace", response);
 	}
 

--- a/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceParticipationCommandService.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceParticipationCommandService.java
@@ -9,11 +9,9 @@ import com.tissue.api.member.exception.MemberNotFoundException;
 import com.tissue.api.workspace.domain.Workspace;
 import com.tissue.api.workspace.domain.repository.WorkspaceRepository;
 import com.tissue.api.workspace.exception.WorkspaceNotFoundException;
-import com.tissue.api.workspace.validator.WorkspaceValidator;
 import com.tissue.api.workspacemember.domain.WorkspaceMember;
 import com.tissue.api.workspacemember.domain.repository.WorkspaceMemberRepository;
 import com.tissue.api.workspacemember.exception.AlreadyJoinedWorkspaceException;
-import com.tissue.api.workspacemember.presentation.dto.request.JoinWorkspaceRequest;
 import com.tissue.api.workspacemember.presentation.dto.response.JoinWorkspaceResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -28,19 +26,17 @@ public class WorkspaceParticipationCommandService {
 	private final WorkspaceRepository workspaceRepository;
 	private final MemberRepository memberRepository;
 	private final WorkspaceMemberRepository workspaceMemberRepository;
-	private final WorkspaceValidator workspaceValidator;
 
 	/**
-	 * 참여할 워크스페이스의 코드와 참여 요청을 통해
+	 * 참여할 워크스페이스의 코드를 통해
 	 * 참여를 요청한 로그인 멤버를 해당 워크스페이스에 참여시킨다.
 	 *
 	 * @param code     - 워크스페이스의 고유 코드
-	 * @param request  - 워크스페이스 참여 요청 객체
 	 * @param memberId - 세션에서 꺼낸 멤버 id(PK)
-	 * @return - 워크스페이스 참여 응답을 위한 DTO
+	 * @return JoinWorkspaceResponse - 워크스페이스 참여 응답을 위한 DTO
 	 */
 	@Transactional
-	public JoinWorkspaceResponse joinWorkspace(String code, JoinWorkspaceRequest request, Long memberId) {
+	public JoinWorkspaceResponse joinWorkspace(String code, Long memberId) {
 
 		Workspace workspace = workspaceRepository.findByCode(code)
 			.orElseThrow(WorkspaceNotFoundException::new);
@@ -51,8 +47,6 @@ public class WorkspaceParticipationCommandService {
 		if (workspaceMemberRepository.existsByMemberIdAndWorkspaceCode(memberId, code)) {
 			throw new AlreadyJoinedWorkspaceException();
 		}
-
-		workspaceValidator.validatePasswordIfExists(workspace.getPassword(), request.password());
 
 		WorkspaceMember workspaceMember = WorkspaceMember.addCollaboratorWorkspaceMember(member, workspace);
 		workspaceMemberRepository.save(workspaceMember);

--- a/backend/src/test/java/com/tissue/api/workspace/presentation/controller/WorkspaceControllerTest.java
+++ b/backend/src/test/java/com/tissue/api/workspace/presentation/controller/WorkspaceControllerTest.java
@@ -48,7 +48,7 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 	}
 
 	@Test
-	@DisplayName("POST /workspaces - 워크스페이스 생성을 성공하면 201을 응답한다")
+	@DisplayName("POST /workspaces - 워크스페이스 생성을 성공하면 CREATED를 응답한다")
 	void test1() throws Exception {
 		// given
 		CreateWorkspaceRequest request = CreateWorkspaceRequest.builder()
@@ -88,7 +88,7 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 	}
 
 	@Test
-	@DisplayName("POST /workspaces - 워크스페이스 생성 요청에서 이름의 범위는 2~50자, 설명은 1~255자를 지키지 않으면 400을 응답한다")
+	@DisplayName("POST /workspaces - 워크스페이스 생성 요청에서 이름의 범위는 2~50자, 설명은 1~255자를 지키지 않으면 BAD_REQUEST 응답한다")
 	void test3() throws Exception {
 		// given
 		String longName = createLongString(51);
@@ -112,7 +112,7 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 	}
 
 	@Test
-	@DisplayName("PATCH /workspaces/{code}/info - 워크스페이스 정보 수정 요청에 성공하면 200을 응답받는다")
+	@DisplayName("PATCH /workspaces/{code}/info - 워크스페이스 정보 수정 요청에 성공하면 OK를 응답한다")
 	void updateWorkspaceContent_shouldReturnUpdatedContent() throws Exception {
 		// given
 		UpdateWorkspaceInfoRequest request = new UpdateWorkspaceInfoRequest("New Title", "New Description");
@@ -144,7 +144,7 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 	}
 
 	@Test
-	@DisplayName("DELETE /workspaces/{code} - 워크스페이스 삭제 요청에 성공하면 200을 응답받는다")
+	@DisplayName("DELETE /workspaces/{code} - 워크스페이스 삭제 요청에 성공하면 OK를 응답한다")
 	void deleteWorkspace_shouldReturnSuccess() throws Exception {
 		// given
 		DeleteWorkspaceRequest request = new DeleteWorkspaceRequest("password1234!");
@@ -153,10 +153,7 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 			.code("TESTCODE")
 			.build();
 
-		when(workspaceCommandService.deleteWorkspace(
-			ArgumentMatchers.any(DeleteWorkspaceRequest.class),
-			eq("TESTCODE"),
-			anyLong()))
+		when(workspaceCommandService.deleteWorkspace(eq("TESTCODE"), anyLong()))
 			.thenReturn(DeleteWorkspaceResponse.from(workspace));
 
 		// when & then
@@ -168,11 +165,11 @@ class WorkspaceControllerTest extends ControllerTestHelper {
 			.andExpect(jsonPath("$.data.code").value("TESTCODE"));
 
 		verify(workspaceCommandService, times(1))
-			.deleteWorkspace(ArgumentMatchers.any(DeleteWorkspaceRequest.class), eq("TESTCODE"), anyLong());
+			.deleteWorkspace(eq("TESTCODE"), anyLong());
 	}
 
 	@Test
-	@DisplayName("GET /workspaces/{code} - 워크스페이스 상세 정보 조회를 성공하면 200을 응답한다")
+	@DisplayName("GET /workspaces/{code} - 워크스페이스 상세 정보 조회를 성공하면 OK를 응답한다")
 	void test5() throws Exception {
 		// given
 		String code = "ABCD1234";

--- a/backend/src/test/java/com/tissue/api/workspace/service/query/WorkspaceQueryServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/workspace/service/query/WorkspaceQueryServiceIT.java
@@ -14,7 +14,6 @@ import com.tissue.api.workspace.domain.Workspace;
 import com.tissue.api.workspace.exception.WorkspaceNotFoundException;
 import com.tissue.api.workspace.presentation.dto.WorkspaceDetail;
 import com.tissue.api.workspacemember.domain.WorkspaceRole;
-import com.tissue.api.workspacemember.presentation.dto.request.JoinWorkspaceRequest;
 import com.tissue.helper.ServiceIntegrationTestHelper;
 
 class WorkspaceQueryServiceIT extends ServiceIntegrationTestHelper {
@@ -44,8 +43,8 @@ class WorkspaceQueryServiceIT extends ServiceIntegrationTestHelper {
 		);
 
 		// member1은 workspace1,2에 참여
-		workspaceParticipationCommandService.joinWorkspace("TEST1111", new JoinWorkspaceRequest(null), 1L);
-		workspaceParticipationCommandService.joinWorkspace("TEST2222", new JoinWorkspaceRequest(null), 1L);
+		workspaceParticipationCommandService.joinWorkspace("TEST1111", 1L);
+		workspaceParticipationCommandService.joinWorkspace("TEST2222", 1L);
 	}
 
 	@AfterEach
@@ -65,11 +64,7 @@ class WorkspaceQueryServiceIT extends ServiceIntegrationTestHelper {
 		);
 		memberCommandService.signup(signupMemberRequest);
 
-		workspaceParticipationCommandService.joinWorkspace(
-			"TEST1111",
-			new JoinWorkspaceRequest(null),
-			2L
-		);
+		workspaceParticipationCommandService.joinWorkspace("TEST1111", 2L);
 
 		// when
 		WorkspaceDetail response = workspaceQueryService.getWorkspaceDetail("TEST1111");

--- a/backend/src/test/java/com/tissue/api/workspace/validator/WorkspaceValidatorTest.java
+++ b/backend/src/test/java/com/tissue/api/workspace/validator/WorkspaceValidatorTest.java
@@ -1,0 +1,69 @@
+package com.tissue.api.workspace.validator;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.tissue.api.workspace.exception.InvalidWorkspacePasswordException;
+import com.tissue.api.workspace.exception.WorkspaceNotFoundException;
+import com.tissue.helper.ServiceIntegrationTestHelper;
+
+class WorkspaceValidatorTest extends ServiceIntegrationTestHelper {
+
+	@AfterEach
+	void tearDown() {
+		databaseCleaner.execute();
+	}
+
+	@Test
+	@DisplayName("검증하는 워크스페이스 코드를 이미 사용중이면 false를 반환한다")
+	void validateWorkspaceCodeIsUnique_returnsFalse_ifCodeIsNotUnique() {
+		// given
+		workspaceRepositoryFixture.createAndSaveWorkspace(
+			"Test Workspace",
+			"Test Workspace",
+			"TESTCODE",
+			null
+		);
+
+		// when
+		boolean result = workspaceValidator.validateWorkspaceCodeIsUnique("TESTCODE");
+
+		// then
+		assertThat(result).isFalse();
+	}
+
+	@Test
+	@DisplayName("검증하는 패스워드가 워크스페이스의 암호화된 패스워드와 일치하지 않으면 예외가 발생한다")
+	void ifPassword_doesNotMatch_workspacePassword_throwException() {
+		// given
+		workspaceRepositoryFixture.createAndSaveWorkspace(
+			"Test Workspace",
+			"Test Workspace",
+			"TESTCODE",
+			"test1234!"
+		);
+
+		// when & then
+		assertThatThrownBy(() -> workspaceValidator.validateWorkspacePassword("invalidPassword", "TESTCODE"))
+			.isInstanceOf(InvalidWorkspacePasswordException.class);
+	}
+
+	@Test
+	@DisplayName("워크스페이스의 패스워드와 맞는지 검증할 때, 코드에 대한 워크스페이스가 존재하지 않으면 예외가 발생한다")
+	void ifWorkspaceCode_workspaceDoesNotExist() {
+		// given
+		workspaceRepositoryFixture.createAndSaveWorkspace(
+			"Test Workspace",
+			"Test Workspace",
+			"TESTCODE",
+			"test1234!"
+		);
+
+		// when & then
+		assertThatThrownBy(() -> workspaceValidator.validateWorkspacePassword("test1234!", "NOTFOUND"))
+			.isInstanceOf(WorkspaceNotFoundException.class);
+	}
+}

--- a/backend/src/test/java/com/tissue/api/workspacemember/presentation/controller/WorkspaceParticipationControllerTest.java
+++ b/backend/src/test/java/com/tissue/api/workspacemember/presentation/controller/WorkspaceParticipationControllerTest.java
@@ -48,10 +48,6 @@ class WorkspaceParticipationControllerTest extends ControllerTestHelper {
 	@Test
 	@DisplayName("POST /members/workspaces/{code} - 워크스페이스 참여 요청을 성공하는 경우 200을 응답 받는다")
 	void test11() throws Exception {
-		// Session 모킹
-		MockHttpSession session = new MockHttpSession();
-		session.setAttribute(SessionAttributes.LOGIN_MEMBER_ID, 1L);
-
 		// given
 		String workspaceCode = "TESTCODE";
 		String loginId = "member1";
@@ -65,13 +61,11 @@ class WorkspaceParticipationControllerTest extends ControllerTestHelper {
 
 		JoinWorkspaceResponse response = JoinWorkspaceResponse.from(workspaceMember);
 
-		when(workspaceParticipationCommandService.joinWorkspace(eq(workspaceCode),
-			any(JoinWorkspaceRequest.class),
-			anyLong())).thenReturn(response);
+		when(workspaceParticipationCommandService.joinWorkspace(eq(workspaceCode), anyLong()))
+			.thenReturn(response);
 
 		// when & then
 		mockMvc.perform(post("/api/v1/workspaces/{code}", workspaceCode)
-				.session(session)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
@@ -82,23 +76,17 @@ class WorkspaceParticipationControllerTest extends ControllerTestHelper {
 	@Test
 	@DisplayName("POST /members/workspaces/{code} - 워크스페이스 참여 요청 시 비밀번호가 불일치하는 경우 401을 응답 받는다")
 	void test12() throws Exception {
-		// Session 모킹
-		MockHttpSession session = new MockHttpSession();
-		session.setAttribute(SessionAttributes.LOGIN_MEMBER_ID, 1L);
-
 		// given
 		String workspaceCode = "TESTCODE";
 		String invalidPassword = "invalid1234!";
 
 		JoinWorkspaceRequest request = new JoinWorkspaceRequest(invalidPassword);
 
-		when(workspaceParticipationCommandService.joinWorkspace(eq("TESTCODE"), any(JoinWorkspaceRequest.class),
-			anyLong()))
+		when(workspaceParticipationCommandService.joinWorkspace(eq("TESTCODE"), anyLong()))
 			.thenThrow(new InvalidWorkspacePasswordException());
 
 		// when & then
 		mockMvc.perform(post("/api/v1/workspaces/{code}", workspaceCode)
-				.session(session)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isUnauthorized())

--- a/backend/src/test/java/com/tissue/api/workspacemember/service/command/WorkspaceParticipationCommandServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/workspacemember/service/command/WorkspaceParticipationCommandServiceIT.java
@@ -9,10 +9,8 @@ import org.junit.jupiter.api.Test;
 
 import com.tissue.api.member.domain.Member;
 import com.tissue.api.workspace.domain.Workspace;
-import com.tissue.api.workspace.exception.InvalidWorkspacePasswordException;
 import com.tissue.api.workspacemember.domain.WorkspaceRole;
 import com.tissue.api.workspacemember.exception.AlreadyJoinedWorkspaceException;
-import com.tissue.api.workspacemember.presentation.dto.request.JoinWorkspaceRequest;
 import com.tissue.api.workspacemember.presentation.dto.response.JoinWorkspaceResponse;
 import com.tissue.helper.ServiceIntegrationTestHelper;
 
@@ -49,30 +47,9 @@ class WorkspaceParticipationCommandServiceIT extends ServiceIntegrationTestHelpe
 	}
 
 	@Test
-	@DisplayName("워크스페이스 참여 시 비밀번호가 일치하지 않는 경우 예외가 발생한다")
-	void testJoinWorkspace_InvalidPasswordException() {
-		// given
-		workspaceRepositoryFixture.createAndSaveWorkspace(
-			"Workspace",
-			"Workspace with Password",
-			"CODE1234",
-			"password1234!"
-		);
-
-		JoinWorkspaceRequest request = new JoinWorkspaceRequest("WrongPassword1234!");
-
-		// when & then
-		assertThatThrownBy(
-			() -> workspaceParticipationCommandService.joinWorkspace("CODE1234", request, member.getId()))
-			.isInstanceOf(InvalidWorkspacePasswordException.class);
-	}
-
-	@Test
 	@DisplayName("워크스페이스 참여가 성공하는 경우 워크스페이스 참여 응답을 정상적으로 반환한다")
 	void testJoinWorkspace_Success() {
 		// given
-		JoinWorkspaceRequest request = new JoinWorkspaceRequest(null);
-
 		Member member2 = memberRepositoryFixture.createAndSaveMember(
 			"member2",
 			"member2@test.com",
@@ -82,7 +59,6 @@ class WorkspaceParticipationCommandServiceIT extends ServiceIntegrationTestHelpe
 		// when
 		JoinWorkspaceResponse response = workspaceParticipationCommandService.joinWorkspace(
 			"TESTCODE",
-			request,
 			member2.getId()
 		);
 
@@ -95,12 +71,10 @@ class WorkspaceParticipationCommandServiceIT extends ServiceIntegrationTestHelpe
 	void testJoinWorkspace_isAlreadyMemberTrue() {
 		// given
 		String workspaceCode = "TESTCODE";
-		JoinWorkspaceRequest request = new JoinWorkspaceRequest(null);
 
 		// when & then
 		assertThatThrownBy(() -> workspaceParticipationCommandService.joinWorkspace(
 				workspaceCode,
-				request,
 				member.getId()
 			)
 		).isInstanceOf(AlreadyJoinedWorkspaceException.class);

--- a/backend/src/test/java/com/tissue/api/workspacemember/service/query/WorkspaceParticipationQueryServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/workspacemember/service/query/WorkspaceParticipationQueryServiceIT.java
@@ -19,7 +19,6 @@ import com.tissue.api.member.presentation.dto.request.SignupMemberRequest;
 import com.tissue.api.workspace.domain.Workspace;
 import com.tissue.api.workspace.presentation.dto.WorkspaceDetail;
 import com.tissue.api.workspacemember.domain.WorkspaceRole;
-import com.tissue.api.workspacemember.presentation.dto.request.JoinWorkspaceRequest;
 import com.tissue.api.workspacemember.presentation.dto.response.MyWorkspacesResponse;
 import com.tissue.helper.ServiceIntegrationTestHelper;
 
@@ -50,8 +49,8 @@ class WorkspaceParticipationQueryServiceIT extends ServiceIntegrationTestHelper 
 		);
 
 		// member1은 workspace1,2에 참여
-		workspaceParticipationCommandService.joinWorkspace("TEST1111", new JoinWorkspaceRequest(null), 1L);
-		workspaceParticipationCommandService.joinWorkspace("TEST2222", new JoinWorkspaceRequest(null), 1L);
+		workspaceParticipationCommandService.joinWorkspace("TEST1111", 1L);
+		workspaceParticipationCommandService.joinWorkspace("TEST2222", 1L);
 	}
 
 	@AfterEach
@@ -87,7 +86,6 @@ class WorkspaceParticipationQueryServiceIT extends ServiceIntegrationTestHelper 
 
 		workspaceParticipationCommandService.joinWorkspace(
 			"TEST1111",
-			new JoinWorkspaceRequest(null),
 			2L
 		);
 

--- a/backend/src/test/java/com/tissue/api/workspacemember/validator/WorkspaceMemberValidatorTest.java
+++ b/backend/src/test/java/com/tissue/api/workspacemember/validator/WorkspaceMemberValidatorTest.java
@@ -1,5 +1,0 @@
-package com.tissue.api.workspacemember.validator;
-
-class WorkspaceMemberValidatorTest {
-
-}

--- a/backend/src/test/java/com/tissue/helper/ControllerTestHelper.java
+++ b/backend/src/test/java/com/tissue/helper/ControllerTestHelper.java
@@ -38,6 +38,7 @@ import com.tissue.api.workspace.presentation.controller.WorkspaceController;
 import com.tissue.api.workspace.service.command.WorkspaceCommandService;
 import com.tissue.api.workspace.service.command.create.CheckCodeDuplicationService;
 import com.tissue.api.workspace.service.query.WorkspaceQueryService;
+import com.tissue.api.workspace.validator.WorkspaceValidator;
 import com.tissue.api.workspacemember.domain.repository.WorkspaceMemberRepository;
 import com.tissue.api.workspacemember.presentation.controller.WorkspaceMemberInfoController;
 import com.tissue.api.workspacemember.presentation.controller.WorkspaceMembershipController;
@@ -129,6 +130,8 @@ public abstract class ControllerTestHelper {
 	 */
 	@MockBean
 	protected MemberValidator memberValidator;
+	@MockBean
+	protected WorkspaceValidator workspaceValidator;
 
 	/**
 	 * Repository

--- a/backend/src/test/java/com/tissue/helper/ServiceIntegrationTestHelper.java
+++ b/backend/src/test/java/com/tissue/helper/ServiceIntegrationTestHelper.java
@@ -23,6 +23,7 @@ import com.tissue.api.workspace.domain.repository.WorkspaceRepository;
 import com.tissue.api.workspace.service.command.WorkspaceCommandService;
 import com.tissue.api.workspace.service.command.create.RetryCodeGenerationOnExceptionService;
 import com.tissue.api.workspace.service.query.WorkspaceQueryService;
+import com.tissue.api.workspace.validator.WorkspaceValidator;
 import com.tissue.api.workspacemember.domain.repository.WorkspaceMemberRepository;
 import com.tissue.api.workspacemember.service.command.WorkspaceMemberCommandService;
 import com.tissue.api.workspacemember.service.command.WorkspaceMemberInviteService;
@@ -95,6 +96,8 @@ public abstract class ServiceIntegrationTestHelper {
 	 */
 	@Autowired
 	protected MemberValidator memberValidator;
+	@Autowired
+	protected WorkspaceValidator workspaceValidator;
 
 	/**
 	 * Repository


### PR DESCRIPTION
## 🚀 설명
- (AsIs) 기존에는 서비스 계층에서 패스워드 검증을 진행했었음
  - 이로 인해 서비스의 재사용이 어려울 것이라고 판단 함(예를 들어 어드민 권한의 관리자는 패스워드 검증이 필요 없음)
  - 처음에는 이를 해결하고자 임시 권한을 얻는 API를 호출하고 -> 권한을 검증하고 서비스 호출하는 방식으로 구현했음
  - 그러나 이 방법은 API 두 번 호출과, 보안상 헛점이 발생할 우려가 있어서 사용하지 않기로 함
    - 해당 방법은 그냥 멤버의 상세 정보(프로필) 변경에만 사용하기로 함
- (Tobe)
  - 컨트롤러에서 권한 검증을 하는게 아니라 그냥 요청에서 패스워드를 꺼내서 검증하는 방식을 사용하기로 함
  - 이제 API 호출 한 번으로 해결 가능

## 🤔 고민
- **퍼사드 패턴(facade pattern)**을 도입해야 할까?
- 퍼사드 패턴을 도입하면 다음과 같은 형태로 사용될 것이다
```java
@Service
@RequiredArgsConstructor
public class WorkspaceJoinFacade {
    private final WorkspaceValidator workspaceValidator;
    private final WorkspaceParticipationCommandService participationService;
    
    public JoinWorkspaceResponse joinWorkspace(String code, Long memberId, String password) {
        workspaceValidator.validateWorkspacePassword(password, code);
        return participationService.joinWorkspace(code, memberId);
    }
}
```
- 로직이 복잡하지 않아서, 기존에 했던 것 처럼 그냥 컨트롤러에서 처리해도 괜찮을 것 같다
- Q. 그럼 언제 퍼사드 패턴을 도입해야 할까?
- A. 향후 확장하면서 로직에 추가적인 검증이나 절차가 필요하다면 도입을 고민해 볼 것 같다.
- 예를 들면 아래와 같은 경우
```java
public class WorkspaceJoinFacade {
    public JoinWorkspaceResponse joinWorkspace(...) {
        validateWorkspacePassword(...);
        checkParticipantLimit(...);
        validateInvitationCode(...);
        checkJoinableTime(...);
        notifyWorkspaceOwner(...);
        return participationService.joinWorkspace(...);
    }
}
```

---
## ✅ 변경 사항
- [x] 패스워드 검증을 컨트롤러 단에서 해결
  - [x] 워크스페이스 삭제
  - [x] 멤버 탈퇴
  - [x] 멤버 비빌번호 변경
  - [x] 워크스페이스 비빌번호 변경
  - [x] 워크스페이스 참여
- [x] 멤버 상세 정보(프로필) 변경은 기존 세션 권한 방식 사용

---
## 🚩 관련 이슈, PR
- #166 

---
## 📖 참고