### PR TITLE
Refactor/#156 회원 가입 정책 변경

### DIFF
--- a/backend/src/main/java/com/tissue/api/member/domain/Member.java
+++ b/backend/src/main/java/com/tissue/api/member/domain/Member.java
@@ -54,17 +54,14 @@ public class Member extends BaseDateEntity {
 	private String password;
 
 	@Embedded
-	@Column(nullable = false)
 	private Name name;
 
 	@Lob
-	private String introduction;
+	private String biography;
 
-	@Column(nullable = false)
 	private LocalDate birthDate;
 
 	@Enumerated(EnumType.STRING)
-	@Column(nullable = false)
 	private JobType jobType;
 
 	@Column(nullable = false)
@@ -81,7 +78,7 @@ public class Member extends BaseDateEntity {
 		String loginId,
 		String email,
 		String password,
-		String introduction,
+		String biography,
 		JobType jobType,
 		Name name,
 		LocalDate birthDate
@@ -89,7 +86,7 @@ public class Member extends BaseDateEntity {
 		this.loginId = loginId;
 		this.email = email;
 		this.password = password;
-		this.introduction = introduction;
+		this.biography = biography;
 		this.jobType = jobType;
 		this.name = name;
 		this.birthDate = birthDate;
@@ -117,8 +114,8 @@ public class Member extends BaseDateEntity {
 		this.name = name;
 	}
 
-	public void updateIntroduction(String introduction) {
-		this.introduction = introduction;
+	public void updateBiography(String biography) {
+		this.biography = biography;
 	}
 
 	public void updateBirthDate(LocalDate birthDate) {

--- a/backend/src/main/java/com/tissue/api/member/presentation/controller/MemberController.java
+++ b/backend/src/main/java/com/tissue/api/member/presentation/controller/MemberController.java
@@ -16,14 +16,12 @@ import com.tissue.api.member.presentation.dto.request.PermissionRequest;
 import com.tissue.api.member.presentation.dto.request.SignupMemberRequest;
 import com.tissue.api.member.presentation.dto.request.UpdateMemberEmailRequest;
 import com.tissue.api.member.presentation.dto.request.UpdateMemberInfoRequest;
-import com.tissue.api.member.presentation.dto.request.UpdateMemberNameRequest;
 import com.tissue.api.member.presentation.dto.request.UpdateMemberPasswordRequest;
 import com.tissue.api.member.presentation.dto.request.WithdrawMemberRequest;
 import com.tissue.api.member.presentation.dto.response.MyProfileResponse;
 import com.tissue.api.member.presentation.dto.response.SignupMemberResponse;
 import com.tissue.api.member.presentation.dto.response.UpdateMemberEmailResponse;
 import com.tissue.api.member.presentation.dto.response.UpdateMemberInfoResponse;
-import com.tissue.api.member.presentation.dto.response.UpdateMemberNameResponse;
 import com.tissue.api.member.service.command.MemberCommandService;
 import com.tissue.api.member.service.query.MemberQueryService;
 import com.tissue.api.member.validator.MemberValidator;
@@ -72,10 +70,6 @@ public class MemberController {
 		return ApiResponse.created("Signup successful.", response);
 	}
 
-	/**
-	 * Todo
-	 *  - Info를 업데이트하는 API에 name을 업데이트 하는 API를 통합
-	 */
 	@LoginRequired
 	@PatchMapping
 	public ApiResponse<UpdateMemberInfoResponse> updateMemberInfo(
@@ -84,29 +78,26 @@ public class MemberController {
 		HttpSession session
 	) {
 		sessionValidator.validatePermissionInSession(session, PermissionType.MEMBER_UPDATE);
-		UpdateMemberInfoResponse response = memberCommandService.updateInfo(
-			request,
-			loginMemberId
-		);
+		UpdateMemberInfoResponse response = memberCommandService.updateInfo(request, loginMemberId);
 
 		return ApiResponse.ok("Member info updated.", response);
 	}
 
-	@LoginRequired
-	@PatchMapping("/name")
-	public ApiResponse<UpdateMemberNameResponse> updateMemberName(
-		@RequestBody @Valid UpdateMemberNameRequest request,
-		@ResolveLoginMember Long loginMemberId,
-		HttpSession session
-	) {
-		sessionValidator.validatePermissionInSession(session, PermissionType.MEMBER_UPDATE);
-		UpdateMemberNameResponse response = memberCommandService.updateName(
-			request,
-			loginMemberId
-		);
-
-		return ApiResponse.ok("Member name updated.", response);
-	}
+	// @LoginRequired
+	// @PatchMapping("/name")
+	// public ApiResponse<UpdateMemberNameResponse> updateMemberName(
+	// 	@RequestBody @Valid UpdateMemberNameRequest request,
+	// 	@ResolveLoginMember Long loginMemberId,
+	// 	HttpSession session
+	// ) {
+	// 	sessionValidator.validatePermissionInSession(session, PermissionType.MEMBER_UPDATE);
+	// 	UpdateMemberNameResponse response = memberCommandService.updateName(
+	// 		request,
+	// 		loginMemberId
+	// 	);
+	//
+	// 	return ApiResponse.ok("Member name updated.", response);
+	// }
 
 	@LoginRequired
 	@PatchMapping("/email")
@@ -129,7 +120,6 @@ public class MemberController {
 		@ResolveLoginMember Long loginMemberId,
 		HttpSession session
 	) {
-		// sessionValidator.validatePermissionInSession(session, PermissionType.MEMBER_UPDATE);
 		memberValidator.validateMemberPassword(request.originalPassword(), loginMemberId);
 		memberCommandService.updatePassword(request, loginMemberId);
 
@@ -143,7 +133,6 @@ public class MemberController {
 		@ResolveLoginMember Long loginMemberId,
 		HttpSession session
 	) {
-		// sessionValidator.validatePermissionInSession(session, PermissionType.MEMBER_DELETE);
 		memberValidator.validateMemberPassword(request.getPassword(), loginMemberId);
 		memberCommandService.withdraw(loginMemberId);
 		session.invalidate();

--- a/backend/src/main/java/com/tissue/api/member/presentation/dto/MemberDetail.java
+++ b/backend/src/main/java/com/tissue/api/member/presentation/dto/MemberDetail.java
@@ -18,7 +18,7 @@ public class MemberDetail {
 	private String firstName;
 	private LocalDate birthDate;
 	private JobType jobType;
-	private String introduction;
+	private String biography;
 	private int ownedWorkspaceCount;
 	private LocalDateTime createdAt;
 	private LocalDateTime updatedAt;
@@ -31,7 +31,7 @@ public class MemberDetail {
 		String firstName,
 		LocalDate birthDate,
 		JobType jobType,
-		String introduction,
+		String biography,
 		int ownedWorkspaceCount,
 		LocalDateTime createdAt,
 		LocalDateTime updatedAt
@@ -42,7 +42,7 @@ public class MemberDetail {
 		this.firstName = firstName;
 		this.birthDate = birthDate;
 		this.jobType = jobType;
-		this.introduction = introduction;
+		this.biography = biography;
 		this.ownedWorkspaceCount = ownedWorkspaceCount;
 		this.createdAt = createdAt;
 		this.updatedAt = updatedAt;
@@ -56,7 +56,7 @@ public class MemberDetail {
 			.firstName(member.getName().getFirstName())
 			.birthDate(member.getBirthDate())
 			.jobType(member.getJobType())
-			.introduction(member.getIntroduction())
+			.biography(member.getBiography())
 			.ownedWorkspaceCount(member.getMyWorkspaceCount())
 			.createdAt(member.getCreatedDate())
 			.updatedAt(member.getLastModifiedDate())

--- a/backend/src/main/java/com/tissue/api/member/presentation/dto/request/SignupMemberRequest.java
+++ b/backend/src/main/java/com/tissue/api/member/presentation/dto/request/SignupMemberRequest.java
@@ -10,7 +10,6 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -46,19 +45,15 @@ public class SignupMemberRequest {
 			+ " including at least one special character and must be between 8 and 30 characters")
 	private String password;
 
-	@NotBlank(message = "First name must not be blank")
 	@Size(max = 50, message = "First name must be less than 50 characters")
 	private String firstName;
 
-	@NotBlank(message = "Last name must not be blank")
 	@Size(max = 50, message = "Last name must be less than 50 characters")
 	private String lastName;
 
-	@NotNull(message = "Birth date must not be null")
 	@Past(message = "Birth date must be in the past")
 	private LocalDate birthDate;
 
-	@NotNull(message = "Job type must not be null")
 	@Enumerated(EnumType.STRING)
 	private JobType jobType;
 
@@ -67,7 +62,7 @@ public class SignupMemberRequest {
 	 *  - introduction에 size 검증 필요
 	 */
 	@Size(max = 255, message = "Introduction must be less than 255 characters")
-	private String introduction;
+	private String biography;
 
 	@Builder
 	public SignupMemberRequest(
@@ -78,7 +73,7 @@ public class SignupMemberRequest {
 		String lastName,
 		LocalDate birthDate,
 		JobType jobType,
-		String introduction
+		String biography
 	) {
 		this.loginId = loginId;
 		this.email = email;
@@ -87,7 +82,7 @@ public class SignupMemberRequest {
 		this.lastName = lastName;
 		this.birthDate = birthDate;
 		this.jobType = jobType;
-		this.introduction = introduction;
+		this.biography = biography;
 	}
 
 	public Member toEntity(String encodedPassword) {
@@ -101,7 +96,7 @@ public class SignupMemberRequest {
 				.build())
 			.birthDate(this.birthDate)
 			.jobType(this.jobType)
-			.introduction(this.introduction)
+			.biography(this.biography)
 			.build();
 	}
 }

--- a/backend/src/main/java/com/tissue/api/member/presentation/dto/request/UpdateMemberInfoRequest.java
+++ b/backend/src/main/java/com/tissue/api/member/presentation/dto/request/UpdateMemberInfoRequest.java
@@ -13,12 +13,17 @@ import lombok.Builder;
  */
 @Builder
 public record UpdateMemberInfoRequest(
+	String firstName,
+	String lastName,
 	@Past(message = "Birth date must be in the past")
 	LocalDate birthDate,
 	JobType jobType,
-	String introduction
-
+	String biography
 ) {
+	public boolean hasName() {
+		return isNotBlank(firstName) && isNotBlank(lastName);
+	}
+
 	public boolean hasBirthDate() {
 		return birthDate != null;
 	}
@@ -27,8 +32,8 @@ public record UpdateMemberInfoRequest(
 		return jobType != null;
 	}
 
-	public boolean hasIntroduction() {
-		return isNotBlank(introduction);
+	public boolean hasBiography() {
+		return isNotBlank(biography);
 	}
 
 	private boolean isNotBlank(String value) {

--- a/backend/src/main/java/com/tissue/api/member/presentation/dto/response/MyProfileResponse.java
+++ b/backend/src/main/java/com/tissue/api/member/presentation/dto/response/MyProfileResponse.java
@@ -13,7 +13,7 @@ public record MyProfileResponse(
 	String firstName,
 	LocalDate birthDate,
 	JobType jobType,
-	String introduction,
+	String biography,
 	int ownedWorkspaceCount,
 	LocalDateTime createdAt,
 	LocalDateTime updatedAt
@@ -26,7 +26,7 @@ public record MyProfileResponse(
 			member.getName().getFirstName(),
 			member.getBirthDate(),
 			member.getJobType(),
-			member.getIntroduction(),
+			member.getBiography(),
 			member.getMyWorkspaceCount(),
 			member.getCreatedDate(),
 			member.getLastModifiedDate()

--- a/backend/src/main/java/com/tissue/api/member/service/command/MemberCommandService.java
+++ b/backend/src/main/java/com/tissue/api/member/service/command/MemberCommandService.java
@@ -57,6 +57,7 @@ public class MemberCommandService {
 		return UpdateMemberInfoResponse.from(member);
 	}
 
+	@Transactional
 	public UpdateMemberNameResponse updateName(
 		UpdateMemberNameRequest request,
 		Long memberId
@@ -118,14 +119,20 @@ public class MemberCommandService {
 		UpdateMemberInfoRequest request,
 		Member member
 	) {
+		if (request.hasName()) {
+			member.updateName(Name.builder()
+				.firstName(request.firstName())
+				.lastName(request.lastName())
+				.build());
+		}
 		if (request.hasBirthDate()) {
 			member.updateBirthDate(request.birthDate());
 		}
 		if (request.hasJobType()) {
 			member.updateJobType(request.jobType());
 		}
-		if (request.hasIntroduction()) {
-			member.updateIntroduction(request.introduction());
+		if (request.hasBiography()) {
+			member.updateBiography(request.biography());
 		}
 	}
 

--- a/backend/src/main/java/com/tissue/api/security/session/SessionValidator.java
+++ b/backend/src/main/java/com/tissue/api/security/session/SessionValidator.java
@@ -45,7 +45,6 @@ public class SessionValidator {
 		Boolean permissionExists = (Boolean)session.getAttribute(SessionAttributes.PERMISSION_EXISTS);
 		LocalDateTime expiresAt = (LocalDateTime)session.getAttribute(SessionAttributes.PERMISSION_EXPIRES_AT);
 
-		// 현재 세션에 저장된 권한 정보가 요청한 권한 타입과 일치하는지 확인
 		if (storedPermissionType != permissionType) {
 			throw new PermissionMismatchException();
 		}

--- a/backend/src/test/java/com/tissue/api/member/presentation/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/tissue/api/member/presentation/controller/MemberControllerTest.java
@@ -75,7 +75,7 @@ class MemberControllerTest extends ControllerTestHelper {
 				.build())
 			.birthDate(LocalDate.of(1990, 1, 1))
 			.jobType(JobType.DEVELOPER)
-			.introduction("Im a backend developer.")
+			.biography("Im a backend developer.")
 			.build();
 
 		when(memberQueryService.getMyProfile(anyLong())).thenReturn(MyProfileResponse.from(member));
@@ -100,7 +100,7 @@ class MemberControllerTest extends ControllerTestHelper {
 			.firstName("Gildong")
 			.lastName("Hong")
 			.birthDate(LocalDate.of(1995, 1, 1))
-			.introduction("Im a backend engineer.")
+			.biography("Im a backend engineer.")
 			.jobType(JobType.DEVELOPER)
 			.build();
 		String requestBody = objectMapper.writeValueAsString(signupMemberRequest);
@@ -130,7 +130,7 @@ class MemberControllerTest extends ControllerTestHelper {
 			.firstName("Gildong")
 			.lastName("Hong")
 			.birthDate(LocalDate.of(1995, 1, 1))
-			.introduction("Im a backend engineer.")
+			.biography("Im a backend engineer.")
 			.jobType(JobType.DEVELOPER)
 			.build();
 
@@ -164,7 +164,7 @@ class MemberControllerTest extends ControllerTestHelper {
 			.firstName("Gildong")
 			.lastName("Hong")
 			.birthDate(LocalDate.of(1995, 1, 1))
-			.introduction("Im a backend engineer.")
+			.biography("Im a backend engineer.")
 			.jobType(JobType.DEVELOPER)
 			.build();
 
@@ -188,7 +188,7 @@ class MemberControllerTest extends ControllerTestHelper {
 			.firstName("Gildong")
 			.lastName("Hong")
 			.birthDate(LocalDate.of(1995, 1, 1))
-			.introduction("Im a backend engineer.")
+			.biography("Im a backend engineer.")
 			.jobType(JobType.DEVELOPER)
 			.build();
 
@@ -245,13 +245,10 @@ class MemberControllerTest extends ControllerTestHelper {
 	@DisplayName("PATCH /members - 멤버 상세 정보(프로필) 업데이트에 성공하면 OK를 응답한다")
 	void updateMemberInfo_success_OK() throws Exception {
 		// given
-		MockHttpSession session = new MockHttpSession();
-		session.setAttribute(SessionAttributes.LOGIN_MEMBER_ID, 1L);
-
 		UpdateMemberInfoRequest request = UpdateMemberInfoRequest.builder()
 			.birthDate(LocalDate.of(1995, 1, 1))
 			.jobType(JobType.DEVELOPER)
-			.introduction("Im a backend developer")
+			.biography("Im a backend developer")
 			.build();
 
 		Member member = Member.builder()
@@ -263,7 +260,7 @@ class MemberControllerTest extends ControllerTestHelper {
 				.build())
 			.birthDate(LocalDate.of(1995, 1, 1))
 			.jobType(JobType.DEVELOPER)
-			.introduction("Im a backend developer")
+			.biography("Im a backend developer")
 			.build();
 
 		when(memberCommandService.updateInfo(any(UpdateMemberInfoRequest.class), anyLong()))
@@ -271,7 +268,6 @@ class MemberControllerTest extends ControllerTestHelper {
 
 		// when & then
 		mockMvc.perform(patch("/api/v1/members")
-				.session(session)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
@@ -284,9 +280,6 @@ class MemberControllerTest extends ControllerTestHelper {
 	@DisplayName("PATCH /members - 멤버 상세 정보(프로필) 업데이트 시 생일을 현재 날짜 이후로 설정하면 검증에 실패한다")
 	void updateMemberInfo_fail_ifBirthDateIsLaterThanNow() throws Exception {
 		// given
-		MockHttpSession session = new MockHttpSession();
-		session.setAttribute(SessionAttributes.LOGIN_MEMBER_ID, 1L);
-
 		UpdateMemberInfoRequest request = UpdateMemberInfoRequest.builder()
 			.birthDate(LocalDate.of(2995, 1, 1))
 			.build();
@@ -300,7 +293,7 @@ class MemberControllerTest extends ControllerTestHelper {
 				.build())
 			.birthDate(LocalDate.of(1995, 1, 1))
 			.jobType(JobType.DEVELOPER)
-			.introduction("Im a backend developer")
+			.biography("Im a backend developer")
 			.build();
 
 		when(memberCommandService.updateInfo(any(UpdateMemberInfoRequest.class), anyLong()))
@@ -308,7 +301,6 @@ class MemberControllerTest extends ControllerTestHelper {
 
 		// when & then
 		mockMvc.perform(patch("/api/v1/members")
-				.session(session)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isBadRequest())

--- a/backend/src/test/java/com/tissue/fixture/api/MemberApiFixture.java
+++ b/backend/src/test/java/com/tissue/fixture/api/MemberApiFixture.java
@@ -5,8 +5,8 @@ import java.time.LocalDate;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
-import com.tissue.api.member.presentation.dto.request.SignupMemberRequest;
 import com.tissue.api.member.domain.JobType;
+import com.tissue.api.member.presentation.dto.request.SignupMemberRequest;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -22,7 +22,7 @@ public class MemberApiFixture {
 			.firstName("Gildong")
 			.lastName("Hong")
 			.birthDate(LocalDate.of(1995, 1, 1))
-			.introduction("Im a backend engineer.")
+			.biography("Im a backend engineer.")
 			.jobType(JobType.DEVELOPER)
 			.build();
 

--- a/backend/src/test/java/com/tissue/fixture/dto/SignupRequestDtoFixture.java
+++ b/backend/src/test/java/com/tissue/fixture/dto/SignupRequestDtoFixture.java
@@ -22,7 +22,7 @@ public class SignupRequestDtoFixture {
 			.firstName("Gildong")
 			.lastName("Hong")
 			.birthDate(LocalDate.of(1995, 1, 1))
-			.introduction("Im a backend engineer.")
+			.biography("Im a backend engineer.")
 			.jobType(JobType.DEVELOPER)
 			.build();
 	}

--- a/backend/src/test/java/com/tissue/fixture/repository/MemberRepositoryFixture.java
+++ b/backend/src/test/java/com/tissue/fixture/repository/MemberRepositoryFixture.java
@@ -43,7 +43,7 @@ public class MemberRepositoryFixture {
 				.lastName("Hong")
 				.build())
 			.birthDate(LocalDate.of(1995, 1, 1))
-			.introduction("Im a backend engineer.")
+			.biography("Im a backend engineer.")
 			.jobType(JobType.DEVELOPER)
 			.build();
 		return memberRepository.save(member);


### PR DESCRIPTION
## 🚀 설명
- 상세 정보는 전부 선택 사항으로 변경
- introduction -> biography로 필드명 변경

---
## ✅ 변경 사항
- [x] `introduction` -> `biography`로 필드명 변경
- [x] 회원 가입 시 상세 정보(`name`, `birthDate`, `biography`, `jobType`)는 전부 선택 사항으로 변경
- [x] `infoUpdate`에 이름 변경도 포함

---
## 🚩 관련 이슈, PR
- #156 

---
## 📖 참고