### PR TITLE
Feat/#190 이슈 상태 업데이트 검증 추가

### DIFF
--- a/backend/src/main/java/com/tissue/api/issue/domain/Issue.java
+++ b/backend/src/main/java/com/tissue/api/issue/domain/Issue.java
@@ -84,6 +84,9 @@ import lombok.NoArgsConstructor;
  * <br>
  * Todo 6
  *  - 이슈 상태 변화에 대한 검증을 그냥 validator 클래스에서 정의해서 서비스에서 진행 고려
+ * <br>
+ * Todo 7
+ *  - difficulty를 Issue로 이동
  */
 @Entity
 @Getter
@@ -421,6 +424,7 @@ public abstract class Issue extends WorkspaceContextBaseEntity {
 		return this.getCurrentReviewRound() != 0;
 	}
 
+	// Todo: 횡단 관심사(cross cutting concern)는 AOP로 구현하는걸 고려하자
 	private void updateTimestamps(IssueStatus newStatus) {
 		if (newStatus == IN_PROGRESS && this.startedAt == null) {
 			this.startedAt = LocalDateTime.now();
@@ -435,6 +439,12 @@ public abstract class Issue extends WorkspaceContextBaseEntity {
 		}
 	}
 
+	/**
+	 * Todo
+	 *  - 설정 엔티티를 구현하면, forceReviewEnabled=true인 경우 다음 구현
+	 *   - 리뷰가 강제되는 리뷰의 difficulty 수준을 설정 할 수 있도록 구현
+	 *   - 리뷰를 하지 않아도 되는 priority 수준을 설정 할 수 있도록 구현
+	 */
 	protected void validateStatusTransition(IssueStatus newStatus) {
 		// 기본 상태 전이 검증
 		validateBasicTransition(newStatus);

--- a/backend/src/main/java/com/tissue/api/issue/domain/Issue.java
+++ b/backend/src/main/java/com/tissue/api/issue/domain/Issue.java
@@ -1,9 +1,12 @@
 package com.tissue.api.issue.domain;
 
+import static com.tissue.api.issue.domain.enums.IssueStatus.*;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import com.tissue.api.assignee.domain.IssueAssignee;
 import com.tissue.api.assignee.exception.AssigneeNotFoundException;
@@ -15,9 +18,10 @@ import com.tissue.api.common.entity.WorkspaceContextBaseEntity;
 import com.tissue.api.issue.domain.enums.IssuePriority;
 import com.tissue.api.issue.domain.enums.IssueStatus;
 import com.tissue.api.issue.domain.enums.IssueType;
-import com.tissue.api.issue.exception.UpdateIssueInReviewStatusException;
-import com.tissue.api.issue.exception.UpdateStatusToInReviewException;
+import com.tissue.api.issue.exception.InvalidStatusTransitionException;
+import com.tissue.api.issue.exception.UnauthorizedIssueModifyException;
 import com.tissue.api.review.domain.IssueReviewer;
+import com.tissue.api.review.domain.enums.ReviewStatus;
 import com.tissue.api.review.exception.CannotRemoveReviewerException;
 import com.tissue.api.review.exception.DuplicateReviewerException;
 import com.tissue.api.review.exception.IncompleteReviewRoundException;
@@ -25,6 +29,8 @@ import com.tissue.api.review.exception.IssueStatusNotChangesRequestedException;
 import com.tissue.api.review.exception.IssueStatusNotInReviewException;
 import com.tissue.api.review.exception.MaxReviewersExceededException;
 import com.tissue.api.review.exception.NoReviewersAddedException;
+import com.tissue.api.review.exception.PendingReviewExistsException;
+import com.tissue.api.review.exception.ReviewRequiredException;
 import com.tissue.api.review.exception.ReviewerNotFoundException;
 import com.tissue.api.review.exception.UnauthorizedReviewerModificationException;
 import com.tissue.api.workspace.domain.Workspace;
@@ -183,9 +189,7 @@ public abstract class Issue extends WorkspaceContextBaseEntity {
 		}
 
 		// 작업자인 경우도 통과
-		boolean isAssignee = assignees.stream()
-			.anyMatch(issueAssignee ->
-				issueAssignee.getAssignee().getId().equals(requesterWorkspaceMemberId));
+		boolean isAssignee = isAssignee(requesterWorkspaceMemberId);
 
 		if (!isAssignee) {
 			throw new UnauthorizedReviewerModificationException(
@@ -288,14 +292,29 @@ public abstract class Issue extends WorkspaceContextBaseEntity {
 	}
 
 	public void validateIsAssignee(Long workspaceMemberId) {
-		boolean isAssignee = assignees.stream()
-			.anyMatch(issueAssignee ->
-				issueAssignee.getAssignee().getId().equals(workspaceMemberId));
+		boolean isAssignee = isAssignee(workspaceMemberId);
 
 		if (!isAssignee) {
 			throw new UnauthorizedAssigneeModificationException(
 				"You must be an assignee of the Issue.");
 		}
+	}
+
+	public void validateIsAssigneeOrAuthor(Long workspaceMemberId) {
+		if (isAssignee(workspaceMemberId) || isAuthor(workspaceMemberId)) {
+			return;
+		}
+		throw new UnauthorizedIssueModifyException("Must be the author or a assignee of this issue.");
+	}
+
+	private boolean isAssignee(Long workspaceMemberId) {
+		return assignees.stream()
+			.anyMatch(issueAssignee ->
+				issueAssignee.getAssignee().getId().equals(workspaceMemberId));
+	}
+
+	private boolean isAuthor(Long workspaceMemberId) {
+		return this.getCreatedByWorkspaceMember().equals(workspaceMemberId);
 	}
 
 	private void validateAssigneeLimit() {
@@ -313,8 +332,7 @@ public abstract class Issue extends WorkspaceContextBaseEntity {
 	}
 
 	private void validateNotAlreadyAssigned(WorkspaceMember assignee) {
-		boolean isAlreadyAssigned = this.assignees.stream()
-			.anyMatch(ia -> ia.getAssignee().getId().equals(assignee.getId()));
+		boolean isAlreadyAssigned = isAssignee(assignee.getId());
 
 		if (isAlreadyAssigned) {
 			throw new DuplicateAssigneeException(
@@ -365,7 +383,7 @@ public abstract class Issue extends WorkspaceContextBaseEntity {
 	}
 
 	public void updateStatus(IssueStatus newStatus) {
-		// validateStatusTransition(newStatus);
+		validateStatusTransition(newStatus);
 		this.status = newStatus;
 		updateTimestamps(newStatus);
 	}
@@ -404,7 +422,7 @@ public abstract class Issue extends WorkspaceContextBaseEntity {
 	}
 
 	private void updateTimestamps(IssueStatus newStatus) {
-		if (newStatus == IssueStatus.IN_PROGRESS && this.startedAt == null) {
+		if (newStatus == IN_PROGRESS && this.startedAt == null) {
 			this.startedAt = LocalDateTime.now();
 			return;
 		}
@@ -418,12 +436,60 @@ public abstract class Issue extends WorkspaceContextBaseEntity {
 	}
 
 	protected void validateStatusTransition(IssueStatus newStatus) {
-		if (this.status == IssueStatus.IN_REVIEW) {
-			throw new UpdateIssueInReviewStatusException();
+		// 기본 상태 전이 검증
+		validateBasicTransition(newStatus);
+
+		// 특수한 상태 전이 검증
+		if (newStatus == IssueStatus.DONE) {
+			validateTransitionToDone();
 		}
-		if (newStatus == IssueStatus.IN_REVIEW) {
-			throw new UpdateStatusToInReviewException();
+	}
+
+	private void validateTransitionToDone() {
+		/*
+		 * Todo: 워크스페이스 마다 가지는 설정을 관리하는 엔티티를 만들자.
+		 *  - isForceReviewEnabled==true: DONE으로 변경하기 위해서는 리뷰어 등록, 모든 리뷰가 APPROVED이어야 함
+		 */
+		// if (!isForceReviewEnabled) {
+		// 	return;
+		// }
+
+		if (reviewers.isEmpty()) {
+			throw new ReviewRequiredException("Review is required to complete this issue.");
 		}
+
+		if (isAllReviewsNotApproved()) {
+			throw new PendingReviewExistsException("All reviews must be approved.");
+		}
+	}
+
+	private boolean isAllReviewsNotApproved() {
+		return !reviewers.stream()
+			.allMatch(reviewer ->
+				reviewer.getCurrentReviewStatus(currentReviewRound) == ReviewStatus.APPROVED
+			);
+	}
+
+	private void validateBasicTransition(IssueStatus newStatus) {
+		Set<IssueStatus> allowedStatuses = getAllowedNextStatuses();
+
+		if (!allowedStatuses.contains(newStatus)) {
+			throw new InvalidStatusTransitionException(
+				String.format("Cannot transition from %s to %s.", this.status, newStatus)
+			);
+		}
+	}
+
+	private Set<IssueStatus> getAllowedNextStatuses() {
+		return switch (this.status) {
+			case TODO -> Set.of(IN_PROGRESS, PAUSED, CLOSED);
+			case IN_PROGRESS -> Set.of(IN_REVIEW, PAUSED, DONE, CLOSED);
+			case IN_REVIEW -> Set.of(CHANGES_REQUESTED, DONE);
+			case CHANGES_REQUESTED -> Set.of(IN_REVIEW);
+			case DONE -> Set.of();
+			case PAUSED -> Set.of(IN_PROGRESS, CLOSED);
+			case CLOSED -> Set.of();
+		};
 	}
 
 	protected abstract void validateParentIssue(Issue parentIssue);

--- a/backend/src/main/java/com/tissue/api/issue/exception/InvalidStatusTransitionException.java
+++ b/backend/src/main/java/com/tissue/api/issue/exception/InvalidStatusTransitionException.java
@@ -1,0 +1,19 @@
+package com.tissue.api.issue.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.tissue.api.common.exception.domain.IssueException;
+
+public class InvalidStatusTransitionException extends IssueException {
+
+	private static final String MESSAGE = "This is a invalid status transition.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public InvalidStatusTransitionException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public InvalidStatusTransitionException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/issue/exception/UnauthorizedIssueModifyException.java
+++ b/backend/src/main/java/com/tissue/api/issue/exception/UnauthorizedIssueModifyException.java
@@ -1,0 +1,19 @@
+package com.tissue.api.issue.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.tissue.api.common.exception.domain.IssueException;
+
+public class UnauthorizedIssueModifyException extends IssueException {
+
+	private static final String MESSAGE = "You do not have authorization to modify this Issue.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.UNAUTHORIZED;
+
+	public UnauthorizedIssueModifyException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public UnauthorizedIssueModifyException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/issue/presentation/controller/IssueController.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/controller/IssueController.java
@@ -12,10 +12,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.tissue.api.common.dto.ApiResponse;
 import com.tissue.api.issue.presentation.dto.request.AssignParentIssueRequest;
+import com.tissue.api.issue.presentation.dto.request.UpdateIssueStatusRequest;
 import com.tissue.api.issue.presentation.dto.request.create.CreateIssueRequest;
 import com.tissue.api.issue.presentation.dto.request.update.UpdateIssueRequest;
 import com.tissue.api.issue.presentation.dto.response.AssignParentIssueResponse;
 import com.tissue.api.issue.presentation.dto.response.RemoveParentIssueResponse;
+import com.tissue.api.issue.presentation.dto.response.UpdateIssueStatusResponse;
 import com.tissue.api.issue.presentation.dto.response.create.CreateIssueResponse;
 import com.tissue.api.issue.presentation.dto.response.delete.DeleteIssueResponse;
 import com.tissue.api.issue.presentation.dto.response.update.UpdateIssueResponse;
@@ -23,6 +25,7 @@ import com.tissue.api.issue.service.command.IssueCommandService;
 import com.tissue.api.security.authentication.interceptor.LoginRequired;
 import com.tissue.api.security.authorization.interceptor.RoleRequired;
 import com.tissue.api.workspacemember.domain.WorkspaceRole;
+import com.tissue.api.workspacemember.resolver.CurrentWorkspaceMember;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -86,28 +89,40 @@ public class IssueController {
 	 *  - Issue 상태 변경 -> review 제출이 필요 없는 경우에만 가능(설정으로 규칙 설정 가능하도록)
 	 *  -> 모든 review가 APPROVED인 경우 상태를 DONE으로 변경 가능
 	 */
+	@LoginRequired
+	@RoleRequired(roles = WorkspaceRole.MEMBER)
+	@PatchMapping("/{issueKey}/status")
+	public ApiResponse<UpdateIssueStatusResponse> updateIssueStatus(
+		@PathVariable String code,
+		@PathVariable String issueKey,
+		@CurrentWorkspaceMember Long currentWorkspaceMemberId,
+		@RequestBody @Valid UpdateIssueStatusRequest request
+	) {
+		UpdateIssueStatusResponse response = issueCommandService.updateIssueStatus(
+			code,
+			issueKey,
+			currentWorkspaceMemberId,
+			request
+		);
 
-	// @LoginRequired
-	// @RoleRequired(roles = WorkspaceRole.COLLABORATOR)
-	// @PatchMapping("/{issueKey}/status")
-	// public ApiResponse<UpdateIssueStatusResponse> updateIssueStatus(
-	// 	@PathVariable String code,
-	// 	@PathVariable String issueKey,
-	// 	@RequestBody @Valid UpdateIssueStatusRequest request
-	// ) {
-	// 	UpdateIssueStatusResponse response = issueCommandService.updateIssueStatus(code, issueKey, request);
-	//
-	// 	return ApiResponse.ok("Issue status updated.", response);
-	// }
+		return ApiResponse.ok("Issue status updated.", response);
+	}
+
 	@LoginRequired
 	@RoleRequired(roles = WorkspaceRole.MEMBER)
 	@PatchMapping("/{issueKey}")
 	public ApiResponse<UpdateIssueResponse> updateIssueDetails(
 		@PathVariable String code,
 		@PathVariable String issueKey,
+		@CurrentWorkspaceMember Long currentWorkspaceMemberId,
 		@RequestBody @Valid UpdateIssueRequest request
 	) {
-		UpdateIssueResponse response = issueCommandService.updateIssue(code, issueKey, request);
+		UpdateIssueResponse response = issueCommandService.updateIssue(
+			code,
+			issueKey,
+			currentWorkspaceMemberId,
+			request
+		);
 
 		return ApiResponse.ok("Issue details updated.", response);
 	}
@@ -118,9 +133,15 @@ public class IssueController {
 	public ApiResponse<AssignParentIssueResponse> assignParentIssue(
 		@PathVariable String code,
 		@PathVariable String issueKey,
+		@CurrentWorkspaceMember Long currentWorkspaceMemberId,
 		@RequestBody @Valid AssignParentIssueRequest request
 	) {
-		AssignParentIssueResponse response = issueCommandService.assignParentIssue(code, issueKey, request);
+		AssignParentIssueResponse response = issueCommandService.assignParentIssue(
+			code,
+			issueKey,
+			currentWorkspaceMemberId,
+			request
+		);
 
 		return ApiResponse.ok("Parent issue assigned.", response);
 	}
@@ -130,9 +151,14 @@ public class IssueController {
 	@DeleteMapping("/{issueKey}/parent")
 	public ApiResponse<RemoveParentIssueResponse> removeParentIssue(
 		@PathVariable String code,
-		@PathVariable String issueKey
+		@PathVariable String issueKey,
+		@CurrentWorkspaceMember Long currentWorkspaceMemberId
 	) {
-		RemoveParentIssueResponse response = issueCommandService.removeParentIssue(code, issueKey);
+		RemoveParentIssueResponse response = issueCommandService.removeParentIssue(
+			code,
+			issueKey,
+			currentWorkspaceMemberId
+		);
 
 		return ApiResponse.ok("Parent issue relationship removed.", response);
 	}
@@ -142,9 +168,14 @@ public class IssueController {
 	@DeleteMapping("/{issueKey}")
 	public ApiResponse<DeleteIssueResponse> deleteIssue(
 		@PathVariable String code,
-		@PathVariable String issueKey
+		@PathVariable String issueKey,
+		@CurrentWorkspaceMember Long currentWorkspaceMemberId
 	) {
-		DeleteIssueResponse response = issueCommandService.deleteIssue(code, issueKey);
+		DeleteIssueResponse response = issueCommandService.deleteIssue(
+			code,
+			issueKey,
+			currentWorkspaceMemberId
+		);
 
 		return ApiResponse.ok("Parent issue deleted.", response);
 	}

--- a/backend/src/main/java/com/tissue/api/issue/service/command/IssueCommandService.java
+++ b/backend/src/main/java/com/tissue/api/issue/service/command/IssueCommandService.java
@@ -70,9 +70,15 @@ public class IssueCommandService {
 	public UpdateIssueResponse updateIssue(
 		String code,
 		String issueKey,
+		Long requesterWorkspaceMemberId,
 		UpdateIssueRequest request
 	) {
 		Issue issue = findIssue(code, issueKey);
+		WorkspaceMember requester = findWorkspaceMember(requesterWorkspaceMemberId);
+
+		if (requester.roleIsLowerThan(WorkspaceRole.MANAGER)) {
+			issue.validateIsAssigneeOrAuthor(requesterWorkspaceMemberId);
+		}
 
 		// Todo: Issue에서 검증 메서드 정의해서 사용하도록 리팩토링
 		issueValidator.validateIssueTypeMatch(issue, request);
@@ -105,10 +111,16 @@ public class IssueCommandService {
 	public AssignParentIssueResponse assignParentIssue(
 		String code,
 		String issueKey,
+		Long requesterWorkspaceMemberId,
 		AssignParentIssueRequest request
 	) {
 		Issue issue = findIssue(code, issueKey);
 		Issue parentIssue = findIssue(code, request.parentIssueKey());
+		WorkspaceMember requester = findWorkspaceMember(requesterWorkspaceMemberId);
+
+		if (requester.roleIsLowerThan(WorkspaceRole.MANAGER)) {
+			issue.validateIsAssigneeOrAuthor(requesterWorkspaceMemberId);
+		}
 
 		issue.setParentIssue(parentIssue);
 
@@ -118,10 +130,18 @@ public class IssueCommandService {
 	@Transactional
 	public RemoveParentIssueResponse removeParentIssue(
 		String code,
-		String issueKey
+		String issueKey,
+		Long requesterWorkspaceMemberId
 	) {
 		Issue issue = findIssue(code, issueKey);
 
+		WorkspaceMember requester = findWorkspaceMember(requesterWorkspaceMemberId);
+
+		if (requester.roleIsLowerThan(WorkspaceRole.MANAGER)) {
+			issue.validateIsAssigneeOrAuthor(requesterWorkspaceMemberId);
+		}
+
+		// Todo: Issue에 validateCanRemoveParentIssue 형태로 리팩토링
 		if (cannotRemoveParent(issue)) {
 			throw new CannotRemoveParentException();
 		}
@@ -133,9 +153,15 @@ public class IssueCommandService {
 	@Transactional
 	public DeleteIssueResponse deleteIssue(
 		String code,
-		String issueKey
+		String issueKey,
+		Long requesterWorkspaceMemberId
 	) {
 		Issue issue = findIssue(code, issueKey);
+		WorkspaceMember requester = findWorkspaceMember(requesterWorkspaceMemberId);
+
+		if (requester.roleIsLowerThan(WorkspaceRole.MANAGER)) {
+			issue.validateIsAssigneeOrAuthor(requesterWorkspaceMemberId);
+		}
 
 		// Todo: Issue에서 검증 메서드 정의해서 사용하도록 리팩토링
 		issueValidator.validateNotParentOfSubTask(issue);

--- a/backend/src/main/java/com/tissue/api/issue/service/command/IssueCommandService.java
+++ b/backend/src/main/java/com/tissue/api/issue/service/command/IssueCommandService.java
@@ -50,8 +50,7 @@ public class IssueCommandService {
 		String code,
 		CreateIssueRequest request
 	) {
-		Workspace workspace = workspaceRepository.findByCode(code)
-			.orElseThrow(WorkspaceNotFoundException::new);
+		Workspace workspace = findWorkspace(code);
 
 		Issue issue = request.to(
 			workspace,
@@ -70,6 +69,7 @@ public class IssueCommandService {
 	) {
 		Issue issue = findIssue(code, issueKey);
 
+		// Todo: Issue에서 검증 메서드 정의해서 사용하도록 리팩토링
 		issueValidator.validateIssueTypeMatch(issue, request);
 
 		request.update(issue);
@@ -126,6 +126,7 @@ public class IssueCommandService {
 	) {
 		Issue issue = findIssue(code, issueKey);
 
+		// Todo: Issue에서 검증 메서드 정의해서 사용하도록 리팩토링
 		issueValidator.validateNotParentOfSubTask(issue);
 
 		Long issueId = issue.getId();
@@ -133,6 +134,11 @@ public class IssueCommandService {
 		issueRepository.delete(issue);
 
 		return DeleteIssueResponse.from(issueId, issueKey, LocalDateTime.now());
+	}
+
+	private Workspace findWorkspace(String code) {
+		return workspaceRepository.findByCode(code)
+			.orElseThrow(WorkspaceNotFoundException::new);
 	}
 
 	/**

--- a/backend/src/main/java/com/tissue/api/issue/validator/IssueValidator.java
+++ b/backend/src/main/java/com/tissue/api/issue/validator/IssueValidator.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Component;
 
 import com.tissue.api.issue.domain.Issue;
 import com.tissue.api.issue.domain.enums.IssueType;
-import com.tissue.api.issue.domain.repository.IssueRepository;
 import com.tissue.api.issue.exception.CannotDeleteParentOfSubTaskException;
 import com.tissue.api.issue.exception.IssueTypeMismatchException;
 import com.tissue.api.issue.presentation.dto.request.update.UpdateIssueRequest;
@@ -14,8 +13,6 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class IssueValidator {
-
-	private final IssueRepository issueRepository;
 
 	public void validateIssueTypeMatch(Issue issue, UpdateIssueRequest request) {
 		if (issue.getType() != request.getType()) {

--- a/backend/src/main/java/com/tissue/api/review/domain/Review.java
+++ b/backend/src/main/java/com/tissue/api/review/domain/Review.java
@@ -64,11 +64,11 @@ public class Review extends WorkspaceContextBaseEntity {
 	}
 
 	public void updateStatus(ReviewStatus status) {
-		validateIsPendingStatus();
+		validateCanUpdateStatus();
 		this.status = status;
 	}
 
-	private void validateIsPendingStatus() {
+	private void validateCanUpdateStatus() {
 		if (this.status != ReviewStatus.PENDING) {
 			throw new CannotChangeReviewStatusException();
 		}

--- a/backend/src/main/java/com/tissue/api/review/exception/PendingReviewExistsException.java
+++ b/backend/src/main/java/com/tissue/api/review/exception/PendingReviewExistsException.java
@@ -1,0 +1,19 @@
+package com.tissue.api.review.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.tissue.api.common.exception.domain.IssueException;
+
+public class PendingReviewExistsException extends IssueException {
+
+	private static final String MESSAGE = "All reviews must be approved.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public PendingReviewExistsException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public PendingReviewExistsException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/review/exception/ReviewRequiredException.java
+++ b/backend/src/main/java/com/tissue/api/review/exception/ReviewRequiredException.java
@@ -1,0 +1,19 @@
+package com.tissue.api.review.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.tissue.api.common.exception.domain.IssueException;
+
+public class ReviewRequiredException extends IssueException {
+
+	private static final String MESSAGE = "Review is required.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.NOT_FOUND;
+
+	public ReviewRequiredException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public ReviewRequiredException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/review/service/command/ReviewCommandService.java
+++ b/backend/src/main/java/com/tissue/api/review/service/command/ReviewCommandService.java
@@ -112,6 +112,7 @@ public class ReviewCommandService {
 			.orElseThrow(IssueNotFoundException::new);
 	}
 
+	// Todo: 굳이 workspaceCode 까지 활용 해야 함? 이미 인터셉터에서 해당 워크스페이스에 속하는지 검사 중.
 	private WorkspaceMember findWorkspaceMember(Long id, String workspaceCode) {
 		return workspaceMemberRepository.findByIdAndWorkspaceCode(id, workspaceCode)
 			.orElseThrow(WorkspaceMemberNotFoundException::new);
@@ -139,6 +140,7 @@ public class ReviewCommandService {
 		 *  - 모든 리뷰어가 승인한 경우, 작업자에게 알림
 		 *  - 알림 서비스 구현 필요
 		 *  - 자동으로 이슈 상태 DONE으로 변경 X
+		 *  - 알림은 이벤트 리스너로 구현하는 것이 좋을 듯
 		 */
 		boolean allApproved = issue.getReviewers().stream()
 			.allMatch(reviewer ->

--- a/backend/src/main/java/com/tissue/api/review/service/command/ReviewCommandService.java
+++ b/backend/src/main/java/com/tissue/api/review/service/command/ReviewCommandService.java
@@ -65,7 +65,7 @@ public class ReviewCommandService {
 
 		Review savedReview = reviewRepository.save(review);
 
-		updateIssueStatusBasedOnReview(issue, request.status());
+		updateIssueStatusBasedOnReviewStatus(issue, request.status());
 
 		return CreateReviewResponse.from(savedReview);
 	}
@@ -102,7 +102,7 @@ public class ReviewCommandService {
 		}
 
 		review.updateStatus(request.status());
-		updateIssueStatusBasedOnReview(issue, request.status());
+		updateIssueStatusBasedOnReviewStatus(issue, request.status());
 
 		return UpdateReviewStatusResponse.from(review);
 	}
@@ -127,7 +127,7 @@ public class ReviewCommandService {
 			.orElseThrow(ReviewNotFoundException::new);
 	}
 
-	private void updateIssueStatusBasedOnReview(Issue issue, ReviewStatus reviewStatus) {
+	private void updateIssueStatusBasedOnReviewStatus(Issue issue, ReviewStatus reviewStatus) {
 		// CHANGES_REQUESTED의 경우 자동 상태 변경
 		if (reviewStatus == ReviewStatus.CHANGES_REQUESTED) {
 			issue.updateStatus(IssueStatus.CHANGES_REQUESTED);

--- a/backend/src/test/java/com/tissue/api/issue/presentation/controller/IssueControllerTest.java
+++ b/backend/src/test/java/com/tissue/api/issue/presentation/controller/IssueControllerTest.java
@@ -127,7 +127,7 @@ class IssueControllerTest extends ControllerTestHelper {
 			.acceptanceCriteria("Updated Acceptance Criteria")
 			.build();
 
-		when(issueCommandService.updateIssue(workspaceCode, issueKey, request))
+		when(issueCommandService.updateIssue(eq(workspaceCode), eq(issueKey), anyLong(), eq(request)))
 			.thenReturn(response);
 
 		// when & then
@@ -149,7 +149,7 @@ class IssueControllerTest extends ControllerTestHelper {
 			.andExpect(jsonPath("$.data.acceptanceCriteria").value("Updated Acceptance Criteria"))
 			.andDo(print());
 
-		verify(issueCommandService).updateIssue(workspaceCode, issueKey, request);
+		verify(issueCommandService).updateIssue(eq(workspaceCode), eq(issueKey), anyLong(), eq(request));
 	}
 
 	@Test
@@ -167,7 +167,7 @@ class IssueControllerTest extends ControllerTestHelper {
 			.acceptanceCriteria("Updated Acceptance Criteria")
 			.build();
 
-		when(issueCommandService.updateIssue(any(), any(), any()))
+		when(issueCommandService.updateIssue(any(), any(), any(), any()))
 			.thenThrow(new IssueTypeMismatchException());
 
 		// when & then
@@ -182,7 +182,7 @@ class IssueControllerTest extends ControllerTestHelper {
 	@DisplayName("PATCH /workspaces/{code}/issues/{issueKey}/parent - 이슈의 부모 이슈 등록에 성공하면 OK를 응답한다")
 	void assignParentIssue() throws Exception {
 		// given
-		String code = "WORKSPACE";
+		String workspaceCode = "WORKSPACE";
 		String issueKey = "ISSUE-1";
 		String parentIssueKey = "ISSUE-999";
 		AssignParentIssueRequest request = new AssignParentIssueRequest(parentIssueKey);
@@ -195,11 +195,11 @@ class IssueControllerTest extends ControllerTestHelper {
 			.assignedAt(LocalDateTime.now())
 			.build();
 
-		when(issueCommandService.assignParentIssue(code, issueKey, request))
+		when(issueCommandService.assignParentIssue(eq(workspaceCode), eq(issueKey), anyLong(), eq(request)))
 			.thenReturn(response);
 
 		// when & then
-		mockMvc.perform(patch("/api/v1/workspaces/{code}/issues/{issueKey}/parent", code, issueKey)
+		mockMvc.perform(patch("/api/v1/workspaces/{workspaceCode}/issues/{issueKey}/parent", workspaceCode, issueKey)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
@@ -215,7 +215,7 @@ class IssueControllerTest extends ControllerTestHelper {
 	@DisplayName("DELETE /workspaces/{code}/issues/{issueKey}/parent - 이슈의 부모 이슈 해제에 성공하면 OK를 응답한다")
 	void removeParentIssue_fromStory() throws Exception {
 		// given
-		String code = "WORKSPACE";
+		String workspaceCode = "WORKSPACE";
 		String issueKey = "ISSUE-1";
 
 		RemoveParentIssueResponse response = RemoveParentIssueResponse.builder()
@@ -224,11 +224,11 @@ class IssueControllerTest extends ControllerTestHelper {
 			.removedAt(LocalDateTime.now())
 			.build();
 
-		when(issueCommandService.removeParentIssue(code, issueKey))
+		when(issueCommandService.removeParentIssue(eq(workspaceCode), eq(issueKey), anyLong()))
 			.thenReturn(response);
 
 		// when & then
-		mockMvc.perform(delete("/api/v1/workspaces/{code}/issues/{issueKey}/parent", code, issueKey)
+		mockMvc.perform(delete("/api/v1/workspaces/{workspaceCode}/issues/{issueKey}/parent", workspaceCode, issueKey)
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.message").value("Parent issue relationship removed."))

--- a/backend/src/test/java/com/tissue/api/review/service/ReviewCommandServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/review/service/ReviewCommandServiceIT.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.tissue.api.issue.domain.Issue;
 import com.tissue.api.issue.domain.enums.IssueStatus;
+import com.tissue.api.issue.presentation.dto.request.UpdateIssueStatusRequest;
 import com.tissue.api.issue.presentation.dto.response.create.CreateStoryResponse;
 import com.tissue.api.member.presentation.dto.response.SignupMemberResponse;
 import com.tissue.api.review.exception.DuplicateReviewInRoundException;
@@ -110,6 +111,13 @@ class ReviewCommandServiceIT extends ServiceIntegrationTestHelper {
 			requesterWorkspaceMemberId
 		);
 
+		issueCommandService.updateIssueStatus(
+			workspaceCode,
+			issueKey,
+			requesterWorkspaceMemberId,
+			new UpdateIssueStatusRequest(IssueStatus.IN_PROGRESS)
+		);
+
 		reviewerCommandService.requestReview(
 			workspaceCode,
 			issueKey,
@@ -145,6 +153,13 @@ class ReviewCommandServiceIT extends ServiceIntegrationTestHelper {
 			issueKey,
 			reviewerWorkspaceMemberId,
 			requesterWorkspaceMemberId
+		);
+
+		issueCommandService.updateIssueStatus(
+			workspaceCode,
+			issueKey,
+			requesterWorkspaceMemberId,
+			new UpdateIssueStatusRequest(IssueStatus.IN_PROGRESS)
 		);
 
 		reviewerCommandService.requestReview(
@@ -190,6 +205,13 @@ class ReviewCommandServiceIT extends ServiceIntegrationTestHelper {
 			requesterWorkspaceMemberId
 		);
 
+		issueCommandService.updateIssueStatus(
+			workspaceCode,
+			issueKey,
+			requesterWorkspaceMemberId,
+			new UpdateIssueStatusRequest(IssueStatus.IN_PROGRESS)
+		);
+
 		reviewerCommandService.requestReview(
 			workspaceCode,
 			issueKey,
@@ -232,6 +254,13 @@ class ReviewCommandServiceIT extends ServiceIntegrationTestHelper {
 			issueKey,
 			reviewerWorkspaceMemberId,
 			requesterWorkspaceMemberId
+		);
+
+		issueCommandService.updateIssueStatus(
+			workspaceCode,
+			issueKey,
+			requesterWorkspaceMemberId,
+			new UpdateIssueStatusRequest(IssueStatus.IN_PROGRESS)
 		);
 
 		reviewerCommandService.requestReview(
@@ -290,6 +319,13 @@ class ReviewCommandServiceIT extends ServiceIntegrationTestHelper {
 			requesterWorkspaceMemberId
 		);
 
+		issueCommandService.updateIssueStatus(
+			workspaceCode,
+			issueKey,
+			requesterWorkspaceMemberId,
+			new UpdateIssueStatusRequest(IssueStatus.IN_PROGRESS)
+		);
+
 		reviewerCommandService.requestReview(
 			workspaceCode,
 			issueKey,
@@ -325,6 +361,13 @@ class ReviewCommandServiceIT extends ServiceIntegrationTestHelper {
 			issueKey,
 			reviewerWorkspaceMemberId,
 			requesterWorkspaceMemberId
+		);
+
+		issueCommandService.updateIssueStatus(
+			workspaceCode,
+			issueKey,
+			requesterWorkspaceMemberId,
+			new UpdateIssueStatusRequest(IssueStatus.IN_PROGRESS)
 		);
 
 		reviewerCommandService.requestReview(

--- a/backend/src/test/java/com/tissue/api/review/service/ReviewerCommandServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/review/service/ReviewerCommandServiceIT.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import com.tissue.api.assignee.exception.UnauthorizedAssigneeModificationException;
 import com.tissue.api.issue.domain.Issue;
 import com.tissue.api.issue.domain.enums.IssueStatus;
+import com.tissue.api.issue.presentation.dto.request.UpdateIssueStatusRequest;
 import com.tissue.api.issue.presentation.dto.response.create.CreateStoryResponse;
 import com.tissue.api.member.presentation.dto.response.SignupMemberResponse;
 import com.tissue.api.review.exception.DuplicateReviewerException;
@@ -197,6 +198,13 @@ class ReviewerCommandServiceIT extends ServiceIntegrationTestHelper {
 			issueKey,
 			reviewerWorkspaceMemberId,
 			requesterWorkspaceMemberId
+		);
+
+		issueCommandService.updateIssueStatus(
+			workspaceCode,
+			issueKey,
+			requesterWorkspaceMemberId,
+			new UpdateIssueStatusRequest(IssueStatus.IN_PROGRESS)
 		);
 
 		// when


### PR DESCRIPTION
## 🚀 설명
- `Issue`에 상태 업데이트에 대한 검증 메서드 추가
  - `validateStatusTransition`: 이슈의 상태 전이 검증 메서드
    - `validateBasicTransition`: 기본 상태 전이 검증
    - `validateTransitionToDone`: DONE으로 상태 변경하는 경우 검증
  - `validateIsAssigneeOrAuthor`: 이슈의 작성자 또는 작업자에 해당하는지 검증
- 이슈 생성을 제외한 나머지 이슈 관련 기능에도 `validateIsAssigneeOrAuthor` 검증 추가
  - 물론 `MANAGER` 권한 이상이면 해당 검증 안함
---
## ✅ 변경 사항
- [x] `validateStatusTransition` 추가
- [x] `validateIsAssigneeOrAuthor` 추가
- [x] 깨진 테스트 수정

---
## 🚩 관련 이슈, PR
- #190 

---
## 📖 참고