### PR TITLE
Feat/#176 `IssueRelation` 구현

### DIFF
--- a/backend/src/main/java/com/tissue/api/issue/domain/Issue.java
+++ b/backend/src/main/java/com/tissue/api/issue/domain/Issue.java
@@ -323,7 +323,10 @@ public abstract class Issue extends WorkspaceContextBaseEntity {
 	}
 
 	public void validateIsAssigneeOrAuthor(Long workspaceMemberId) {
-		if (isAssignee(workspaceMemberId) || isAuthor(workspaceMemberId)) {
+		if (isAssignee(workspaceMemberId)) {
+			return;
+		}
+		if (isAuthor(workspaceMemberId)) {
 			return;
 		}
 		throw new UnauthorizedIssueModifyException("Must be the author or a assignee of this issue.");

--- a/backend/src/main/java/com/tissue/api/issue/domain/IssueRelation.java
+++ b/backend/src/main/java/com/tissue/api/issue/domain/IssueRelation.java
@@ -1,0 +1,91 @@
+package com.tissue.api.issue.domain;
+
+import com.tissue.api.common.entity.WorkspaceContextBaseEntity;
+import com.tissue.api.issue.domain.enums.IssueRelationType;
+import com.tissue.api.issue.exception.DuplicateIssueRelationException;
+import com.tissue.api.issue.exception.SelfReferenceNotAllowedException;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IssueRelation extends WorkspaceContextBaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "SOURCE_ISSUE_ID", nullable = false)
+	private Issue sourceIssue;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "TARGET_ISSUE_ID", nullable = false)
+	private Issue targetIssue;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private IssueRelationType relationType;
+
+	private IssueRelation(Issue sourceIssue, Issue targetIssue, IssueRelationType relationType) {
+		this.sourceIssue = sourceIssue;
+		this.targetIssue = targetIssue;
+		this.relationType = relationType != null ? relationType : IssueRelationType.RELEVANT;
+	}
+
+	// 정적 팩토리 메서드
+	public static void createRelation(Issue sourceIssue, Issue targetIssue, IssueRelationType type) {
+		validateRelation(sourceIssue, targetIssue);
+
+		// 정방향 관계 생성
+		IssueRelation relation = new IssueRelation(sourceIssue, targetIssue, type);
+		sourceIssue.getOutgoingRelations()
+			.add(relation);
+
+		// 역방향 관계 생성
+		IssueRelation oppositeRelation = new IssueRelation(targetIssue, sourceIssue, type.getOpposite());
+		targetIssue.getOutgoingRelations()
+			.add(oppositeRelation);
+	}
+
+	public static void removeRelation(Issue sourceIssue, Issue targetIssue) {
+		// 정방향 관계 제거
+		sourceIssue.getOutgoingRelations()
+			.removeIf(relation -> relation.getTargetIssue().equals(targetIssue));
+
+		// 역방향 관계 제거
+		targetIssue.getOutgoingRelations()
+			.removeIf(relation -> relation.getTargetIssue().equals(sourceIssue));
+	}
+
+	private static void validateRelation(Issue sourceIssue, Issue targetIssue) {
+		if (sourceIssue.equals(targetIssue)) {
+			throw new SelfReferenceNotAllowedException();
+		}
+
+		boolean hasRelation = sourceIssue.getOutgoingRelations().stream()
+			.anyMatch(relation -> relation.getTargetIssue().equals(targetIssue));
+
+		if (hasRelation) {
+			throw new DuplicateIssueRelationException();
+		}
+
+	}
+	
+	public String getWorkspaceCode() {
+		return sourceIssue.getWorkspaceCode();
+	}
+}

--- a/backend/src/main/java/com/tissue/api/issue/domain/IssueRelation.java
+++ b/backend/src/main/java/com/tissue/api/issue/domain/IssueRelation.java
@@ -57,10 +57,12 @@ public class IssueRelation extends WorkspaceContextBaseEntity {
 		// 정방향 관계 생성
 		IssueRelation relation = new IssueRelation(sourceIssue, targetIssue, type);
 		sourceIssue.getOutgoingRelations().add(relation);
+		targetIssue.getIncomingRelations().add(relation);
 
 		// 역방향 관계 생성
 		IssueRelation oppositeRelation = new IssueRelation(targetIssue, sourceIssue, type.getOpposite());
 		targetIssue.getOutgoingRelations().add(oppositeRelation);
+		sourceIssue.getIncomingRelations().add(oppositeRelation);
 	}
 
 	public static void removeRelation(Issue sourceIssue, Issue targetIssue) {
@@ -101,8 +103,7 @@ public class IssueRelation extends WorkspaceContextBaseEntity {
 		// 직접적인 순환 참조 검증 (A->B->A)
 		boolean isDirectCircular = targetIssue.getOutgoingRelations().stream()
 			.anyMatch(relation ->
-				relation.getTargetIssue().equals(sourceIssue) &&
-					relation.getRelationType() == IssueRelationType.BLOCKS
+				relation.getTargetIssue().equals(sourceIssue) && relation.getRelationType() == IssueRelationType.BLOCKS
 			);
 
 		if (isDirectCircular) {

--- a/backend/src/main/java/com/tissue/api/issue/domain/enums/IssueRelationType.java
+++ b/backend/src/main/java/com/tissue/api/issue/domain/enums/IssueRelationType.java
@@ -1,0 +1,20 @@
+package com.tissue.api.issue.domain.enums;
+
+public enum IssueRelationType {
+
+	RELEVANT,
+	BLOCKS,
+	BLOCKED_BY,
+	CAUSES,
+	CAUSED_BY;
+
+	public IssueRelationType getOpposite() {
+		return switch (this) {
+			case BLOCKS -> BLOCKED_BY;
+			case BLOCKED_BY -> BLOCKS;
+			case CAUSES -> CAUSED_BY;
+			case CAUSED_BY -> CAUSES;
+			case RELEVANT -> RELEVANT;
+		};
+	}
+}

--- a/backend/src/main/java/com/tissue/api/issue/exception/BlockingIssuesNotCompletedException.java
+++ b/backend/src/main/java/com/tissue/api/issue/exception/BlockingIssuesNotCompletedException.java
@@ -1,0 +1,19 @@
+package com.tissue.api.issue.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.tissue.api.common.exception.domain.IssueException;
+
+public class BlockingIssuesNotCompletedException extends IssueException {
+
+	private static final String MESSAGE = "Blocking issues need to be completed.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public BlockingIssuesNotCompletedException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public BlockingIssuesNotCompletedException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/issue/exception/CircularDependencyException.java
+++ b/backend/src/main/java/com/tissue/api/issue/exception/CircularDependencyException.java
@@ -1,0 +1,19 @@
+package com.tissue.api.issue.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.tissue.api.common.exception.domain.IssueException;
+
+public class CircularDependencyException extends IssueException {
+
+	private static final String MESSAGE = "Circular dependency was detected.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public CircularDependencyException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public CircularDependencyException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/issue/exception/DuplicateIssueRelationException.java
+++ b/backend/src/main/java/com/tissue/api/issue/exception/DuplicateIssueRelationException.java
@@ -1,0 +1,19 @@
+package com.tissue.api.issue.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.tissue.api.common.exception.domain.IssueException;
+
+public class DuplicateIssueRelationException extends IssueException {
+
+	private static final String MESSAGE = "Same issue relation already exists.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public DuplicateIssueRelationException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public DuplicateIssueRelationException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/issue/exception/SelfReferenceNotAllowedException.java
+++ b/backend/src/main/java/com/tissue/api/issue/exception/SelfReferenceNotAllowedException.java
@@ -1,0 +1,19 @@
+package com.tissue.api.issue.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.tissue.api.common.exception.domain.IssueException;
+
+public class SelfReferenceNotAllowedException extends IssueException {
+
+	private static final String MESSAGE = "Self reference is not allowed.";
+	private static final HttpStatus HTTP_STATUS = HttpStatus.BAD_REQUEST;
+
+	public SelfReferenceNotAllowedException() {
+		super(MESSAGE, HTTP_STATUS);
+	}
+
+	public SelfReferenceNotAllowedException(String message) {
+		super(message, HTTP_STATUS);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/issue/presentation/controller/IssueRelationController.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/controller/IssueRelationController.java
@@ -1,0 +1,69 @@
+package com.tissue.api.issue.presentation.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.tissue.api.common.dto.ApiResponse;
+import com.tissue.api.issue.presentation.dto.request.CreateIssueRelationRequest;
+import com.tissue.api.issue.presentation.dto.response.CreateIssueRelationResponse;
+import com.tissue.api.issue.presentation.dto.response.RemoveIssueRelationResponse;
+import com.tissue.api.issue.service.command.IssueRelationCommandService;
+import com.tissue.api.security.authentication.interceptor.LoginRequired;
+import com.tissue.api.security.authorization.interceptor.RoleRequired;
+import com.tissue.api.workspacemember.domain.WorkspaceRole;
+import com.tissue.api.workspacemember.resolver.CurrentWorkspaceMember;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/workspaces/{code}/issues/{issueKey}/relations")
+public class IssueRelationController {
+
+	private final IssueRelationCommandService issueRelationCommandService;
+
+	@LoginRequired
+	@RoleRequired(roles = WorkspaceRole.MEMBER)
+	@PostMapping("/{targetIssueKey}")
+	public ApiResponse<CreateIssueRelationResponse> createRelation(
+		@PathVariable String code,
+		@PathVariable String issueKey,
+		@PathVariable String targetIssueKey,
+		@CurrentWorkspaceMember Long currentWorkspaceMemberId,
+		@RequestBody @Valid CreateIssueRelationRequest request
+	) {
+		CreateIssueRelationResponse response = issueRelationCommandService.createRelation(
+			code,
+			issueKey,
+			targetIssueKey,
+			currentWorkspaceMemberId,
+			request
+		);
+
+		return ApiResponse.ok("Issue relation created.", response);
+	}
+
+	@LoginRequired
+	@RoleRequired(roles = WorkspaceRole.MEMBER)
+	@DeleteMapping("/{targetIssueKey}")
+	public ApiResponse<RemoveIssueRelationResponse> removeRelation(
+		@PathVariable String code,
+		@PathVariable String issueKey,
+		@PathVariable String targetIssueKey,
+		@CurrentWorkspaceMember Long currentWorkspaceMemberId
+	) {
+		RemoveIssueRelationResponse response = issueRelationCommandService.removeRelation(
+			code,
+			issueKey,
+			targetIssueKey,
+			currentWorkspaceMemberId
+		);
+
+		return ApiResponse.ok("Issue relation removed.", response);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/request/CreateIssueRelationRequest.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/request/CreateIssueRelationRequest.java
@@ -1,0 +1,11 @@
+package com.tissue.api.issue.presentation.dto.request;
+
+import com.tissue.api.issue.domain.enums.IssueRelationType;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CreateIssueRelationRequest(
+	@NotNull(message = "Relation type is required.")
+	IssueRelationType relationType
+) {
+}

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/CreateIssueRelationResponse.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/CreateIssueRelationResponse.java
@@ -1,0 +1,31 @@
+package com.tissue.api.issue.presentation.dto.response;
+
+import com.tissue.api.issue.domain.Issue;
+import com.tissue.api.issue.domain.enums.IssueRelationType;
+
+import lombok.Builder;
+
+@Builder
+public record CreateIssueRelationResponse(
+	String sourceIssueKey,
+	String sourceIssueTitle,
+	String targetIssueKey,
+	String targetIssueTitle,
+	IssueRelationType relationType,
+	IssueRelationType oppositeRelationType
+) {
+	public static CreateIssueRelationResponse from(
+		Issue sourceIssue,
+		Issue targetIssue,
+		IssueRelationType relationType
+	) {
+		return CreateIssueRelationResponse.builder()
+			.sourceIssueKey(sourceIssue.getIssueKey())
+			.sourceIssueTitle(sourceIssue.getTitle())
+			.targetIssueKey(targetIssue.getIssueKey())
+			.targetIssueTitle(targetIssue.getTitle())
+			.relationType(relationType)
+			.oppositeRelationType(relationType.getOpposite())
+			.build();
+	}
+}

--- a/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/RemoveIssueRelationResponse.java
+++ b/backend/src/main/java/com/tissue/api/issue/presentation/dto/response/RemoveIssueRelationResponse.java
@@ -1,0 +1,22 @@
+package com.tissue.api.issue.presentation.dto.response;
+
+import com.tissue.api.issue.domain.Issue;
+
+import lombok.Builder;
+
+@Builder
+public record RemoveIssueRelationResponse(
+	String sourceIssueKey,
+	String sourceIssueTitle,
+	String targetIssueKey,
+	String targetIssueTitle
+) {
+	public static RemoveIssueRelationResponse from(Issue sourceIssue, Issue targetIssue) {
+		return RemoveIssueRelationResponse.builder()
+			.sourceIssueKey(sourceIssue.getIssueKey())
+			.sourceIssueTitle(sourceIssue.getTitle())
+			.targetIssueKey(targetIssue.getIssueKey())
+			.targetIssueTitle(targetIssue.getTitle())
+			.build();
+	}
+}

--- a/backend/src/main/java/com/tissue/api/issue/service/command/IssueRelationCommandService.java
+++ b/backend/src/main/java/com/tissue/api/issue/service/command/IssueRelationCommandService.java
@@ -1,0 +1,77 @@
+package com.tissue.api.issue.service.command;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.tissue.api.issue.domain.Issue;
+import com.tissue.api.issue.domain.IssueRelation;
+import com.tissue.api.issue.domain.repository.IssueRepository;
+import com.tissue.api.issue.exception.IssueNotFoundException;
+import com.tissue.api.issue.presentation.dto.request.CreateIssueRelationRequest;
+import com.tissue.api.issue.presentation.dto.response.CreateIssueRelationResponse;
+import com.tissue.api.issue.presentation.dto.response.RemoveIssueRelationResponse;
+import com.tissue.api.workspacemember.domain.WorkspaceMember;
+import com.tissue.api.workspacemember.domain.WorkspaceRole;
+import com.tissue.api.workspacemember.domain.repository.WorkspaceMemberRepository;
+import com.tissue.api.workspacemember.exception.WorkspaceMemberNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class IssueRelationCommandService {
+
+	private final IssueRepository issueRepository;
+	private final WorkspaceMemberRepository workspaceMemberRepository;
+
+	@Transactional
+	public CreateIssueRelationResponse createRelation(
+		String workspaceCode,
+		String sourceIssueKey,
+		String targetIssueKey,
+		Long requesterWorkspaceMemberId,
+		CreateIssueRelationRequest request
+	) {
+		Issue sourceIssue = findIssue(workspaceCode, sourceIssueKey);
+		Issue targetIssue = findIssue(workspaceCode, targetIssueKey);
+		WorkspaceMember requester = findWorkspaceMember(requesterWorkspaceMemberId);
+
+		if (requester.roleIsLowerThan(WorkspaceRole.MANAGER)) {
+			sourceIssue.validateIsAssigneeOrAuthor(requesterWorkspaceMemberId);
+		}
+
+		IssueRelation.createRelation(sourceIssue, targetIssue, request.relationType());
+
+		return CreateIssueRelationResponse.from(sourceIssue, targetIssue, request.relationType());
+	}
+
+	@Transactional
+	public RemoveIssueRelationResponse removeRelation(
+		String workspaceCode,
+		String sourceIssueKey,
+		String targetIssueKey,
+		Long requesterWorkspaceMemberId
+	) {
+		Issue sourceIssue = findIssue(workspaceCode, sourceIssueKey);
+		Issue targetIssue = findIssue(workspaceCode, targetIssueKey);
+		WorkspaceMember requester = findWorkspaceMember(requesterWorkspaceMemberId);
+
+		if (requester.roleIsLowerThan(WorkspaceRole.MANAGER)) {
+			sourceIssue.validateIsAssigneeOrAuthor(requesterWorkspaceMemberId);
+		}
+
+		IssueRelation.removeRelation(sourceIssue, targetIssue);
+
+		return RemoveIssueRelationResponse.from(sourceIssue, targetIssue);
+	}
+
+	private Issue findIssue(String code, String issueKey) {
+		return issueRepository.findByIssueKeyAndWorkspaceCode(issueKey, code)
+			.orElseThrow(IssueNotFoundException::new);
+	}
+
+	private WorkspaceMember findWorkspaceMember(Long id) {
+		return workspaceMemberRepository.findById(id)
+			.orElseThrow(WorkspaceMemberNotFoundException::new);
+	}
+}

--- a/backend/src/test/java/com/tissue/api/issue/service/command/IssueCommandServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/issue/service/command/IssueCommandServiceIT.java
@@ -1,4 +1,4 @@
-package com.tissue.api.issue.service;
+package com.tissue.api.issue.service.command;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/backend/src/test/java/com/tissue/api/issue/service/command/IssueRelationCommandServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/issue/service/command/IssueRelationCommandServiceIT.java
@@ -1,0 +1,287 @@
+package com.tissue.api.issue.service.command;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.tissue.api.issue.domain.Issue;
+import com.tissue.api.issue.domain.enums.IssueRelationType;
+import com.tissue.api.issue.exception.CircularDependencyException;
+import com.tissue.api.issue.exception.DuplicateIssueRelationException;
+import com.tissue.api.issue.exception.SelfReferenceNotAllowedException;
+import com.tissue.api.issue.presentation.dto.request.CreateIssueRelationRequest;
+import com.tissue.api.issue.presentation.dto.request.create.CreateStoryRequest;
+import com.tissue.api.issue.presentation.dto.response.CreateIssueRelationResponse;
+import com.tissue.api.issue.presentation.dto.response.RemoveIssueRelationResponse;
+import com.tissue.api.issue.presentation.dto.response.create.CreateStoryResponse;
+import com.tissue.api.member.presentation.dto.response.SignupMemberResponse;
+import com.tissue.api.workspace.presentation.dto.response.CreateWorkspaceResponse;
+import com.tissue.helper.ServiceIntegrationTestHelper;
+
+class IssueRelationCommandServiceIT extends ServiceIntegrationTestHelper {
+
+	String workspaceCode;
+	String sourceIssueKey;
+	String targetIssueKey;
+
+	@BeforeEach
+	void setUp() {
+		// 테스트 멤버 testUser, testUser2, testUser3 생성
+		SignupMemberResponse testUser = memberFixture.createMember("testuser", "test@test.com");
+		SignupMemberResponse testUser2 = memberFixture.createMember("testuser2", "test2@test.com");
+		SignupMemberResponse testUser3 = memberFixture.createMember("testuser3", "test3@test.com");
+
+		// testUser가 Workspace 생성
+		CreateWorkspaceResponse createWorkspace = workspaceFixture.createWorkspace(testUser.memberId());
+
+		workspaceCode = createWorkspace.code();
+
+		// testUser2, testUser3가 생성한 Workspace에 참가
+		workspaceParticipationCommandService.joinWorkspace(workspaceCode, testUser2.memberId());
+		workspaceParticipationCommandService.joinWorkspace(workspaceCode, testUser3.memberId());
+
+		// Source Issue 생성
+		CreateStoryRequest createSourceStory = CreateStoryRequest.builder()
+			.title("Source Story Issue")
+			.content("Source Story Issue")
+			.userStory("Source Story Issue")
+			.build();
+
+		CreateStoryResponse sourceIssue = (CreateStoryResponse)issueCommandService.createIssue(workspaceCode,
+			createSourceStory);
+
+		// testUser2가 Source Issue에 작업자로 참여
+		assigneeCommandService.addAssignee(workspaceCode, sourceIssue.issueKey(), 2L);
+
+		// Target Issue 생성
+		CreateStoryRequest createTargetStory = CreateStoryRequest.builder()
+			.title("Target Story Issue")
+			.content("Target Story Issue")
+			.userStory("Target Story Issue")
+			.build();
+
+		CreateStoryResponse targetIssue = (CreateStoryResponse)issueCommandService.createIssue(workspaceCode,
+			createTargetStory);
+
+		sourceIssueKey = sourceIssue.issueKey();
+		targetIssueKey = targetIssue.issueKey();
+	}
+
+	@AfterEach
+	public void tearDown() {
+		databaseCleaner.execute();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("이슈 간 관계 설정을 성공하면 성공 응답을 반환 한다")
+	void createIssueRelation_success_returnsCreateIssueRelationResponse() {
+		// given
+		Long requesterWorkspaceMemberId = 2L;
+		CreateIssueRelationRequest request = new CreateIssueRelationRequest(IssueRelationType.BLOCKS);
+
+		// when - 소스 이슈가 타겟 이슈를 BLOCKS
+		CreateIssueRelationResponse response = issueRelationCommandService.createRelation(
+			workspaceCode,
+			sourceIssueKey,
+			targetIssueKey,
+			requesterWorkspaceMemberId,
+			request
+		);
+
+		// then
+		assertThat(response.relationType()).isEqualTo(IssueRelationType.BLOCKS);
+		assertThat(response.sourceIssueKey()).isEqualTo(sourceIssueKey);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("이슈 간 관계 설정을 성공하면 소스 이슈와 타겟 이슈의 각 정방향, 역방향 관계의 수는 1개 이어야 한다")
+	void createIssueRelation_success_outgoingRelationSize1_incomingRelationsSize1() {
+		// given
+		Long requesterWorkspaceMemberId = 2L;
+		CreateIssueRelationRequest request = new CreateIssueRelationRequest(IssueRelationType.BLOCKS);
+
+		// when
+		CreateIssueRelationResponse response = issueRelationCommandService.createRelation(
+			workspaceCode,
+			sourceIssueKey,
+			targetIssueKey,
+			requesterWorkspaceMemberId,
+			request
+		);
+
+		// then
+		assertThat(response.relationType()).isEqualTo(IssueRelationType.BLOCKS);
+		assertThat(response.sourceIssueKey()).isEqualTo(sourceIssueKey);
+
+		Issue sourceIssue = issueRepository.findByIssueKeyAndWorkspaceCode(sourceIssueKey, workspaceCode).orElseThrow();
+		Issue targetIssue = issueRepository.findByIssueKeyAndWorkspaceCode(targetIssueKey, workspaceCode).orElseThrow();
+
+		assertThat(sourceIssue.getOutgoingRelations()).hasSize(1);
+		assertThat(sourceIssue.getIncomingRelations()).hasSize(1);
+		assertThat(targetIssue.getOutgoingRelations()).hasSize(1);
+		assertThat(targetIssue.getIncomingRelations()).hasSize(1);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("타겟 이슈에서 반대로 소스 이슈에 대한 관계를 설정하려고 하면 예외가 발생한다(A -> B -> A)")
+	void createIssueRelation_sourceToTargetToSource_circularDependency() {
+		// given
+		Long requesterWorkspaceMemberId = 2L;
+		CreateIssueRelationRequest request = new CreateIssueRelationRequest(IssueRelationType.BLOCKS);
+
+		issueRelationCommandService.createRelation(
+			workspaceCode,
+			sourceIssueKey,
+			targetIssueKey,
+			requesterWorkspaceMemberId,
+			request
+		);
+
+		// 타겟 이슈에 작업자로 참여
+		assigneeCommandService.addAssignee(
+			workspaceCode,
+			targetIssueKey,
+			2L
+		);
+
+		// when & then
+		assertThatThrownBy(() -> issueRelationCommandService.createRelation(
+			workspaceCode,
+			targetIssueKey,
+			sourceIssueKey,
+			requesterWorkspaceMemberId,
+			request
+		)).isInstanceOf(DuplicateIssueRelationException.class);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("소스 이슈가 스스로에 대해 관계를 설정하려고 하면 예외가 발생한다(A -> A)")
+	void createIssueRelation_sameIssue_throwsException() {
+		// given
+		Long requesterWorkspaceMemberId = 2L;
+		CreateIssueRelationRequest request = new CreateIssueRelationRequest(IssueRelationType.BLOCKS);
+
+		// when & then
+		assertThatThrownBy(() -> issueRelationCommandService.createRelation(
+			workspaceCode,
+			sourceIssueKey,
+			sourceIssueKey,
+			requesterWorkspaceMemberId,
+			request
+		)).isInstanceOf(SelfReferenceNotAllowedException.class);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("상위의 타겟 이슈에서 하위의 소스 이슈 간 관계를 설정하려면 예외가 발생한다(A -> B -> C -> A)")
+	void createIssueRelation_sourceToTargetToTargetToSource_circularDependency() {
+		// given
+		Long requesterWorkspaceMemberId = 2L;
+
+		// 이슈 A-B 관계 설정
+		issueRelationCommandService.createRelation(
+			workspaceCode,
+			sourceIssueKey,
+			targetIssueKey,
+			requesterWorkspaceMemberId,
+			new CreateIssueRelationRequest(IssueRelationType.BLOCKS)
+		);
+
+		// 이슈 B에 참여
+		assigneeCommandService.addAssignee(
+			workspaceCode,
+			targetIssueKey,
+			2L
+		);
+
+		// 이슈 B의 타겟 이슈 C 생성
+		CreateStoryRequest createTargetIssueC = CreateStoryRequest.builder()
+			.title("Target Story Issue C")
+			.content("Target Story Issue C")
+			.userStory("Target Story Issue C")
+			.build();
+
+		CreateStoryResponse targetIssueC = (CreateStoryResponse)issueCommandService.createIssue(workspaceCode,
+			createTargetIssueC);
+
+		// 이슈 C에 참여
+		assigneeCommandService.addAssignee(
+			workspaceCode,
+			targetIssueC.issueKey(),
+			2L
+		);
+
+		// 이슈 B-C 관계 설정
+		issueRelationCommandService.createRelation(
+			workspaceCode,
+			targetIssueKey,
+			targetIssueC.issueKey(),
+			requesterWorkspaceMemberId,
+			new CreateIssueRelationRequest(IssueRelationType.BLOCKS)
+		);
+
+		// when & then - C-A 관계 시도
+		assertThatThrownBy(() -> issueRelationCommandService.createRelation(
+			workspaceCode,
+			targetIssueC.issueKey(),
+			sourceIssueKey,
+			requesterWorkspaceMemberId,
+			new CreateIssueRelationRequest(IssueRelationType.BLOCKS)
+		)).isInstanceOf(CircularDependencyException.class);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("이슈 간 관계 제거에 성공하면 성공 응답을 반환한다")
+	void removeIssueRelation_success_returnsRemoveIssueRelationResponse() {
+		// given
+		Long requesterWorkspaceMemberId = 2L;
+
+		// when
+		RemoveIssueRelationResponse response = issueRelationCommandService.removeRelation(
+			workspaceCode,
+			sourceIssueKey,
+			targetIssueKey,
+			requesterWorkspaceMemberId
+		);
+
+		// then
+		assertThat(response.sourceIssueKey()).isEqualTo(sourceIssueKey);
+		assertThat(response.targetIssueKey()).isEqualTo(targetIssueKey);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("이슈 간 관계 제거에 성공하면 소스 이슈와 타겟 이슈의 각 정방향, 역방향 관계는 비어있어야 한다")
+	void createIssueRelation_success_outgoingRelationEmpty_incomingRelationsEmpty() {
+		// given
+		Long requesterWorkspaceMemberId = 2L;
+
+		// when
+		RemoveIssueRelationResponse response = issueRelationCommandService.removeRelation(
+			workspaceCode,
+			sourceIssueKey,
+			targetIssueKey,
+			requesterWorkspaceMemberId
+		);
+
+		// then
+		assertThat(response.sourceIssueKey()).isEqualTo(sourceIssueKey);
+		assertThat(response.targetIssueKey()).isEqualTo(targetIssueKey);
+
+		Issue sourceIssue = issueRepository.findByIssueKeyAndWorkspaceCode(sourceIssueKey, workspaceCode).orElseThrow();
+		Issue targetIssue = issueRepository.findByIssueKeyAndWorkspaceCode(targetIssueKey, workspaceCode).orElseThrow();
+		assertThat(sourceIssue.getOutgoingRelations()).isEmpty();
+		assertThat(sourceIssue.getIncomingRelations()).isEmpty();
+		assertThat(targetIssue.getOutgoingRelations()).isEmpty();
+		assertThat(targetIssue.getIncomingRelations()).isEmpty();
+	}
+}

--- a/backend/src/test/java/com/tissue/helper/ServiceIntegrationTestHelper.java
+++ b/backend/src/test/java/com/tissue/helper/ServiceIntegrationTestHelper.java
@@ -11,6 +11,7 @@ import com.tissue.api.invitation.service.command.InvitationCommandService;
 import com.tissue.api.invitation.service.query.InvitationQueryService;
 import com.tissue.api.issue.domain.repository.IssueRepository;
 import com.tissue.api.issue.service.command.IssueCommandService;
+import com.tissue.api.issue.service.command.IssueRelationCommandService;
 import com.tissue.api.member.domain.repository.MemberRepository;
 import com.tissue.api.member.service.command.MemberCommandService;
 import com.tissue.api.member.service.query.MemberQueryService;
@@ -105,6 +106,8 @@ public abstract class ServiceIntegrationTestHelper {
 	protected TeamQueryService teamQueryService;
 	@Autowired
 	protected IssueCommandService issueCommandService;
+	@Autowired
+	protected IssueRelationCommandService issueRelationCommandService;
 	@Autowired
 	protected ReviewCommandService reviewCommandService;
 	@Autowired


### PR DESCRIPTION
## 🚀 설명
- 이슈 간 관계 설정 기능 구현
- `BLOCKS` 관계를 설정하는 경우 순환 참조가 일어나지 않도록 검증
  - `A -> A` 불가
  - `A -> B -> A` 불가
  - `A -> B -> C -> A` 불가
- 블록 당한 이슈는, 블로킹 하는 이슈를 해결해야 `DONE`으로 전환 가능

---
## ✅ 변경 사항
- [x] `IssueRelation` 추가
- [x] `IssueRelationType` 추가
- [x] 이슈 관계 등록 API
- [x] 이슈 관계 제거 API
- [x] 관련 테스트 코드 추가

---
## 🚩 관련 이슈, PR
- #176 

---
## 📖 참고