### PR TITLE
Refactor/#180 여러 개의 `Position`을 할당 받을 수 있도록 변경

### DIFF
--- a/backend/src/main/java/com/tissue/api/position/domain/Position.java
+++ b/backend/src/main/java/com/tissue/api/position/domain/Position.java
@@ -6,8 +6,8 @@ import java.util.List;
 import com.tissue.api.common.entity.WorkspaceContextBaseEntity;
 import com.tissue.api.common.enums.ColorType;
 import com.tissue.api.workspace.domain.Workspace;
-import com.tissue.api.workspacemember.domain.WorkspaceMember;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -56,8 +56,11 @@ public class Position extends WorkspaceContextBaseEntity {
 	@Column(name = "WORKSPACE_CODE", nullable = false)
 	private String workspaceCode;
 
-	@OneToMany(mappedBy = "position")
-	private List<WorkspaceMember> workspaceMembers = new ArrayList<>();
+	// @OneToMany(mappedBy = "position")
+	// private List<WorkspaceMember> workspaceMembers = new ArrayList<>();
+
+	@OneToMany(mappedBy = "position", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<WorkspaceMemberPosition> workspaceMemberPositions = new ArrayList<>();
 
 	@Builder
 	public Position(

--- a/backend/src/main/java/com/tissue/api/position/domain/Position.java
+++ b/backend/src/main/java/com/tissue/api/position/domain/Position.java
@@ -19,8 +19,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,10 +26,6 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(uniqueConstraints = {
-	@UniqueConstraint(name = "UK_WORKSPACE_POSITION_NAME",
-		columnNames = {"workspace_code", "name"})
-})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Position extends WorkspaceContextBaseEntity {
 	@Id
@@ -55,9 +49,6 @@ public class Position extends WorkspaceContextBaseEntity {
 
 	@Column(name = "WORKSPACE_CODE", nullable = false)
 	private String workspaceCode;
-
-	// @OneToMany(mappedBy = "position")
-	// private List<WorkspaceMember> workspaceMembers = new ArrayList<>();
 
 	@OneToMany(mappedBy = "position", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<WorkspaceMemberPosition> workspaceMemberPositions = new ArrayList<>();

--- a/backend/src/main/java/com/tissue/api/position/domain/WorkspaceMemberPosition.java
+++ b/backend/src/main/java/com/tissue/api/position/domain/WorkspaceMemberPosition.java
@@ -1,0 +1,51 @@
+package com.tissue.api.position.domain;
+
+import com.tissue.api.workspacemember.domain.WorkspaceMember;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "UK_WORKSPACE_MEMBER_POSITION",
+			columnNames = {"WORKSPACE_MEMBER_ID", "POSITION_ID"})
+	}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WorkspaceMemberPosition {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "WORKSPACE_MEMBER_ID", nullable = false)
+	private WorkspaceMember workspaceMember;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "POSITION_ID", nullable = false)
+	private Position position;
+
+	@Builder
+	public WorkspaceMemberPosition(WorkspaceMember workspaceMember, Position position) {
+		this.workspaceMember = workspaceMember;
+		this.position = position;
+
+		workspaceMember.getWorkspaceMemberPositions().add(this);
+		position.getWorkspaceMemberPositions().add(this);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/position/domain/WorkspaceMemberPosition.java
+++ b/backend/src/main/java/com/tissue/api/position/domain/WorkspaceMemberPosition.java
@@ -1,5 +1,6 @@
 package com.tissue.api.position.domain;
 
+import com.tissue.api.common.entity.WorkspaceContextBaseEntity;
 import com.tissue.api.workspacemember.domain.WorkspaceMember;
 
 import jakarta.persistence.Entity;
@@ -26,7 +27,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class WorkspaceMemberPosition {
+public class WorkspaceMemberPosition extends WorkspaceContextBaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/tissue/api/position/domain/repository/PositionRepository.java
+++ b/backend/src/main/java/com/tissue/api/position/domain/repository/PositionRepository.java
@@ -12,15 +12,8 @@ import com.tissue.api.position.domain.Position;
 public interface PositionRepository extends JpaRepository<Position, Long> {
 	Optional<Position> findByIdAndWorkspaceCode(Long id, String workspaceCode);
 
-	/**
-	 * Todo
-	 *  - 더 쉬운 이름으로 변경
-	 *  - SQL 또는 QueryDSL 사용
-	 */
 	List<Position> findAllByWorkspaceCodeOrderByCreatedDateAsc(String workspaceCode);
 
-	@Query("SELECT COUNT(wm) > 0 FROM WorkspaceMember wm WHERE wm.position = :position")
+	@Query("SELECT COUNT(wmp) > 0 FROM WorkspaceMemberPosition wmp WHERE wmp.position = :position")
 	boolean existsByWorkspaceMembers(@Param("position") Position position);
-
-	boolean existsByWorkspaceCodeAndName(String workspaceCode, String name);
 }

--- a/backend/src/main/java/com/tissue/api/position/exception/DuplicatePositionAssignmentException.java
+++ b/backend/src/main/java/com/tissue/api/position/exception/DuplicatePositionAssignmentException.java
@@ -1,0 +1,19 @@
+package com.tissue.api.position.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.tissue.api.common.exception.domain.PositionException;
+
+public class DuplicatePositionAssignmentException extends PositionException {
+
+	private static final String MESSAGE = "Position is already assigned to this workspace member.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public DuplicatePositionAssignmentException(String message) {
+		super(message, HTTP_STATUS);
+	}
+
+	public DuplicatePositionAssignmentException(Throwable cause) {
+		super(MESSAGE, HTTP_STATUS, cause);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/position/exception/PositionNotAssignedException.java
+++ b/backend/src/main/java/com/tissue/api/position/exception/PositionNotAssignedException.java
@@ -1,0 +1,19 @@
+package com.tissue.api.position.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.tissue.api.common.exception.domain.PositionException;
+
+public class PositionNotAssignedException extends PositionException {
+
+	private static final String MESSAGE = "Position was not assigned to this workspace member.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public PositionNotAssignedException(String message) {
+		super(message, HTTP_STATUS);
+	}
+
+	public PositionNotAssignedException(Throwable cause) {
+		super(MESSAGE, HTTP_STATUS, cause);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/position/service/command/PositionCommandService.java
+++ b/backend/src/main/java/com/tissue/api/position/service/command/PositionCommandService.java
@@ -129,7 +129,15 @@ public class PositionCommandService {
 	}
 
 	private Position createPosition(CreatePositionRequest request, Workspace workspace, ColorType color) {
-		Position position = workspace.createPosition(request.name(), request.description(), color);
+		// Position position = workspace.createPosition(request.name(), request.description(), color);
+
+		Position position = Position.builder()
+			.name(request.name())
+			.description(request.description())
+			.color(color)
+			.workspace(workspace)
+			.build();
+
 		return positionRepository.save(position);
 	}
 

--- a/backend/src/main/java/com/tissue/api/position/service/command/PositionCommandService.java
+++ b/backend/src/main/java/com/tissue/api/position/service/command/PositionCommandService.java
@@ -36,28 +36,11 @@ public class PositionCommandService {
 		String workspaceCode,
 		CreatePositionRequest request
 	) {
-
 		Workspace workspace = findWorkspaceByCode(workspaceCode);
 
-		positionValidator.validateDuplicatePositionName(
-			workspaceCode,
-			request.name()
-		);
-
-		// 사용되지 않은 색상 중에서 랜덤으로 선택
 		ColorType randomColor = ColorType.getRandomUnusedColor(workspace.getUsedPositionColors());
 
-		Position savedPosition = createPosition(
-			request,
-			workspace,
-			randomColor
-		);
-
-		log.debug("Position {} created with color: {} ({})",
-			request.name(),
-			randomColor.getDisplayName(),
-			randomColor.getHexCode()
-		);
+		Position savedPosition = createPosition(request, workspace, randomColor);
 
 		return CreatePositionResponse.from(savedPosition);
 	}
@@ -68,16 +51,7 @@ public class PositionCommandService {
 		Long positionId,
 		UpdatePositionRequest request
 	) {
-
-		positionValidator.validateDuplicatePositionName(
-			workspaceCode,
-			request.name()
-		);
-
-		Position position = findPositionByIdAndWorkspaceCode(
-			workspaceCode,
-			positionId
-		);
+		Position position = findPosition(workspaceCode, positionId);
 
 		position.updateName(request.name());
 		position.updateDescription(request.description());
@@ -91,8 +65,7 @@ public class PositionCommandService {
 		Long positionId,
 		UpdatePositionColorRequest request
 	) {
-
-		Position position = findPositionByIdAndWorkspaceCode(
+		Position position = findPosition(
 			workspaceCode,
 			positionId
 		);
@@ -108,7 +81,7 @@ public class PositionCommandService {
 		Long positionId
 	) {
 
-		Position position = findPositionByIdAndWorkspaceCode(
+		Position position = findPosition(
 			workspaceCode,
 			positionId
 		);
@@ -120,8 +93,11 @@ public class PositionCommandService {
 		return DeletePositionResponse.from(position);
 	}
 
-	private Position createPosition(CreatePositionRequest request, Workspace workspace, ColorType color) {
-		// Position position = workspace.createPosition(request.name(), request.description(), color);
+	private Position createPosition(
+		CreatePositionRequest request,
+		Workspace workspace,
+		ColorType color
+	) {
 
 		Position position = Position.builder()
 			.name(request.name())
@@ -138,7 +114,10 @@ public class PositionCommandService {
 			.orElseThrow(WorkspaceNotFoundException::new);
 	}
 
-	private Position findPositionByIdAndWorkspaceCode(String workspaceCode, Long positionId) {
+	private Position findPosition(
+		String workspaceCode,
+		Long positionId
+	) {
 		return positionRepository.findByIdAndWorkspaceCode(positionId, workspaceCode)
 			.orElseThrow(PositionNotFoundException::new);
 	}

--- a/backend/src/main/java/com/tissue/api/position/service/command/PositionCommandService.java
+++ b/backend/src/main/java/com/tissue/api/position/service/command/PositionCommandService.java
@@ -1,8 +1,5 @@
 package com.tissue.api.position.service.command;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,13 +44,8 @@ public class PositionCommandService {
 			request.name()
 		);
 
-		// 현재 워크스페이스에서 사용 중인 색상들을 Set으로 추출
-		Set<ColorType> usedColors = workspace.getPositions().stream()
-			.map(Position::getColor)
-			.collect(Collectors.toSet());
-
 		// 사용되지 않은 색상 중에서 랜덤으로 선택
-		ColorType randomColor = ColorType.getRandomUnusedColor(usedColors);
+		ColorType randomColor = ColorType.getRandomUnusedColor(workspace.getUsedPositionColors());
 
 		Position savedPosition = createPosition(
 			request,

--- a/backend/src/main/java/com/tissue/api/position/service/command/PositionCommandService.java
+++ b/backend/src/main/java/com/tissue/api/position/service/command/PositionCommandService.java
@@ -98,7 +98,6 @@ public class PositionCommandService {
 		Workspace workspace,
 		ColorType color
 	) {
-
 		Position position = Position.builder()
 			.name(request.name())
 			.description(request.description())

--- a/backend/src/main/java/com/tissue/api/position/validator/PositionValidator.java
+++ b/backend/src/main/java/com/tissue/api/position/validator/PositionValidator.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Component;
 
 import com.tissue.api.position.domain.Position;
 import com.tissue.api.position.domain.repository.PositionRepository;
-import com.tissue.api.position.exception.DuplicatePositionNameException;
 import com.tissue.api.position.exception.PositionInUseException;
 
 import lombok.RequiredArgsConstructor;
@@ -22,12 +21,6 @@ import lombok.RequiredArgsConstructor;
 public class PositionValidator {
 
 	private final PositionRepository positionRepository;
-
-	public void validateDuplicatePositionName(String workspaceCode, String positionName) {
-		if (positionRepository.existsByWorkspaceCodeAndName(workspaceCode, positionName)) {
-			throw new DuplicatePositionNameException();
-		}
-	}
 
 	public void validatePositionIsUsed(Position position) {
 		if (positionRepository.existsByWorkspaceMembers(position)) {

--- a/backend/src/main/java/com/tissue/api/workspace/domain/Workspace.java
+++ b/backend/src/main/java/com/tissue/api/workspace/domain/Workspace.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.tissue.api.common.entity.WorkspaceBaseEntity;
-import com.tissue.api.common.enums.ColorType;
 import com.tissue.api.invitation.domain.Invitation;
 import com.tissue.api.issue.domain.Issue;
 import com.tissue.api.member.domain.Member;
@@ -99,14 +98,14 @@ public class Workspace extends WorkspaceBaseEntity {
 		this.keyPrefix = toUpperCaseOrDefault(keyPrefix);
 	}
 
-	public Position createPosition(String name, String description, ColorType color) {
-		return Position.builder()
-			.name(name)
-			.description(description)
-			.color(color)
-			.workspace(this)
-			.build();
-	}
+	// public Position createPosition(String name, String description, ColorType color) {
+	// 	return Position.builder()
+	// 		.name(name)
+	// 		.description(description)
+	// 		.color(color)
+	// 		.workspace(this)
+	// 		.build();
+	// }
 
 	public void setCode(String code) {
 		this.code = code;

--- a/backend/src/main/java/com/tissue/api/workspace/domain/Workspace.java
+++ b/backend/src/main/java/com/tissue/api/workspace/domain/Workspace.java
@@ -2,8 +2,11 @@ package com.tissue.api.workspace.domain;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.tissue.api.common.entity.WorkspaceBaseEntity;
+import com.tissue.api.common.enums.ColorType;
 import com.tissue.api.invitation.domain.Invitation;
 import com.tissue.api.issue.domain.Issue;
 import com.tissue.api.member.domain.Member;
@@ -125,6 +128,12 @@ public class Workspace extends WorkspaceBaseEntity {
 
 	public void updateDescription(String description) {
 		this.description = description;
+	}
+
+	public Set<ColorType> getUsedPositionColors() {
+		return this.positions.stream()
+			.map(Position::getColor)
+			.collect(Collectors.toSet());
 	}
 
 	public String getIssueKey() {

--- a/backend/src/main/java/com/tissue/api/workspace/domain/Workspace.java
+++ b/backend/src/main/java/com/tissue/api/workspace/domain/Workspace.java
@@ -101,15 +101,6 @@ public class Workspace extends WorkspaceBaseEntity {
 		this.keyPrefix = toUpperCaseOrDefault(keyPrefix);
 	}
 
-	// public Position createPosition(String name, String description, ColorType color) {
-	// 	return Position.builder()
-	// 		.name(name)
-	// 		.description(description)
-	// 		.color(color)
-	// 		.workspace(this)
-	// 		.build();
-	// }
-
 	public void setCode(String code) {
 		this.code = code;
 	}

--- a/backend/src/main/java/com/tissue/api/workspacemember/domain/WorkspaceMember.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/domain/WorkspaceMember.java
@@ -7,6 +7,8 @@ import com.tissue.api.common.entity.BaseEntity;
 import com.tissue.api.member.domain.Member;
 import com.tissue.api.position.domain.Position;
 import com.tissue.api.position.domain.WorkspaceMemberPosition;
+import com.tissue.api.position.exception.DuplicatePositionAssignmentException;
+import com.tissue.api.position.exception.PositionNotAssignedException;
 import com.tissue.api.position.exception.PositionNotFoundException;
 import com.tissue.api.workspace.domain.Workspace;
 import com.tissue.api.workspacemember.exception.InvalidRoleUpdateException;
@@ -35,7 +37,7 @@ import lombok.NoArgsConstructor;
 	uniqueConstraints = {
 		@UniqueConstraint(
 			name = "UK_WORKSPACE_NICKNAME",
-			columnNames = {"workspace_code", "nickname"})
+			columnNames = {"WORKSPACE_CODE", "nickname"})
 	}
 )
 @Getter
@@ -57,10 +59,6 @@ public class WorkspaceMember extends BaseEntity {
 	@Column(name = "WORKSPACE_CODE", nullable = false)
 	private String workspaceCode;
 
-	// @ManyToOne(fetch = FetchType.LAZY)
-	// @JoinColumn(name = "POSITION_ID")
-	// private Position position;
-
 	@OneToMany(mappedBy = "workspaceMember", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<WorkspaceMemberPosition> workspaceMemberPositions = new ArrayList<>();
 
@@ -72,7 +70,12 @@ public class WorkspaceMember extends BaseEntity {
 	private String nickname;
 
 	@Builder
-	public WorkspaceMember(Member member, Workspace workspace, WorkspaceRole role, String nickname) {
+	public WorkspaceMember(
+		Member member,
+		Workspace workspace,
+		WorkspaceRole role,
+		String nickname
+	) {
 		this.member = member;
 		this.workspace = workspace;
 		this.role = role;
@@ -80,8 +83,12 @@ public class WorkspaceMember extends BaseEntity {
 		this.workspaceCode = workspace.getCode();
 	}
 
-	public static WorkspaceMember addWorkspaceMember(Member member, Workspace workspace, WorkspaceRole role,
-		String nickname) {
+	public static WorkspaceMember addWorkspaceMember(
+		Member member,
+		Workspace workspace,
+		WorkspaceRole role,
+		String nickname
+	) {
 		WorkspaceMember workspaceMember = WorkspaceMember.builder()
 			.member(member)
 			.workspace(workspace)
@@ -95,13 +102,19 @@ public class WorkspaceMember extends BaseEntity {
 		return workspaceMember;
 	}
 
-	public static WorkspaceMember addOwnerWorkspaceMember(Member member, Workspace workspace) {
+	public static WorkspaceMember addOwnerWorkspaceMember(
+		Member member,
+		Workspace workspace
+	) {
 		member.increaseMyWorkspaceCount();
 		workspace.increaseMemberCount();
 		return addWorkspaceMember(member, workspace, WorkspaceRole.OWNER, member.getEmail());
 	}
 
-	public static WorkspaceMember addCollaboratorWorkspaceMember(Member member, Workspace workspace) {
+	public static WorkspaceMember addCollaboratorWorkspaceMember(
+		Member member,
+		Workspace workspace
+	) {
 		workspace.increaseMemberCount();
 		return addWorkspaceMember(member, workspace, WorkspaceRole.MEMBER, member.getEmail());
 	}
@@ -112,22 +125,10 @@ public class WorkspaceMember extends BaseEntity {
 		this.workspace.getWorkspaceMembers().remove(this);
 	}
 
-	// public void changePosition(Position position) {
-	// 	if (position != null) {
-	// 		validatePositionBelongsToWorkspace(position);
-	// 	}
-	// 	this.position = position;
-	// }
-	//
-	// public void removePosition() {
-	// 	if (this.position != null) {
-	// 		this.position.getWorkspaceMembers().remove(this);
-	// 		this.position = null;
-	// 	}
-	// }
-
 	public void addPosition(Position position) {
 		validatePositionBelongsToWorkspace(position);
+		validateDuplicateAssignedPosition(position);
+
 		WorkspaceMemberPosition.builder()
 			.workspaceMember(this)
 			.position(position)
@@ -135,10 +136,14 @@ public class WorkspaceMember extends BaseEntity {
 	}
 
 	public void removePosition(Position position) {
-		workspaceMemberPositions.stream()
+		WorkspaceMemberPosition workspaceMemberPosition = workspaceMemberPositions.stream()
 			.filter(wmp -> wmp.getPosition().equals(position))
 			.findFirst()
-			.ifPresent(wmp -> workspaceMemberPositions.remove(wmp));
+			.orElseThrow(() -> new PositionNotAssignedException(
+				String.format("Position '%s' is not assigned to this workspace member", position.getName())
+			));
+
+		workspaceMemberPositions.remove(workspaceMemberPosition);
 	}
 
 	public void clearPositions() {
@@ -164,6 +169,17 @@ public class WorkspaceMember extends BaseEntity {
 
 	public void updateNickname(String nickname) {
 		this.nickname = nickname;
+	}
+
+	private void validateDuplicateAssignedPosition(Position position) {
+		boolean isAlreadyAssigned = this.workspaceMemberPositions.stream()
+			.anyMatch(wmp -> wmp.getPosition().equals(position));
+
+		if (isAlreadyAssigned) {
+			throw new DuplicatePositionAssignmentException(
+				String.format("Position '%s' is already assigned to this workspace member", position.getName())
+			);
+		}
 	}
 
 	private void validatePositionBelongsToWorkspace(Position position) {

--- a/backend/src/main/java/com/tissue/api/workspacemember/presentation/controller/WorkspaceMemberInfoController.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/presentation/controller/WorkspaceMemberInfoController.java
@@ -1,5 +1,6 @@
 package com.tissue.api.workspacemember.presentation.controller;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -64,51 +65,67 @@ public class WorkspaceMemberInfoController {
 	@RoleRequired(roles = {WorkspaceRole.VIEWER})
 	@PatchMapping("/positions/{positionId}")
 	public ApiResponse<AssignPositionResponse> assignMyPosition(
+		@PathVariable String code,
 		@PathVariable Long positionId,
 		@CurrentWorkspaceMember Long workspaceMemberId
 	) {
 		AssignPositionResponse response = workspaceMemberCommandService.assignPosition(
+			code,
 			positionId,
 			workspaceMemberId
 		);
 
-		return ApiResponse.ok("Position assigned to member.", response);
+		return ApiResponse.ok("Position assigned to workspace member.", response);
 	}
 
 	@LoginRequired
 	@RoleRequired(roles = {WorkspaceRole.VIEWER})
-	@PatchMapping("/positions")
-	public ApiResponse<Void> clearMyPosition(
+	@DeleteMapping("/positions/{positionId}")
+	public ApiResponse<Void> removeMyPosition(
+		@PathVariable String code,
+		@PathVariable Long positionId,
 		@CurrentWorkspaceMember Long workspaceMemberId
 	) {
-		workspaceMemberCommandService.clearPosition(workspaceMemberId);
+		workspaceMemberCommandService.removePosition(
+			code,
+			positionId,
+			workspaceMemberId
+		);
 
-		return ApiResponse.okWithNoContent("Position removed from member.");
+		return ApiResponse.okWithNoContent("Position removed from workspace member.");
 	}
 
 	@LoginRequired
 	@RoleRequired(roles = {WorkspaceRole.MANAGER})
 	@PatchMapping("/{workspaceMemberId}/positions/{positionId}")
 	public ApiResponse<AssignPositionResponse> assignPosition(
+		@PathVariable String code,
 		@PathVariable Long workspaceMemberId,
 		@PathVariable Long positionId
 	) {
 		AssignPositionResponse response = workspaceMemberCommandService.assignPosition(
+			code,
 			positionId,
 			workspaceMemberId
 		);
 
-		return ApiResponse.ok("Position assigned to member.", response);
+		return ApiResponse.ok("Position assigned to workspace member.", response);
 	}
 
 	@LoginRequired
 	@RoleRequired(roles = {WorkspaceRole.MANAGER})
 	@PatchMapping("/{workspaceMemberId}/positions")
-	public ApiResponse<Void> clearMemberPosition(
+	public ApiResponse<Void> removeMemberPosition(
+		@PathVariable String code,
+		@PathVariable Long positionId,
 		@PathVariable Long workspaceMemberId
 	) {
-		workspaceMemberCommandService.clearPosition(workspaceMemberId);
+		workspaceMemberCommandService.removePosition(
+			code,
+			positionId,
+			workspaceMemberId
+		);
 
-		return ApiResponse.okWithNoContent("Position removed from member.");
+		return ApiResponse.okWithNoContent("Position removed from workspace member.");
 	}
 }

--- a/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/response/AssignPositionResponse.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/response/AssignPositionResponse.java
@@ -1,19 +1,24 @@
 package com.tissue.api.workspacemember.presentation.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
-import com.tissue.api.position.domain.Position;
+import com.tissue.api.position.presentation.dto.response.PositionDetail;
 import com.tissue.api.workspacemember.domain.WorkspaceMember;
 
 public record AssignPositionResponse(
 	Long workspaceMemberId,
-	String assignedPositionName,
+	List<PositionDetail> assignedPositions,
 	LocalDateTime assignedAt
 ) {
-	public static AssignPositionResponse from(WorkspaceMember workspaceMember, Position position) {
+	public static AssignPositionResponse from(WorkspaceMember workspaceMember) {
+		List<PositionDetail> positionDetails = workspaceMember.getWorkspaceMemberPositions().stream()
+			.map(wmp -> PositionDetail.from(wmp.getPosition()))
+			.toList();
+
 		return new AssignPositionResponse(
 			workspaceMember.getId(),
-			position.getName(),
+			positionDetails,
 			workspaceMember.getLastModifiedDate()
 		);
 	}

--- a/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/response/AssignPositionResponse.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/presentation/dto/response/AssignPositionResponse.java
@@ -2,17 +2,18 @@ package com.tissue.api.workspacemember.presentation.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.tissue.api.position.domain.Position;
 import com.tissue.api.workspacemember.domain.WorkspaceMember;
 
 public record AssignPositionResponse(
 	Long workspaceMemberId,
-	String assignedPosition,
+	String assignedPositionName,
 	LocalDateTime assignedAt
 ) {
-	public static AssignPositionResponse from(WorkspaceMember workspaceMember) {
+	public static AssignPositionResponse from(WorkspaceMember workspaceMember, Position position) {
 		return new AssignPositionResponse(
 			workspaceMember.getId(),
-			workspaceMember.getPosition().getName(),
+			position.getName(),
 			workspaceMember.getLastModifiedDate()
 		);
 	}

--- a/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceMemberCommandService.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceMemberCommandService.java
@@ -88,7 +88,7 @@ public class WorkspaceMemberCommandService {
 	) {
 		WorkspaceMember workspaceMember = findWorkspaceMember(workspaceMemberId);
 
-		workspaceMember.removePosition();
+		// workspaceMember.removePosition();
 	}
 
 	@Transactional

--- a/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceMemberCommandService.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceMemberCommandService.java
@@ -70,25 +70,28 @@ public class WorkspaceMemberCommandService {
 
 	@Transactional
 	public AssignPositionResponse assignPosition(
+		String workspaceCode,
 		Long positionId,
 		Long workspaceMemberId
 	) {
-		Position position = findPosition(positionId);
-
+		Position position = findPosition(positionId, workspaceCode);
 		WorkspaceMember workspaceMember = findWorkspaceMember(workspaceMemberId);
 
-		workspaceMember.changePosition(position);
+		workspaceMember.addPosition(position);
 
-		return AssignPositionResponse.from(workspaceMember);
+		return AssignPositionResponse.from(workspaceMember, position);
 	}
 
 	@Transactional
-	public void clearPosition(
+	public void removePosition(
+		String workspaceCode,
+		Long positionId,
 		Long workspaceMemberId
 	) {
+		Position position = findPosition(positionId, workspaceCode);
 		WorkspaceMember workspaceMember = findWorkspaceMember(workspaceMemberId);
 
-		// workspaceMember.removePosition();
+		workspaceMember.removePosition(position);
 	}
 
 	@Transactional
@@ -126,15 +129,9 @@ public class WorkspaceMemberCommandService {
 			.orElseThrow(WorkspaceMemberNotFoundException::new);
 	}
 
-	// private WorkspaceMember findWorkspaceMember(String code, Long memberId) {
-	// 	return workspaceMemberRepository
-	// 		.findByMemberIdAndWorkspaceCode(memberId, code)
-	// 		.orElseThrow(MemberNotInWorkspaceException::new);
-	// }
-
-	private Position findPosition(Long positionId) {
+	private Position findPosition(Long positionId, String workspaceCode) {
 		return positionRepository
-			.findById(positionId)
+			.findByIdAndWorkspaceCode(positionId, workspaceCode)
 			.orElseThrow(PositionNotFoundException::new);
 	}
 }

--- a/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceMemberCommandService.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceMemberCommandService.java
@@ -79,7 +79,7 @@ public class WorkspaceMemberCommandService {
 
 		workspaceMember.addPosition(position);
 
-		return AssignPositionResponse.from(workspaceMember, position);
+		return AssignPositionResponse.from(workspaceMember);
 	}
 
 	@Transactional

--- a/backend/src/test/java/com/tissue/api/workspacemember/presentation/controller/WorkspaceMemberInfoControllerTest.java
+++ b/backend/src/test/java/com/tissue/api/workspacemember/presentation/controller/WorkspaceMemberInfoControllerTest.java
@@ -5,10 +5,13 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import com.tissue.api.common.enums.ColorType;
+import com.tissue.api.position.presentation.dto.response.PositionDetail;
 import com.tissue.api.workspacemember.presentation.dto.response.AssignPositionResponse;
 import com.tissue.helper.ControllerTestHelper;
 
@@ -26,11 +29,16 @@ class WorkspaceMemberInfoControllerTest extends ControllerTestHelper {
 
 		AssignPositionResponse response = new AssignPositionResponse(
 			1L,
-			"Developer",
+			List.of(PositionDetail.builder()
+				.name("Developer")
+				.description("Developer description")
+				.color(ColorType.BLACK)
+				.build()),
 			LocalDateTime.now()
 		);
 
 		when(workspaceMemberCommandService.assignPosition(
+			workspaceCode,
 			positionId,
 			workspaceMemberId
 		))
@@ -39,24 +47,26 @@ class WorkspaceMemberInfoControllerTest extends ControllerTestHelper {
 		// When & Then
 		mockMvc.perform(patch(BASE_URL + "/positions/{positionId}", workspaceCode, positionId))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.message").value("Position assigned to member."))
+			.andExpect(jsonPath("$.message").value("Position assigned to workspace member."))
 			.andExpect(jsonPath("$.data.workspaceMemberId").value(1))
-			.andExpect(jsonPath("$.data.assignedPosition").value("Developer"));
+			.andExpect(jsonPath("$.data.assignedPositions[0].name").value("Developer"));
 	}
 
 	@Test
-	@DisplayName("PATCH /workspaces/{code}/members/positions - 내 Position 해제를 성공하면 OK 응답, 응답 데이터 없음")
+	@DisplayName("PATCH /workspaces/{code}/members/positions/{positionId} - 내 Position 해제를 성공하면 OK 응답, 응답 데이터 없음")
 	void removePosition_Success() throws Exception {
 		// Given
 		String workspaceCode = "TESTCODE";
 		Long currentWorkspaceMemberId = 1L;
+		Long positionId = 1L;
 
-		doNothing().when(workspaceMemberCommandService).clearPosition(currentWorkspaceMemberId);
+		doNothing().when(workspaceMemberCommandService)
+			.removePosition(workspaceCode, positionId, currentWorkspaceMemberId);
 
 		// When & Then
-		mockMvc.perform(patch(BASE_URL + "/positions", workspaceCode))
+		mockMvc.perform(patch(BASE_URL + "/positions/{positionId}", workspaceCode, positionId))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.message").value("Position removed from member."))
+			.andExpect(jsonPath("$.message").value("Position assigned to workspace member."))
 			.andExpect(jsonPath("$.data").doesNotExist());
 	}
 
@@ -71,11 +81,16 @@ class WorkspaceMemberInfoControllerTest extends ControllerTestHelper {
 
 		AssignPositionResponse response = new AssignPositionResponse(
 			2L,
-			"Developer",
+			List.of(PositionDetail.builder()
+				.name("Developer")
+				.description("Developer description")
+				.color(ColorType.BLACK)
+				.build()),
 			LocalDateTime.now()
 		);
 
 		when(workspaceMemberCommandService.assignPosition(
+			workspaceCode,
 			positionId,
 			targetWorkspaceMemberId
 		))
@@ -85,8 +100,8 @@ class WorkspaceMemberInfoControllerTest extends ControllerTestHelper {
 		mockMvc.perform(
 				patch(BASE_URL + "/{memberId}/positions/{positionId}", workspaceCode, targetWorkspaceMemberId, positionId))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.message").value("Position assigned to member."))
+			.andExpect(jsonPath("$.message").value("Position assigned to workspace member."))
 			.andExpect(jsonPath("$.data.workspaceMemberId").value(2))
-			.andExpect(jsonPath("$.data.assignedPosition").value("Developer"));
+			.andExpect(jsonPath("$.data.assignedPositions[0].name").value("Developer"));
 	}
 }


### PR DESCRIPTION
## 🚀 설명
- 기존에는 한 명의 `WorkspaceMember` 당 하나의 포지션 할당
- `Position`과 `WorkspaceMember` 사이에 `WorkspaceMemberPosition`을 추가하고 멀티 포지션 할당을 받을 수 있도록 변경

---
## ✅ 변경 사항
- [ ] `WorkspaceMemberPosition` 추가
- [ ] 포지션 생성은 포지션의 책임으로 변경
- [ ] 포지션 조회 방법 변경(`id` -> `id` + `workspaceCode`)
- [ ] 포지션 할당 응답에는 해당 워크스페이스 멤버가 할당 받은 포지션의 목록 포함
- [ ] 관련 테스트 수정/추가

---
## 🚩 관련 이슈, PR
- #180 

---
## 📖 참고