### PR TITLE
Refactor/ #173 부모 이슈 조회 방법 변경

### DIFF
--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/request/create/CreateBugRequest.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/request/create/CreateBugRequest.java
@@ -22,7 +22,7 @@ public record CreateBugRequest(
 	IssuePriority priority,
 	LocalDate dueDate,
 	Difficulty difficulty,
-	Long parentIssueId,
+	String parentIssueKey,
 	@NotBlank String reproducingSteps,
 	BugSeverity severity,
 	Set<String> affectedVersions

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/request/create/CreateEpicRequest.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/request/create/CreateEpicRequest.java
@@ -18,10 +18,11 @@ public record CreateEpicRequest(
 	String summary,
 	IssuePriority priority,
 	LocalDate dueDate,
-	Long parentIssueId,
+	String parentIssueKey,
 	@NotBlank String businessGoal,
 	LocalDate targetReleaseDate,
 	LocalDate hardDeadLine
+
 ) implements CreateIssueRequest {
 
 	@Override

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/request/create/CreateIssueRequest.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/request/create/CreateIssueRequest.java
@@ -33,7 +33,7 @@ public interface CreateIssueRequest {
 
 	LocalDate dueDate();
 
-	Long parentIssueId();
+	String parentIssueKey();
 
 	IssueType getType();
 

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/request/create/CreateStoryRequest.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/request/create/CreateStoryRequest.java
@@ -20,7 +20,7 @@ public record CreateStoryRequest(
 	IssuePriority priority,
 	LocalDate dueDate,
 	Difficulty difficulty,
-	Long parentIssueId,
+	String parentIssueKey,
 	@NotBlank String userStory,
 	String acceptanceCriteria
 

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/request/create/CreateSubTaskRequest.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/request/create/CreateSubTaskRequest.java
@@ -20,7 +20,7 @@ public record CreateSubTaskRequest(
 	IssuePriority priority,
 	LocalDate dueDate,
 	Difficulty difficulty,
-	Long parentIssueId
+	String parentIssueKey
 
 ) implements CreateIssueRequest {
 
@@ -39,7 +39,7 @@ public record CreateSubTaskRequest(
 			.priority(priority)
 			.dueDate(dueDate)
 			.difficulty(difficulty)
-			.parentIssue(parentIssue)
+			.parentIssue(parentIssue) // 서비스 계층의 parentIssue 찾는 로직 변경
 			.build();
 	}
 }

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/request/create/CreateTaskRequest.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/request/create/CreateTaskRequest.java
@@ -20,7 +20,7 @@ public record CreateTaskRequest(
 	IssuePriority priority,
 	LocalDate dueDate,
 	Difficulty difficulty,
-	Long parentIssueId
+	String parentIssueKey
 ) implements CreateIssueRequest {
 
 	@Override

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateBugResponse.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateBugResponse.java
@@ -32,7 +32,7 @@ public record CreateBugResponse(
 	Set<String> affectedVersions,
 	Difficulty difficulty,
 	IssueStatus status,
-	Long parentIssueId
+	String parentIssueKey
 ) implements CreateIssueResponse {
 
 	public static CreateBugResponse from(Bug bug) {
@@ -52,8 +52,8 @@ public record CreateBugResponse(
 			.affectedVersions(bug.getAffectedVersions())
 			.difficulty(bug.getDifficulty())
 			.status(bug.getStatus())
-			.parentIssueId(Optional.ofNullable(bug.getParentIssue())
-				.map(Issue::getId)
+			.parentIssueKey(Optional.ofNullable(bug.getParentIssue())
+				.map(Issue::getIssueKey)
 				.orElse(null))
 			.build();
 	}

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateEpicResponse.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateEpicResponse.java
@@ -23,8 +23,7 @@ public record CreateEpicResponse(
 	LocalDate dueDate,
 	String businessGoal,
 	LocalDate targetReleaseDate,
-	LocalDate hardDeadLine,
-	Long parentIssueId
+	LocalDate hardDeadLine
 ) implements CreateIssueResponse {
 
 	public static CreateEpicResponse from(Epic epic) {

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateStoryResponse.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateStoryResponse.java
@@ -27,7 +27,7 @@ public record CreateStoryResponse(
 	String userStory,
 	String acceptanceCriteria,
 	Difficulty difficulty,
-	Long parentIssueId
+	String parentIssueKey
 ) implements CreateIssueResponse {
 
 	public static CreateStoryResponse from(Story story) {
@@ -45,8 +45,8 @@ public record CreateStoryResponse(
 			.userStory(story.getUserStory())
 			.acceptanceCriteria(story.getAcceptanceCriteria())
 			.difficulty(story.getDifficulty())
-			.parentIssueId(Optional.ofNullable(story.getParentIssue())
-				.map(Issue::getId)
+			.parentIssueKey(Optional.ofNullable(story.getParentIssue())
+				.map(Issue::getIssueKey)
 				.orElse(null))
 			.build();
 	}

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateSubTaskResponse.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateSubTaskResponse.java
@@ -25,7 +25,7 @@ public record CreateSubTaskResponse(
 	IssuePriority priority,
 	LocalDate dueDate,
 	Difficulty difficulty,
-	Long parentIssueId
+	String parentIssueKey
 ) implements CreateIssueResponse {
 
 	public static CreateSubTaskResponse from(SubTask subTask) {
@@ -41,8 +41,8 @@ public record CreateSubTaskResponse(
 			.priority(subTask.getPriority())
 			.dueDate(subTask.getDueDate())
 			.difficulty(subTask.getDifficulty())
-			.parentIssueId(Optional.ofNullable(subTask.getParentIssue())
-				.map(Issue::getId)
+			.parentIssueKey(Optional.ofNullable(subTask.getParentIssue())
+				.map(Issue::getIssueKey)
 				.orElse(null))
 			.build();
 	}

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateTaskResponse.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/create/CreateTaskResponse.java
@@ -25,7 +25,7 @@ public record CreateTaskResponse(
 	IssuePriority priority,
 	LocalDate dueDate,
 	Difficulty difficulty,
-	Long parentIssueId
+	String parentIssueKey
 ) implements CreateIssueResponse {
 
 	public static CreateTaskResponse from(Task task) {
@@ -41,8 +41,8 @@ public record CreateTaskResponse(
 			.priority(task.getPriority())
 			.dueDate(task.getDueDate())
 			.difficulty(task.getDifficulty())
-			.parentIssueId(Optional.ofNullable(task.getParentIssue())
-				.map(Issue::getId)
+			.parentIssueKey(Optional.ofNullable(task.getParentIssue())
+				.map(Issue::getIssueKey)
 				.orElse(null))
 			.build();
 	}

--- a/backend/src/main/java/com/tissue/api/issue/service/command/IssueCommandService.java
+++ b/backend/src/main/java/com/tissue/api/issue/service/command/IssueCommandService.java
@@ -55,7 +55,7 @@ public class IssueCommandService {
 
 		Issue issue = request.to(
 			workspace,
-			findParentIssue(request.parentIssueId(), code).orElse(null)
+			findParentIssue(request.parentIssueKey(), code).orElse(null)
 		);
 
 		Issue savedIssue = issueRepository.save(issue);
@@ -134,9 +134,9 @@ public class IssueCommandService {
 		return DeleteIssueResponse.from(issueId, issueKey, LocalDateTime.now());
 	}
 
-	private Optional<Issue> findParentIssue(Long parentIssueId, String workspaceCode) {
-		return Optional.ofNullable(parentIssueId)
-			.map(id -> issueRepository.findByIdAndWorkspaceCode(id, workspaceCode)
+	private Optional<Issue> findParentIssue(String parentIssueKey, String workspaceCode) {
+		return Optional.ofNullable(parentIssueKey)
+			.map(issueKey -> issueRepository.findByIssueKeyAndWorkspaceCode(issueKey, workspaceCode)
 				.orElseThrow(() -> new IssueNotFoundException("Issue does not exist in this workspace.")));
 	}
 

--- a/backend/src/test/java/com/tissue/api/issue/service/IssueCommandServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/issue/service/IssueCommandServiceIT.java
@@ -109,7 +109,7 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 			.priority(IssuePriority.HIGH)
 			.dueDate(LocalDate.now())
 			.difficulty(Difficulty.NORMAL)
-			.parentIssueId(parentIssue.getId())
+			.parentIssueKey(parentIssue.getIssueKey())
 			.userStory("Child Story User Story")
 			.acceptanceCriteria("Child Story Acceptance Criteria")
 			.build();
@@ -152,7 +152,7 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 			.priority(IssuePriority.HIGH)
 			.dueDate(LocalDate.now())
 			.difficulty(Difficulty.NORMAL)
-			.parentIssueId(response.issueId())
+			.parentIssueKey(response.issueKey())
 			.userStory("Child Story User Story")
 			.acceptanceCriteria("Child Story Acceptance Criteria")
 			.build();
@@ -185,7 +185,7 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 			.priority(IssuePriority.HIGH)
 			.dueDate(LocalDate.now())
 			.difficulty(Difficulty.NORMAL)
-			.parentIssueId(parentIssue.getId())
+			.parentIssueKey(parentIssue.getIssueKey())
 			.build();
 
 		// when & then
@@ -215,7 +215,7 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 			.priority(IssuePriority.HIGH)
 			.dueDate(LocalDate.now())
 			.difficulty(Difficulty.NORMAL)
-			.parentIssueId(parentIssue.getId())
+			.parentIssueKey(parentIssue.getIssueKey())
 			.build();
 
 		// when & then
@@ -422,7 +422,7 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 		CreateSubTaskRequest createSubTaskRequest = CreateSubTaskRequest.builder()
 			.title("Child SubTask Title")
 			.content("Child SubTask Content")
-			.parentIssueId(createResponse.issueId())
+			.parentIssueKey(createResponse.issueKey())
 			.build();
 
 		issueCommandService.createIssue("TESTCODE", createSubTaskRequest);
@@ -437,8 +437,13 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 	@DisplayName("Story의 부모로 Epic을 등록할 수 있다")
 	void assignParentIssue_StoryToEpic() {
 		// given
-		CreateEpicResponse epicResponse = (CreateEpicResponse)issueFixture.createEpic("TESTCODE", "Test Epic");
-		CreateStoryResponse storyResponse = (CreateStoryResponse)issueFixture.createStory("TESTCODE", "Test Story",
+		CreateEpicResponse epicResponse = (CreateEpicResponse)issueFixture.createEpic(
+			"TESTCODE",
+			"Test Epic");
+
+		CreateStoryResponse storyResponse = (CreateStoryResponse)issueFixture.createStory(
+			"TESTCODE",
+			"Test Story",
 			null);
 
 		// when
@@ -458,9 +463,13 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 	@DisplayName("Story의 부모로 Story를 등록 시도하면 예외가 발생한다")
 	void assignParentIssue_StoryToStory_throwsException() {
 		// given
-		CreateStoryResponse storyResponse = (CreateStoryResponse)issueFixture.createStory("TESTCODE", "Story 1",
+		CreateStoryResponse storyResponse = (CreateStoryResponse)issueFixture.createStory(
+			"TESTCODE",
+			"Story 1",
 			null);
-		CreateStoryResponse parentStoryResponse = (CreateStoryResponse)issueFixture.createStory("TESTCODE",
+
+		CreateStoryResponse parentStoryResponse = (CreateStoryResponse)issueFixture.createStory(
+			"TESTCODE",
 			"(Parent) Story 2",
 			null);
 
@@ -512,6 +521,7 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 		assertThat(assignParentResponse.parentIssueId()).isEqualTo(newParentEpicResponse.issueId());
 	}
 
+	@Transactional
 	@Test
 	@DisplayName("Story가 부모 이슈인 Epic을 가지고 있으면, 해당 부모 관계를 해제할 수 있다")
 	void storyHasParent_canRemoveParentRelationship() {
@@ -524,7 +534,7 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 		CreateStoryResponse storyResponse = (CreateStoryResponse)issueFixture.createStory(
 			"TESTCODE",
 			"Test Story",
-			epicResponse.parentIssueId()
+			epicResponse.issueKey()
 		);
 
 		// when
@@ -553,7 +563,7 @@ class IssueCommandServiceIT extends ServiceIntegrationTestHelper {
 		CreateSubTaskResponse subTaskResponse = (CreateSubTaskResponse)issueFixture.createSubTask(
 			"TESTCODE",
 			"Test Story",
-			storyResponse.parentIssueId()
+			storyResponse.issueKey()
 		);
 
 		// when & then

--- a/backend/src/test/java/com/tissue/fixture/service/IssueFixture.java
+++ b/backend/src/test/java/com/tissue/fixture/service/IssueFixture.java
@@ -42,7 +42,7 @@ public class IssueFixture {
 	public CreateIssueResponse createTask(
 		String workspaceCode,
 		String title,
-		Long parentIssueId
+		String parentIssueKey
 	) {
 		CreateTaskRequest request = CreateTaskRequest.builder()
 			.title(title)
@@ -50,7 +50,7 @@ public class IssueFixture {
 			.summary("Task Summary")
 			.difficulty(Difficulty.NORMAL)
 			.dueDate(LocalDate.now())
-			.parentIssueId(parentIssueId)
+			.parentIssueKey(parentIssueKey)
 			.build();
 
 		return issueCommandService.createIssue(workspaceCode, request);
@@ -59,7 +59,7 @@ public class IssueFixture {
 	public CreateIssueResponse createStory(
 		String workspaceCode,
 		String title,
-		Long parentIssueId
+		String parentIssueKey
 	) {
 		CreateStoryRequest request = CreateStoryRequest.builder()
 			.title(title)
@@ -67,7 +67,7 @@ public class IssueFixture {
 			.summary("Story Summary")
 			.difficulty(Difficulty.NORMAL)
 			.dueDate(LocalDate.now())
-			.parentIssueId(parentIssueId)
+			.parentIssueKey(parentIssueKey)
 			.userStory("Story User Story")
 			.acceptanceCriteria("Story Acceptance Criteria")
 			.build();
@@ -78,7 +78,7 @@ public class IssueFixture {
 	public CreateIssueResponse createBug(
 		String workspaceCode,
 		String title,
-		Long parentIssueId
+		String parentIssueKey
 	) {
 		CreateBugRequest request = CreateBugRequest.builder()
 			.title(title)
@@ -86,7 +86,7 @@ public class IssueFixture {
 			.summary("Bug Summary")
 			.difficulty(Difficulty.NORMAL)
 			.dueDate(LocalDate.now())
-			.parentIssueId(parentIssueId)
+			.parentIssueKey(parentIssueKey)
 			.reproducingSteps("Bug Reproduce Steps")
 			.severity(BugSeverity.MAJOR)
 			.affectedVersions(Set.of("1.0.0", "1.0.1"))
@@ -98,7 +98,7 @@ public class IssueFixture {
 	public CreateIssueResponse createSubTask(
 		String workspaceCode,
 		String title,
-		Long parentIssueId
+		String parentIssueKey
 	) {
 		CreateSubTaskRequest request = CreateSubTaskRequest.builder()
 			.title(title)
@@ -106,7 +106,7 @@ public class IssueFixture {
 			.summary("SubTask Summary")
 			.difficulty(Difficulty.NORMAL)
 			.dueDate(LocalDate.now())
-			.parentIssueId(parentIssueId)
+			.parentIssueKey(parentIssueKey)
 			.build();
 
 		return issueCommandService.createIssue(workspaceCode, request);


### PR DESCRIPTION
## 🚀 설명
- `id` 조회 -> `issueKey`조회

---
## ✅ 변경 사항
- [x] `IssueCommandService`의 `findParentIssue`에서 `issueKey` 조회로 변경
- [x] 모든 `CreateIssueRequest`에서 `parentIssueId`가 아닌 `parentIssueKey` 전달

---
## 🚩 관련 이슈, PR
- #173 

---
## 📖 참고