### PR TITLE
Feat/#196 댓글(`Comment`) 기능 구현

### DIFF
--- a/backend/src/main/java/com/tissue/api/comment/domain/Comment.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/Comment.java
@@ -67,6 +67,11 @@ public abstract class Comment extends WorkspaceContextBaseEntity {
 		this.content = content;
 		this.author = author;
 		this.parentComment = parentComment;
+
+		if (parentComment != null) {
+			validateParentComment();
+			parentComment.addChildComment(this);
+		}
 	}
 
 	public void updateContent(String content) {

--- a/backend/src/main/java/com/tissue/api/comment/domain/Comment.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/Comment.java
@@ -1,0 +1,105 @@
+package com.tissue.api.comment.domain;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.tissue.api.comment.domain.enums.CommentStatus;
+import com.tissue.api.common.entity.WorkspaceContextBaseEntity;
+import com.tissue.api.common.exception.type.InvalidOperationException;
+import com.tissue.api.workspacemember.domain.WorkspaceMember;
+import com.tissue.api.workspacemember.domain.WorkspaceRole;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "type")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends WorkspaceContextBaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String content;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "AUTHOR_ID", nullable = false)
+	private WorkspaceMember author;
+
+	// 대댓글 구조를 위한 self-referencing 관계
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "PARENT_COMMENT_ID")
+	private Comment parentComment;
+
+	@OneToMany(mappedBy = "parentComment")
+	private final List<Comment> childComments = new ArrayList<>();
+
+	// 댓글의 상태 관리
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private CommentStatus status = CommentStatus.ACTIVE;
+
+	// soft delete를 위한 필드들
+	private LocalDateTime deletedAt;
+	private Long deletedBy;
+
+	public void delete(Long deletedBy) {
+		this.status = CommentStatus.DELETED;
+		this.deletedAt = LocalDateTime.now();
+		this.deletedBy = deletedBy;
+	}
+
+	public boolean isAuthoredBy(WorkspaceMember member) {
+		return author.equals(member);
+	}
+
+	// 바로 검증하는 것 고려
+	public boolean canEdit(WorkspaceMember member) {
+		return author.equals(member) || member.roleIsHigherThan(WorkspaceRole.MANAGER);
+	}
+
+	// 대댓글 추가 시 1-depth 제한과 타입 검증
+	protected void validateParentComment() {
+		if (parentComment == null) {
+			return;
+		}
+
+		if (parentComment.getParentComment() != null) {
+			throw new InvalidOperationException("Comments can only be nested one level deep.");
+		}
+
+		if (parentComment.getClass() != this.getClass()) {
+			throw new InvalidOperationException(
+				String.format("Parent comment type(%s) and child comment type(%s) must match.",
+					parentComment.getClass().getSimpleName(),
+					this.getClass().getSimpleName())
+			);
+		}
+	}
+
+	public void addChildComment(Comment child) {
+		child.validateParentComment();
+		child.parentComment = this;
+		this.childComments.add(child);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/comment/domain/IssueComment.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/IssueComment.java
@@ -1,6 +1,7 @@
 package com.tissue.api.comment.domain;
 
 import com.tissue.api.issue.domain.Issue;
+import com.tissue.api.workspacemember.domain.WorkspaceMember;
 
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
@@ -8,6 +9,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,9 +17,25 @@ import lombok.NoArgsConstructor;
 @Getter
 @DiscriminatorValue("ISSUE_COMMENT")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class IssueComment {
+public class IssueComment extends Comment {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "ISSUE_ID", nullable = false)
 	private Issue issue;
+
+	@Builder
+	private IssueComment(
+		String content,
+		WorkspaceMember author,
+		Issue issue,
+		Comment parentComment
+	) {
+		super(content, author);
+		this.issue = issue;
+
+		if (parentComment != null) {
+			validateParentComment();
+			parentComment.addChildComment(this);
+		}
+	}
 }

--- a/backend/src/main/java/com/tissue/api/comment/domain/IssueComment.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/IssueComment.java
@@ -30,7 +30,7 @@ public class IssueComment extends Comment {
 		Issue issue,
 		Comment parentComment
 	) {
-		super(content, author);
+		super(content, author, parentComment);
 		this.issue = issue;
 
 		if (parentComment != null) {

--- a/backend/src/main/java/com/tissue/api/comment/domain/IssueComment.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/IssueComment.java
@@ -32,10 +32,5 @@ public class IssueComment extends Comment {
 	) {
 		super(content, author, parentComment);
 		this.issue = issue;
-
-		if (parentComment != null) {
-			validateParentComment();
-			parentComment.addChildComment(this);
-		}
 	}
 }

--- a/backend/src/main/java/com/tissue/api/comment/domain/IssueComment.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/IssueComment.java
@@ -1,0 +1,23 @@
+package com.tissue.api.comment.domain;
+
+import com.tissue.api.issue.domain.Issue;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@DiscriminatorValue("ISSUE_COMMENT")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IssueComment {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "ISSUE_ID", nullable = false)
+	private Issue issue;
+}

--- a/backend/src/main/java/com/tissue/api/comment/domain/ReviewComment.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/ReviewComment.java
@@ -1,0 +1,29 @@
+package com.tissue.api.comment.domain;
+
+import com.tissue.api.review.domain.Review;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@DiscriminatorValue("REVIEW_COMMENT")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewComment {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "REVIEW_ID", nullable = false)
+	private Review review;
+
+	/*
+	 * Todo
+	 *  - 깃허브 API 연동
+	 *  - line number, PR number, github comment id, 등을 추가
+	 */
+}

--- a/backend/src/main/java/com/tissue/api/comment/domain/ReviewComment.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/ReviewComment.java
@@ -36,12 +36,7 @@ public class ReviewComment extends Comment {
 		Review review,
 		Comment parentComment
 	) {
-		super(content, author);
+		super(content, author, parentComment);
 		this.review = review;
-
-		if (parentComment != null) {
-			validateParentComment();
-			parentComment.addChildComment(this);
-		}
 	}
 }

--- a/backend/src/main/java/com/tissue/api/comment/domain/ReviewComment.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/ReviewComment.java
@@ -1,6 +1,7 @@
 package com.tissue.api.comment.domain;
 
 import com.tissue.api.review.domain.Review;
+import com.tissue.api.workspacemember.domain.WorkspaceMember;
 
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
@@ -8,6 +9,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @DiscriminatorValue("REVIEW_COMMENT")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ReviewComment {
+public class ReviewComment extends Comment {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "REVIEW_ID", nullable = false)
@@ -26,4 +28,20 @@ public class ReviewComment {
 	 *  - 깃허브 API 연동
 	 *  - line number, PR number, github comment id, 등을 추가
 	 */
+
+	@Builder
+	private ReviewComment(
+		String content,
+		WorkspaceMember author,
+		Review review,
+		Comment parentComment
+	) {
+		super(content, author);
+		this.review = review;
+
+		if (parentComment != null) {
+			validateParentComment();
+			parentComment.addChildComment(this);
+		}
+	}
 }

--- a/backend/src/main/java/com/tissue/api/comment/domain/enums/CommentStatus.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/enums/CommentStatus.java
@@ -1,0 +1,6 @@
+package com.tissue.api.comment.domain.enums;
+
+public enum CommentStatus {
+	ACTIVE,
+	DELETED
+}

--- a/backend/src/main/java/com/tissue/api/comment/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/repository/CommentRepository.java
@@ -16,9 +16,9 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 		String workspaceCode
 	);
 
-	Optional<ReviewComment> findByIdAndReview_IdAndReview_WorkspaceCode(
+	Optional<ReviewComment> findByIdAndReview_IdAndReview_IssueKey(
 		Long commentId,
 		Long reviewId,
-		String workspaceCode
+		String issueKey
 	);
 }

--- a/backend/src/main/java/com/tissue/api/comment/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/repository/CommentRepository.java
@@ -1,8 +1,17 @@
 package com.tissue.api.comment.domain.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.tissue.api.comment.domain.Comment;
+import com.tissue.api.comment.domain.IssueComment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+	Optional<IssueComment> findByIdAndIssue_IssueKeyAndIssue_WorkspaceCode(
+		Long id,
+		String issueKey,
+		String workspaceCode
+	);
 }

--- a/backend/src/main/java/com/tissue/api/comment/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/repository/CommentRepository.java
@@ -3,6 +3,8 @@ package com.tissue.api.comment.domain.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.tissue.api.comment.domain.Comment;
 import com.tissue.api.comment.domain.IssueComment;
@@ -20,5 +22,16 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 		Long commentId,
 		Long reviewId,
 		String issueKey
+	);
+
+	@Query("SELECT rc FROM ReviewComment rc "
+		+ "JOIN rc.review r "
+		+ "WHERE rc.id = :commentId "
+		+ "AND r.id = :reviewId "
+		+ "AND r.issueKey = :issueKey ")
+	Optional<ReviewComment> findByIdAndReviewIdAndIssueKey(
+		@Param("commentId") Long commentId,
+		@Param("reviewId") Long reviewId,
+		@Param("issueKey") String issueKey
 	);
 }

--- a/backend/src/main/java/com/tissue/api/comment/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/repository/CommentRepository.java
@@ -6,12 +6,19 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.tissue.api.comment.domain.Comment;
 import com.tissue.api.comment.domain.IssueComment;
+import com.tissue.api.comment.domain.ReviewComment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	Optional<IssueComment> findByIdAndIssue_IssueKeyAndIssue_WorkspaceCode(
 		Long id,
 		String issueKey,
+		String workspaceCode
+	);
+
+	Optional<ReviewComment> findByIdAndReview_IdAndReview_WorkspaceCode(
+		Long commentId,
+		Long reviewId,
 		String workspaceCode
 	);
 }

--- a/backend/src/main/java/com/tissue/api/comment/domain/repository/CommentRepository.java
+++ b/backend/src/main/java/com/tissue/api/comment/domain/repository/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.tissue.api.comment.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.tissue.api.comment.domain.Comment;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/backend/src/main/java/com/tissue/api/comment/exception/CommentNotFoundException.java
+++ b/backend/src/main/java/com/tissue/api/comment/exception/CommentNotFoundException.java
@@ -1,0 +1,12 @@
+package com.tissue.api.comment.exception;
+
+import com.tissue.api.common.exception.type.ResourceNotFoundException;
+
+public class CommentNotFoundException extends ResourceNotFoundException {
+
+	private static final String ID_MESSAGE = "Review not found with id: %d";
+
+	public CommentNotFoundException(Long commentId) {
+		super(String.format(ID_MESSAGE, commentId));
+	}
+}

--- a/backend/src/main/java/com/tissue/api/comment/presentation/controller/IssueCommentController.java
+++ b/backend/src/main/java/com/tissue/api/comment/presentation/controller/IssueCommentController.java
@@ -1,0 +1,104 @@
+package com.tissue.api.comment.presentation.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.tissue.api.comment.presentation.dto.request.CreateIssueCommentRequest;
+import com.tissue.api.comment.presentation.dto.request.UpdateIssueCommentRequest;
+import com.tissue.api.comment.presentation.dto.response.IssueCommentResponse;
+import com.tissue.api.comment.service.command.IssueCommentCommandService;
+import com.tissue.api.common.dto.ApiResponse;
+import com.tissue.api.security.authorization.interceptor.RoleRequired;
+import com.tissue.api.workspacemember.domain.WorkspaceRole;
+import com.tissue.api.workspacemember.resolver.CurrentWorkspaceMember;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/workspaces/{workspaceCode}/issues/{issueKey}/comments")
+public class IssueCommentController {
+
+	/*
+	 * Todo
+	 *  - 댓글 작성(해당 워크스페이스에서 VIEWER 이상이면 누구나 가능)
+	 *  - 댓글 수정
+	 *    - 작성자 가능
+	 *    - MANAGER 권한 이상 가능
+	 *  - 댓글 삭제
+	 * 	  - 작성자 가능
+	 *    - MANAGER 권한 이상 가능
+	 *    - soft delete 사용(ACTIVE -> DELETED)
+	 *  - 댓글 조회
+	 *    - 내가 해당 워크스페이스에서 작성한 모든 이슈 댓글 조회
+	 *    - 특정 이슈의 모든 댓글 조회
+	 *    - 특정 댓글의 모든 대댓글 조회
+	 */
+	private final IssueCommentCommandService issueCommentCommandService;
+
+	@PostMapping
+	@RoleRequired(role = WorkspaceRole.MEMBER)
+	public ApiResponse<IssueCommentResponse> createComment(
+		@PathVariable String workspaceCode,
+		@PathVariable String issueKey,
+		@Valid @RequestBody CreateIssueCommentRequest request,
+		@CurrentWorkspaceMember Long currentWorkspaceMemberId
+	) {
+		IssueCommentResponse response = issueCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			request,
+			currentWorkspaceMemberId
+		);
+
+		return ApiResponse.created("Comment created.", response);
+	}
+
+	@PatchMapping("/{commentId}")
+	@RoleRequired(role = WorkspaceRole.MEMBER)
+	public ApiResponse<IssueCommentResponse> updateComment(
+		@PathVariable String workspaceCode,
+		@PathVariable String issueKey,
+		@PathVariable Long commentId,
+		@Valid @RequestBody UpdateIssueCommentRequest request,
+		@CurrentWorkspaceMember Long currentWorkspaceMemberId
+	) {
+		IssueCommentResponse response = issueCommentCommandService.updateComment(
+			workspaceCode,
+			issueKey,
+			commentId,
+			request,
+			currentWorkspaceMemberId
+		);
+
+		return ApiResponse.created("Comment updated.", response);
+	}
+
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@DeleteMapping("/{commentId}")
+	@RoleRequired(role = WorkspaceRole.MEMBER)
+	public ApiResponse<Void> deleteComment(
+		@PathVariable String workspaceCode,
+		@PathVariable String issueKey,
+		@PathVariable Long commentId,
+		@CurrentWorkspaceMember Long currentWorkspaceMemberId
+	) {
+		issueCommentCommandService.deleteComment(
+			workspaceCode,
+			issueKey,
+			commentId,
+			currentWorkspaceMemberId
+		);
+
+		return ApiResponse.okWithNoContent("Comment deleted.");
+	}
+
+}

--- a/backend/src/main/java/com/tissue/api/comment/presentation/controller/IssueCommentController.java
+++ b/backend/src/main/java/com/tissue/api/comment/presentation/controller/IssueCommentController.java
@@ -45,6 +45,7 @@ public class IssueCommentController {
 	private final IssueCommentCommandService issueCommentCommandService;
 
 	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
 	@RoleRequired(role = WorkspaceRole.MEMBER)
 	public ApiResponse<IssueCommentResponse> createComment(
 		@PathVariable String workspaceCode,
@@ -82,8 +83,8 @@ public class IssueCommentController {
 		return ApiResponse.created("Comment updated.", response);
 	}
 
-	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@DeleteMapping("/{commentId}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@RoleRequired(role = WorkspaceRole.MEMBER)
 	public ApiResponse<Void> deleteComment(
 		@PathVariable String workspaceCode,

--- a/backend/src/main/java/com/tissue/api/comment/presentation/controller/ReviewCommentController.java
+++ b/backend/src/main/java/com/tissue/api/comment/presentation/controller/ReviewCommentController.java
@@ -1,0 +1,88 @@
+package com.tissue.api.comment.presentation.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.tissue.api.comment.service.command.ReviewCommentCommandService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/workspaces/{workspaceCode}/issues/{issueKey}/reviews/{reviewId}/comments")
+public class ReviewCommentController {
+
+	private final ReviewCommentCommandService reviewCommentCommandService;
+
+	/*
+	 * Todo
+	 *  - 리뷰에 댓글 작성
+	 *    - 댓글 내용
+	 *  - 댓글 수정
+	 *  - 댓글 삭제(soft delete)
+	 *  - 댓글 조회
+	 *  - 깃허브 PR 연동
+	 */
+	// @PostMapping
+	// @ResponseStatus(HttpStatus.CREATED)
+	// @RoleRequired(role = WorkspaceRole.MEMBER)
+	// public ApiResponse<ReviewCommentResponse> createComment(
+	// 	@PathVariable String workspaceCode,
+	// 	@PathVariable String issueKey,
+	// 	@Valid @RequestBody CreateReviewCommentRequest request,
+	// 	@CurrentWorkspaceMember Long currentWorkspaceMemberId
+	// ) {
+	// 	ReviewCommentResponse response = reviewCommentCommandService.createComment(
+	// 		workspaceCode,
+	// 		issueKey,
+	// 		request,
+	// 		currentWorkspaceMemberId
+	// 	);
+	//
+	// 	return ApiResponse.created("Comment created.", response);
+	// }
+	//
+	// @PatchMapping("/{commentId}")
+	// @RoleRequired(role = WorkspaceRole.MEMBER)
+	// public ApiResponse<ReviewCommentResponse> updateComment(
+	// 	@PathVariable String workspaceCode,
+	// 	@PathVariable String issueKey,
+	// 	@PathVariable Long commentId,
+	// 	@Valid @RequestBody UpdateReviewCommentRequest request,
+	// 	@CurrentWorkspaceMember Long currentWorkspaceMemberId
+	// ) {
+	// 	ReviewCommentResponse response = reviewCommentCommandService.updateComment(
+	// 		workspaceCode,
+	// 		issueKey,
+	// 		commentId,
+	// 		request,
+	// 		currentWorkspaceMemberId
+	// 	);
+	//
+	// 	return ApiResponse.created("Comment updated.", response);
+	// }
+	//
+	// /**
+	//  * Todo
+	//  *  - 만약 깃허브 API와 연동을 하는 경우 댓글 삭제 후 복구는 불가능 하도록 만들어야 하나?
+	//  *  - 깃허브 API의 댓글 시스템 파악이 필요
+	//  */
+	// @DeleteMapping("/{commentId}")
+	// @ResponseStatus(HttpStatus.NO_CONTENT)
+	// @RoleRequired(role = WorkspaceRole.MEMBER)
+	// public ApiResponse<Void> deleteComment(
+	// 	@PathVariable String workspaceCode,
+	// 	@PathVariable String issueKey,
+	// 	@PathVariable Long commentId,
+	// 	@CurrentWorkspaceMember Long currentWorkspaceMemberId
+	// ) {
+	// 	reviewCommentCommandService.deleteComment(
+	// 		workspaceCode,
+	// 		issueKey,
+	// 		commentId,
+	// 		currentWorkspaceMemberId
+	// 	);
+	//
+	// 	return ApiResponse.okWithNoContent("Comment deleted.");
+	// }
+}

--- a/backend/src/main/java/com/tissue/api/comment/presentation/controller/ReviewCommentController.java
+++ b/backend/src/main/java/com/tissue/api/comment/presentation/controller/ReviewCommentController.java
@@ -1,10 +1,25 @@
 package com.tissue.api.comment.presentation.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.tissue.api.comment.presentation.dto.request.CreateReviewCommentRequest;
+import com.tissue.api.comment.presentation.dto.request.UpdateReviewCommentRequest;
+import com.tissue.api.comment.presentation.dto.response.ReviewCommentResponse;
 import com.tissue.api.comment.service.command.ReviewCommentCommandService;
+import com.tissue.api.common.dto.ApiResponse;
+import com.tissue.api.security.authorization.interceptor.RoleRequired;
+import com.tissue.api.workspacemember.domain.WorkspaceRole;
+import com.tissue.api.workspacemember.resolver.CurrentWorkspaceMember;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -23,66 +38,72 @@ public class ReviewCommentController {
 	 *  - 댓글 조회
 	 *  - 깃허브 PR 연동
 	 */
-	// @PostMapping
-	// @ResponseStatus(HttpStatus.CREATED)
-	// @RoleRequired(role = WorkspaceRole.MEMBER)
-	// public ApiResponse<ReviewCommentResponse> createComment(
-	// 	@PathVariable String workspaceCode,
-	// 	@PathVariable String issueKey,
-	// 	@Valid @RequestBody CreateReviewCommentRequest request,
-	// 	@CurrentWorkspaceMember Long currentWorkspaceMemberId
-	// ) {
-	// 	ReviewCommentResponse response = reviewCommentCommandService.createComment(
-	// 		workspaceCode,
-	// 		issueKey,
-	// 		request,
-	// 		currentWorkspaceMemberId
-	// 	);
-	//
-	// 	return ApiResponse.created("Comment created.", response);
-	// }
-	//
-	// @PatchMapping("/{commentId}")
-	// @RoleRequired(role = WorkspaceRole.MEMBER)
-	// public ApiResponse<ReviewCommentResponse> updateComment(
-	// 	@PathVariable String workspaceCode,
-	// 	@PathVariable String issueKey,
-	// 	@PathVariable Long commentId,
-	// 	@Valid @RequestBody UpdateReviewCommentRequest request,
-	// 	@CurrentWorkspaceMember Long currentWorkspaceMemberId
-	// ) {
-	// 	ReviewCommentResponse response = reviewCommentCommandService.updateComment(
-	// 		workspaceCode,
-	// 		issueKey,
-	// 		commentId,
-	// 		request,
-	// 		currentWorkspaceMemberId
-	// 	);
-	//
-	// 	return ApiResponse.created("Comment updated.", response);
-	// }
-	//
-	// /**
-	//  * Todo
-	//  *  - 만약 깃허브 API와 연동을 하는 경우 댓글 삭제 후 복구는 불가능 하도록 만들어야 하나?
-	//  *  - 깃허브 API의 댓글 시스템 파악이 필요
-	//  */
-	// @DeleteMapping("/{commentId}")
-	// @ResponseStatus(HttpStatus.NO_CONTENT)
-	// @RoleRequired(role = WorkspaceRole.MEMBER)
-	// public ApiResponse<Void> deleteComment(
-	// 	@PathVariable String workspaceCode,
-	// 	@PathVariable String issueKey,
-	// 	@PathVariable Long commentId,
-	// 	@CurrentWorkspaceMember Long currentWorkspaceMemberId
-	// ) {
-	// 	reviewCommentCommandService.deleteComment(
-	// 		workspaceCode,
-	// 		issueKey,
-	// 		commentId,
-	// 		currentWorkspaceMemberId
-	// 	);
-	//
-	// 	return ApiResponse.okWithNoContent("Comment deleted.");
-	// }
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	@RoleRequired(role = WorkspaceRole.MEMBER)
+	public ApiResponse<ReviewCommentResponse> createComment(
+		@PathVariable String workspaceCode,
+		@PathVariable String issueKey,
+		@PathVariable Long reviewId,
+		@Valid @RequestBody CreateReviewCommentRequest request,
+		@CurrentWorkspaceMember Long currentWorkspaceMemberId
+	) {
+		ReviewCommentResponse response = reviewCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			reviewId,
+			request,
+			currentWorkspaceMemberId
+		);
+
+		return ApiResponse.created("Comment created.", response);
+	}
+
+	@PatchMapping("/{commentId}")
+	@RoleRequired(role = WorkspaceRole.MEMBER)
+	public ApiResponse<ReviewCommentResponse> updateComment(
+		@PathVariable String workspaceCode,
+		@PathVariable String issueKey,
+		@PathVariable Long reviewId,
+		@PathVariable Long commentId,
+		@Valid @RequestBody UpdateReviewCommentRequest request,
+		@CurrentWorkspaceMember Long currentWorkspaceMemberId
+	) {
+		ReviewCommentResponse response = reviewCommentCommandService.updateComment(
+			workspaceCode,
+			issueKey,
+			reviewId,
+			commentId,
+			request,
+			currentWorkspaceMemberId
+		);
+
+		return ApiResponse.created("Comment updated.", response);
+	}
+
+	/**
+	 * Todo
+	 *  - 만약 깃허브 API와 연동을 하는 경우 댓글 삭제 후 복구는 불가능 하도록 만들어야 하나?
+	 *  - 깃허브 API의 댓글 시스템 파악이 필요
+	 */
+	@DeleteMapping("/{commentId}")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@RoleRequired(role = WorkspaceRole.MEMBER)
+	public ApiResponse<Void> deleteComment(
+		@PathVariable String workspaceCode,
+		@PathVariable String issueKey,
+		@PathVariable Long reviewId,
+		@PathVariable Long commentId,
+		@CurrentWorkspaceMember Long currentWorkspaceMemberId
+	) {
+		reviewCommentCommandService.deleteComment(
+			workspaceCode,
+			issueKey,
+			reviewId,
+			commentId,
+			currentWorkspaceMemberId
+		);
+
+		return ApiResponse.okWithNoContent("Comment deleted.");
+	}
 }

--- a/backend/src/main/java/com/tissue/api/comment/presentation/dto/request/CreateIssueCommentRequest.java
+++ b/backend/src/main/java/com/tissue/api/comment/presentation/dto/request/CreateIssueCommentRequest.java
@@ -1,0 +1,16 @@
+package com.tissue.api.comment.presentation.dto.request;
+
+import com.tissue.api.common.validator.annotation.size.text.LongText;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateIssueCommentRequest(
+	@NotBlank @LongText
+	String content,
+	Long parentCommentId
+) {
+
+	public boolean hasParentComment() {
+		return parentCommentId != null;
+	}
+}

--- a/backend/src/main/java/com/tissue/api/comment/presentation/dto/request/CreateIssueCommentRequest.java
+++ b/backend/src/main/java/com/tissue/api/comment/presentation/dto/request/CreateIssueCommentRequest.java
@@ -7,9 +7,9 @@ import jakarta.validation.constraints.NotBlank;
 public record CreateIssueCommentRequest(
 	@NotBlank @LongText
 	String content,
+
 	Long parentCommentId
 ) {
-
 	public boolean hasParentComment() {
 		return parentCommentId != null;
 	}

--- a/backend/src/main/java/com/tissue/api/comment/presentation/dto/request/CreateReviewCommentRequest.java
+++ b/backend/src/main/java/com/tissue/api/comment/presentation/dto/request/CreateReviewCommentRequest.java
@@ -1,0 +1,16 @@
+package com.tissue.api.comment.presentation.dto.request;
+
+import com.tissue.api.common.validator.annotation.size.text.LongText;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateReviewCommentRequest(
+	@NotBlank @LongText
+	String content,
+
+	Long parentCommentId
+) {
+	public boolean hasParentComment() {
+		return parentCommentId != null;
+	}
+}

--- a/backend/src/main/java/com/tissue/api/comment/presentation/dto/request/UpdateIssueCommentRequest.java
+++ b/backend/src/main/java/com/tissue/api/comment/presentation/dto/request/UpdateIssueCommentRequest.java
@@ -1,0 +1,11 @@
+package com.tissue.api.comment.presentation.dto.request;
+
+import com.tissue.api.common.validator.annotation.size.text.LongText;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateIssueCommentRequest(
+	@NotBlank @LongText
+	String content
+) {
+}

--- a/backend/src/main/java/com/tissue/api/comment/presentation/dto/request/UpdateReviewCommentRequest.java
+++ b/backend/src/main/java/com/tissue/api/comment/presentation/dto/request/UpdateReviewCommentRequest.java
@@ -1,0 +1,11 @@
+package com.tissue.api.comment.presentation.dto.request;
+
+import com.tissue.api.common.validator.annotation.size.text.LongText;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateReviewCommentRequest(
+	@NotBlank @LongText
+	String content
+) {
+}

--- a/backend/src/main/java/com/tissue/api/comment/presentation/dto/response/IssueCommentResponse.java
+++ b/backend/src/main/java/com/tissue/api/comment/presentation/dto/response/IssueCommentResponse.java
@@ -6,13 +6,16 @@ import java.util.List;
 import com.tissue.api.comment.domain.IssueComment;
 import com.tissue.api.comment.domain.enums.CommentStatus;
 
+import lombok.Builder;
+
+@Builder
 public record IssueCommentResponse(
 	Long id,
 	String content,
 	AuthorInfo author,
 	LocalDateTime createdAt,
 	boolean isEdited,
-	boolean isDeleted,
+	CommentStatus status,
 	List<IssueCommentResponse> childComments
 ) {
 	public record AuthorInfo(
@@ -22,19 +25,19 @@ public record IssueCommentResponse(
 	}
 
 	public static IssueCommentResponse from(IssueComment comment) {
-		return new IssueCommentResponse(
-			comment.getId(),
-			comment.getContent(),
-			new AuthorInfo(
+		return IssueCommentResponse.builder()
+			.id(comment.getId())
+			.content(comment.getContent())
+			.author(new AuthorInfo(
 				comment.getAuthor().getId(),
 				comment.getAuthor().getNickname()
-			),
-			comment.getCreatedDate(),
-			comment.isEdited(),
-			comment.getStatus() == CommentStatus.DELETED,
-			comment.getChildComments().stream()
+			))
+			.createdAt(comment.getCreatedDate())
+			.isEdited(comment.isEdited())
+			.status(comment.getStatus())
+			.childComments(comment.getChildComments().stream()
 				.map(child -> from((IssueComment)child))
-				.toList()
-		);
+				.toList())
+			.build();
 	}
 }

--- a/backend/src/main/java/com/tissue/api/comment/presentation/dto/response/IssueCommentResponse.java
+++ b/backend/src/main/java/com/tissue/api/comment/presentation/dto/response/IssueCommentResponse.java
@@ -1,0 +1,40 @@
+package com.tissue.api.comment.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.tissue.api.comment.domain.IssueComment;
+import com.tissue.api.comment.domain.enums.CommentStatus;
+
+public record IssueCommentResponse(
+	Long id,
+	String content,
+	AuthorInfo author,
+	LocalDateTime createdAt,
+	boolean isEdited,
+	boolean isDeleted,
+	List<IssueCommentResponse> childComments
+) {
+	public record AuthorInfo(
+		Long workspaceMemberId,
+		String nickname
+	) {
+	}
+
+	public static IssueCommentResponse from(IssueComment comment) {
+		return new IssueCommentResponse(
+			comment.getId(),
+			comment.getContent(),
+			new AuthorInfo(
+				comment.getAuthor().getId(),
+				comment.getAuthor().getNickname()
+			),
+			comment.getCreatedDate(),
+			comment.isEdited(),
+			comment.getStatus() == CommentStatus.DELETED,
+			comment.getChildComments().stream()
+				.map(child -> from((IssueComment)child))
+				.toList()
+		);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/comment/presentation/dto/response/ReviewCommentResponse.java
+++ b/backend/src/main/java/com/tissue/api/comment/presentation/dto/response/ReviewCommentResponse.java
@@ -1,0 +1,43 @@
+package com.tissue.api.comment.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.tissue.api.comment.domain.ReviewComment;
+import com.tissue.api.comment.domain.enums.CommentStatus;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewCommentResponse(
+	Long id,
+	String content,
+	AuthorInfo author,
+	LocalDateTime createdAt,
+	boolean isEdited,
+	CommentStatus status,
+	List<ReviewCommentResponse> childComments
+) {
+	public record AuthorInfo(
+		Long workspaceMemberId,
+		String nickname
+	) {
+	}
+
+	public static ReviewCommentResponse from(ReviewComment comment) {
+		return ReviewCommentResponse.builder()
+			.id(comment.getId())
+			.content(comment.getContent())
+			.author(new AuthorInfo(
+				comment.getAuthor().getId(),
+				comment.getAuthor().getNickname()
+			))
+			.createdAt(comment.getCreatedDate())
+			.isEdited(comment.isEdited())
+			.status(comment.getStatus())
+			.childComments(comment.getChildComments().stream()
+				.map(child -> from((ReviewComment)child))
+				.toList())
+			.build();
+	}
+}

--- a/backend/src/main/java/com/tissue/api/comment/service/command/IssueCommentCommandService.java
+++ b/backend/src/main/java/com/tissue/api/comment/service/command/IssueCommentCommandService.java
@@ -1,0 +1,104 @@
+package com.tissue.api.comment.service.command;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.tissue.api.comment.domain.IssueComment;
+import com.tissue.api.comment.domain.repository.CommentRepository;
+import com.tissue.api.comment.exception.CommentNotFoundException;
+import com.tissue.api.comment.presentation.dto.request.CreateIssueCommentRequest;
+import com.tissue.api.comment.presentation.dto.request.UpdateIssueCommentRequest;
+import com.tissue.api.comment.presentation.dto.response.IssueCommentResponse;
+import com.tissue.api.issue.domain.Issue;
+import com.tissue.api.issue.domain.repository.IssueRepository;
+import com.tissue.api.issue.exception.IssueNotFoundException;
+import com.tissue.api.workspacemember.domain.WorkspaceMember;
+import com.tissue.api.workspacemember.domain.repository.WorkspaceMemberRepository;
+import com.tissue.api.workspacemember.exception.WorkspaceMemberNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class IssueCommentCommandService {
+
+	private final CommentRepository commentRepository;
+	private final IssueRepository issueRepository;
+	private final WorkspaceMemberRepository workspaceMemberRepository;
+
+	@Transactional
+	public IssueCommentResponse createComment(
+		String workspaceCode,
+		String issueKey,
+		CreateIssueCommentRequest request,
+		Long currentWorkspaceMemberId
+	) {
+		// Todo: IssueQueryService 구현 후 재사용하는 방식으로 리팩토링
+		Issue issue = issueRepository.findByIssueKeyAndWorkspaceCode(issueKey, workspaceCode)
+			.orElseThrow(() -> new IssueNotFoundException(issueKey, workspaceCode));
+
+		WorkspaceMember author = workspaceMemberRepository.findById(currentWorkspaceMemberId)
+			.orElseThrow(() -> new WorkspaceMemberNotFoundException(currentWorkspaceMemberId, workspaceCode));
+
+		IssueComment parentComment = null;
+		if (request.hasParentComment()) {
+			parentComment = (IssueComment)commentRepository.findById(request.parentCommentId())
+				.orElseThrow(() -> new CommentNotFoundException(request.parentCommentId()));
+		}
+
+		// Todo: 아래로 리팩토링 가능
+		// IssueComment parentComment = request.hasParentComment()
+		// 	? findIssueComment(request.parentCommentId())
+		// 	: null;
+
+		IssueComment comment = IssueComment.builder()
+			.content(request.content())
+			.issue(issue)
+			.parentComment(parentComment)
+			.author(author)
+			.build();
+
+		commentRepository.save(comment);
+
+		return IssueCommentResponse.from(comment);
+	}
+
+	@Transactional
+	public IssueCommentResponse updateComment(
+		String workspaceCode,
+		String issueKey,
+		Long commentId,
+		UpdateIssueCommentRequest request,
+		Long currentWorkspaceMemberId
+	) {
+		WorkspaceMember currentWorkspaceMember = workspaceMemberRepository.findById(currentWorkspaceMemberId)
+			.orElseThrow(() -> new WorkspaceMemberNotFoundException(currentWorkspaceMemberId, workspaceCode));
+
+		IssueComment comment = commentRepository.findByIdAndIssue_IssueKeyAndIssue_WorkspaceCode(commentId, issueKey,
+				workspaceCode)
+			.orElseThrow(() -> new CommentNotFoundException(commentId));
+
+		comment.validateCanEdit(currentWorkspaceMember);
+		comment.updateContent(request.content());
+
+		return IssueCommentResponse.from(comment);
+	}
+
+	@Transactional
+	public void deleteComment(
+		String workspaceCode,
+		String issueKey,
+		Long commentId,
+		Long currentWorkspaceMemberId
+	) {
+		WorkspaceMember currentWorkspaceMember = workspaceMemberRepository.findById(currentWorkspaceMemberId)
+			.orElseThrow(() -> new WorkspaceMemberNotFoundException(currentWorkspaceMemberId, workspaceCode));
+
+		IssueComment comment = commentRepository.findByIdAndIssue_IssueKeyAndIssue_WorkspaceCode(commentId, issueKey,
+				workspaceCode)
+			.orElseThrow(() -> new CommentNotFoundException(commentId));
+
+		comment.validateCanEdit(currentWorkspaceMember);
+		comment.softDelete(currentWorkspaceMemberId);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/comment/service/command/ReviewCommentCommandService.java
+++ b/backend/src/main/java/com/tissue/api/comment/service/command/ReviewCommentCommandService.java
@@ -1,10 +1,20 @@
 package com.tissue.api.comment.service.command;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.tissue.api.comment.domain.ReviewComment;
 import com.tissue.api.comment.domain.repository.CommentRepository;
+import com.tissue.api.comment.exception.CommentNotFoundException;
+import com.tissue.api.comment.presentation.dto.request.CreateReviewCommentRequest;
+import com.tissue.api.comment.presentation.dto.request.UpdateReviewCommentRequest;
+import com.tissue.api.comment.presentation.dto.response.ReviewCommentResponse;
+import com.tissue.api.common.exception.type.ResourceNotFoundException;
+import com.tissue.api.review.domain.Review;
 import com.tissue.api.review.domain.repository.ReviewRepository;
+import com.tissue.api.workspacemember.domain.WorkspaceMember;
 import com.tissue.api.workspacemember.domain.repository.WorkspaceMemberRepository;
+import com.tissue.api.workspacemember.exception.WorkspaceMemberNotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,81 +26,84 @@ public class ReviewCommentCommandService {
 	private final ReviewRepository reviewRepository;
 	private final WorkspaceMemberRepository workspaceMemberRepository;
 
-	// @Transactional
-	// public IssueCommentResponse createComment(
-	// 	String workspaceCode,
-	// 	String issueKey,
-	// 	CreateIssueCommentRequest request,
-	// 	Long currentWorkspaceMemberId
-	// ) {
-	// 	// Todo: IssueQueryService 구현 후 재사용하는 방식으로 리팩토링
-	// 	Issue issue = issueRepository.findByIssueKeyAndWorkspaceCode(issueKey, workspaceCode)
-	// 		.orElseThrow(() -> new IssueNotFoundException(issueKey, workspaceCode));
-	//
-	// 	Review review = reviewRepository.
-	//
-	// 	WorkspaceMember author = workspaceMemberRepository.findById(currentWorkspaceMemberId)
-	// 		.orElseThrow(() -> new WorkspaceMemberNotFoundException(currentWorkspaceMemberId, workspaceCode));
-	//
-	// 	IssueComment parentComment = null;
-	// 	if (request.hasParentComment()) {
-	// 		parentComment = (IssueComment)commentRepository.findById(request.parentCommentId())
-	// 			.orElseThrow(() -> new CommentNotFoundException(request.parentCommentId()));
-	// 	}
-	//
-	// 	// Todo: 아래로 리팩토링 가능
-	// 	// IssueComment parentComment = request.hasParentComment()
-	// 	// 	? findIssueComment(request.parentCommentId())
-	// 	// 	: null;
-	//
-	// 	IssueComment comment = IssueComment.builder()
-	// 		.content(request.content())
-	// 		.issue(issue)
-	// 		.parentComment(parentComment)
-	// 		.author(author)
-	// 		.build();
-	//
-	// 	commentRepository.save(comment);
-	//
-	// 	return IssueCommentResponse.from(comment);
-	// }
-	//
-	// @Transactional
-	// public IssueCommentResponse updateComment(
-	// 	String workspaceCode,
-	// 	String issueKey,
-	// 	Long commentId,
-	// 	UpdateIssueCommentRequest request,
-	// 	Long currentWorkspaceMemberId
-	// ) {
-	// 	WorkspaceMember currentWorkspaceMember = workspaceMemberRepository.findById(currentWorkspaceMemberId)
-	// 		.orElseThrow(() -> new WorkspaceMemberNotFoundException(currentWorkspaceMemberId, workspaceCode));
-	//
-	// 	IssueComment comment = commentRepository.findByIdAndIssue_IssueKeyAndIssue_WorkspaceCode(commentId, issueKey,
-	// 			workspaceCode)
-	// 		.orElseThrow(() -> new CommentNotFoundException(commentId));
-	//
-	// 	comment.validateCanEdit(currentWorkspaceMember);
-	// 	comment.updateContent(request.content());
-	//
-	// 	return IssueCommentResponse.from(comment);
-	// }
-	//
-	// @Transactional
-	// public void deleteComment(
-	// 	String workspaceCode,
-	// 	String issueKey,
-	// 	Long commentId,
-	// 	Long currentWorkspaceMemberId
-	// ) {
-	// 	WorkspaceMember currentWorkspaceMember = workspaceMemberRepository.findById(currentWorkspaceMemberId)
-	// 		.orElseThrow(() -> new WorkspaceMemberNotFoundException(currentWorkspaceMemberId, workspaceCode));
-	//
-	// 	IssueComment comment = commentRepository.findByIdAndIssue_IssueKeyAndIssue_WorkspaceCode(commentId, issueKey,
-	// 			workspaceCode)
-	// 		.orElseThrow(() -> new CommentNotFoundException(commentId));
-	//
-	// 	comment.validateCanEdit(currentWorkspaceMember);
-	// 	comment.softDelete(currentWorkspaceMemberId);
-	// }
+	@Transactional
+	public ReviewCommentResponse createComment(
+		String workspaceCode,
+		String issueKey,
+		Long reviewId,
+		CreateReviewCommentRequest request,
+		Long currentWorkspaceMemberId
+	) {
+		// Todo: IssueQueryService 구현 후 재사용하는 방식으로 리팩토링
+		// Todo: ReviewNotFoundException을 만들자, 근데 issueKey, workspaceCode 정보가 필요할까?
+		Review review = reviewRepository.findByIdAndIssueKeyAndWorkspaceCode(reviewId, issueKey, workspaceCode)
+			.orElseThrow(
+				() -> new ResourceNotFoundException(String.format(
+					"Review was not found with review id: %d, issue key: %s, workspace code: %s",
+					reviewId, issueKey, workspaceCode)));
+
+		WorkspaceMember author = workspaceMemberRepository.findById(currentWorkspaceMemberId)
+			.orElseThrow(() -> new WorkspaceMemberNotFoundException(currentWorkspaceMemberId, workspaceCode));
+
+		ReviewComment parentComment = null;
+		if (request.hasParentComment()) {
+			parentComment = (ReviewComment)commentRepository.findById(request.parentCommentId())
+				.orElseThrow(() -> new CommentNotFoundException(request.parentCommentId()));
+		}
+
+		// Todo: 아래로 리팩토링 가능
+		// IssueComment parentComment = request.hasParentComment()
+		// 	? findIssueComment(request.parentCommentId())
+		// 	: null;
+
+		ReviewComment comment = ReviewComment.builder()
+			.content(request.content())
+			.review(review)
+			.parentComment(parentComment)
+			.author(author)
+			.build();
+
+		commentRepository.save(comment);
+
+		return ReviewCommentResponse.from(comment);
+	}
+
+	@Transactional
+	public ReviewCommentResponse updateComment(
+		String workspaceCode,
+		String issueKey,
+		Long reviewId,
+		Long commentId,
+		UpdateReviewCommentRequest request,
+		Long currentWorkspaceMemberId
+	) {
+		WorkspaceMember currentWorkspaceMember = workspaceMemberRepository.findById(currentWorkspaceMemberId)
+			.orElseThrow(() -> new WorkspaceMemberNotFoundException(currentWorkspaceMemberId, workspaceCode));
+
+		ReviewComment comment = commentRepository.findByIdAndReview_IdAndReview_IssueKey(commentId, reviewId, issueKey)
+			.orElseThrow(() -> new CommentNotFoundException(commentId));
+
+		comment.validateCanEdit(currentWorkspaceMember);
+		comment.updateContent(request.content());
+
+		return ReviewCommentResponse.from(comment);
+	}
+
+	@Transactional
+	public void deleteComment(
+		String workspaceCode,
+		String issueKey,
+		Long reviewId,
+		Long commentId,
+		Long currentWorkspaceMemberId
+	) {
+		WorkspaceMember currentWorkspaceMember = workspaceMemberRepository.findById(currentWorkspaceMemberId)
+			.orElseThrow(() -> new WorkspaceMemberNotFoundException(currentWorkspaceMemberId, workspaceCode));
+
+		ReviewComment comment = commentRepository.findByIdAndReview_IdAndReview_IssueKey(commentId, reviewId, issueKey)
+			.orElseThrow(() -> new CommentNotFoundException(commentId));
+
+		comment.validateCanEdit(currentWorkspaceMember);
+		comment.softDelete(currentWorkspaceMemberId);
+	}
 }

--- a/backend/src/main/java/com/tissue/api/comment/service/command/ReviewCommentCommandService.java
+++ b/backend/src/main/java/com/tissue/api/comment/service/command/ReviewCommentCommandService.java
@@ -1,0 +1,96 @@
+package com.tissue.api.comment.service.command;
+
+import org.springframework.stereotype.Service;
+
+import com.tissue.api.comment.domain.repository.CommentRepository;
+import com.tissue.api.review.domain.repository.ReviewRepository;
+import com.tissue.api.workspacemember.domain.repository.WorkspaceMemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewCommentCommandService {
+
+	private final CommentRepository commentRepository;
+	private final ReviewRepository reviewRepository;
+	private final WorkspaceMemberRepository workspaceMemberRepository;
+
+	// @Transactional
+	// public IssueCommentResponse createComment(
+	// 	String workspaceCode,
+	// 	String issueKey,
+	// 	CreateIssueCommentRequest request,
+	// 	Long currentWorkspaceMemberId
+	// ) {
+	// 	// Todo: IssueQueryService 구현 후 재사용하는 방식으로 리팩토링
+	// 	Issue issue = issueRepository.findByIssueKeyAndWorkspaceCode(issueKey, workspaceCode)
+	// 		.orElseThrow(() -> new IssueNotFoundException(issueKey, workspaceCode));
+	//
+	// 	Review review = reviewRepository.
+	//
+	// 	WorkspaceMember author = workspaceMemberRepository.findById(currentWorkspaceMemberId)
+	// 		.orElseThrow(() -> new WorkspaceMemberNotFoundException(currentWorkspaceMemberId, workspaceCode));
+	//
+	// 	IssueComment parentComment = null;
+	// 	if (request.hasParentComment()) {
+	// 		parentComment = (IssueComment)commentRepository.findById(request.parentCommentId())
+	// 			.orElseThrow(() -> new CommentNotFoundException(request.parentCommentId()));
+	// 	}
+	//
+	// 	// Todo: 아래로 리팩토링 가능
+	// 	// IssueComment parentComment = request.hasParentComment()
+	// 	// 	? findIssueComment(request.parentCommentId())
+	// 	// 	: null;
+	//
+	// 	IssueComment comment = IssueComment.builder()
+	// 		.content(request.content())
+	// 		.issue(issue)
+	// 		.parentComment(parentComment)
+	// 		.author(author)
+	// 		.build();
+	//
+	// 	commentRepository.save(comment);
+	//
+	// 	return IssueCommentResponse.from(comment);
+	// }
+	//
+	// @Transactional
+	// public IssueCommentResponse updateComment(
+	// 	String workspaceCode,
+	// 	String issueKey,
+	// 	Long commentId,
+	// 	UpdateIssueCommentRequest request,
+	// 	Long currentWorkspaceMemberId
+	// ) {
+	// 	WorkspaceMember currentWorkspaceMember = workspaceMemberRepository.findById(currentWorkspaceMemberId)
+	// 		.orElseThrow(() -> new WorkspaceMemberNotFoundException(currentWorkspaceMemberId, workspaceCode));
+	//
+	// 	IssueComment comment = commentRepository.findByIdAndIssue_IssueKeyAndIssue_WorkspaceCode(commentId, issueKey,
+	// 			workspaceCode)
+	// 		.orElseThrow(() -> new CommentNotFoundException(commentId));
+	//
+	// 	comment.validateCanEdit(currentWorkspaceMember);
+	// 	comment.updateContent(request.content());
+	//
+	// 	return IssueCommentResponse.from(comment);
+	// }
+	//
+	// @Transactional
+	// public void deleteComment(
+	// 	String workspaceCode,
+	// 	String issueKey,
+	// 	Long commentId,
+	// 	Long currentWorkspaceMemberId
+	// ) {
+	// 	WorkspaceMember currentWorkspaceMember = workspaceMemberRepository.findById(currentWorkspaceMemberId)
+	// 		.orElseThrow(() -> new WorkspaceMemberNotFoundException(currentWorkspaceMemberId, workspaceCode));
+	//
+	// 	IssueComment comment = commentRepository.findByIdAndIssue_IssueKeyAndIssue_WorkspaceCode(commentId, issueKey,
+	// 			workspaceCode)
+	// 		.orElseThrow(() -> new CommentNotFoundException(commentId));
+	//
+	// 	comment.validateCanEdit(currentWorkspaceMember);
+	// 	comment.softDelete(currentWorkspaceMemberId);
+	// }
+}

--- a/backend/src/main/java/com/tissue/api/common/validator/annotation/size/text/LongText.java
+++ b/backend/src/main/java/com/tissue/api/common/validator/annotation/size/text/LongText.java
@@ -13,7 +13,7 @@ import jakarta.validation.constraints.Size;
 @Retention(RetentionPolicy.RUNTIME)
 @Constraint(validatedBy = {})
 @Size(
-	max = 5000,
+	max = 2000,
 	message = "{valid.size.long}"
 )
 public @interface LongText {

--- a/backend/src/main/java/com/tissue/api/issue/domain/Issue.java
+++ b/backend/src/main/java/com/tissue/api/issue/domain/Issue.java
@@ -134,16 +134,15 @@ public abstract class Issue extends WorkspaceContextBaseEntity {
 	private Issue parentIssue;
 
 	@OneToMany(mappedBy = "parentIssue")
-	private final List<Issue> childIssues = new ArrayList<>();
+	private List<Issue> childIssues = new ArrayList<>();
 
 	@OneToMany(mappedBy = "sourceIssue", cascade = CascadeType.ALL, orphanRemoval = true)
-	private final List<IssueRelation> outgoingRelations = new ArrayList<>();
+	private List<IssueRelation> outgoingRelations = new ArrayList<>();
 
 	@OneToMany(mappedBy = "targetIssue", cascade = CascadeType.ALL, orphanRemoval = true)
-	private final List<IssueRelation> incomingRelations = new ArrayList<>();
+	private List<IssueRelation> incomingRelations = new ArrayList<>();
 
-	@OneToMany(cascade = CascadeType.ALL)
-	@JoinColumn(name = "ISSUE_ID")
+	@OneToMany(mappedBy = "issue", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<IssueReviewer> reviewers = new ArrayList<>();
 
 	@Column(nullable = false)
@@ -151,7 +150,7 @@ public abstract class Issue extends WorkspaceContextBaseEntity {
 
 	@OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
 	@JoinColumn(name = "ISSUE_ID")
-	private final List<IssueAssignee> assignees = new ArrayList<>();
+	private List<IssueAssignee> assignees = new ArrayList<>();
 
 	public void requestReview() {
 		validateReviewersExist();
@@ -167,7 +166,7 @@ public abstract class Issue extends WorkspaceContextBaseEntity {
 		validateReviewerLimit();
 		validateIsReviewer(reviewer);
 
-		reviewers.add(new IssueReviewer(reviewer));
+		reviewers.add(new IssueReviewer(reviewer, this));
 	}
 
 	public void removeReviewer(WorkspaceMember workspaceMember) {

--- a/backend/src/main/java/com/tissue/api/review/domain/IssueReviewer.java
+++ b/backend/src/main/java/com/tissue/api/review/domain/IssueReviewer.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.tissue.api.common.entity.WorkspaceContextBaseEntity;
 import com.tissue.api.common.exception.type.InvalidOperationException;
+import com.tissue.api.issue.domain.Issue;
 import com.tissue.api.review.domain.enums.ReviewStatus;
 import com.tissue.api.workspacemember.domain.WorkspaceMember;
 
@@ -31,31 +32,35 @@ public class IssueReviewer extends WorkspaceContextBaseEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "ISSUE_ID", nullable = false)
+	private Issue issue;
+
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "REVIEWER_ID", nullable = false)
 	private WorkspaceMember reviewer;
 
 	@OneToMany(mappedBy = "issueReviewer", cascade = CascadeType.ALL, orphanRemoval = true)
 	private final List<Review> reviews = new ArrayList<>();
 
-	public IssueReviewer(WorkspaceMember reviewer) {
+	public IssueReviewer(WorkspaceMember reviewer, Issue issue) {
 		this.reviewer = reviewer;
+		this.issue = issue;
 	}
 
 	public Review addReview(
 		ReviewStatus status,
 		String title,
-		String content,
-		int reviewRound
+		String content
 	) {
 		// 해당 라운드에 이미 리뷰가 있는지 확인
-		validateNoReviewInRound(reviewRound);
+		validateNoReviewInRound(issue.getCurrentReviewRound());
 
 		Review review = Review.builder()
 			.issueReviewer(this)
 			.status(status)
 			.title(title)
 			.content(content)
-			.reviewRound(reviewRound)
+			.reviewRound(issue.getCurrentReviewRound())
 			.build();
 		this.reviews.add(review);
 

--- a/backend/src/main/java/com/tissue/api/review/domain/Review.java
+++ b/backend/src/main/java/com/tissue/api/review/domain/Review.java
@@ -49,6 +49,9 @@ public class Review extends WorkspaceContextBaseEntity {
 	@Column(nullable = false)
 	private int reviewRound;
 
+	@Column(nullable = false)
+	private String workspaceCode;
+
 	@Builder
 	public Review(
 		IssueReviewer issueReviewer,
@@ -62,6 +65,7 @@ public class Review extends WorkspaceContextBaseEntity {
 		this.title = title;
 		this.content = content;
 		this.reviewRound = reviewRound;
+		this.workspaceCode = getWorkspaceCode();
 	}
 
 	public void updateStatus(ReviewStatus status) {

--- a/backend/src/main/java/com/tissue/api/review/domain/Review.java
+++ b/backend/src/main/java/com/tissue/api/review/domain/Review.java
@@ -52,6 +52,9 @@ public class Review extends WorkspaceContextBaseEntity {
 	@Column(nullable = false)
 	private String workspaceCode;
 
+	@Column
+	private String issueKey;
+
 	@Builder
 	public Review(
 		IssueReviewer issueReviewer,
@@ -65,12 +68,21 @@ public class Review extends WorkspaceContextBaseEntity {
 		this.title = title;
 		this.content = content;
 		this.reviewRound = reviewRound;
-		this.workspaceCode = getWorkspaceCode();
+		this.workspaceCode = issueReviewer.getIssue().getWorkspaceCode();
+		this.issueKey = issueReviewer.getIssue().getIssueKey();
 	}
 
 	public void updateStatus(ReviewStatus status) {
 		validateCanUpdateStatus();
 		this.status = status;
+	}
+
+	public void updateTitle(String title) {
+		this.title = title;
+	}
+
+	public void updateContent(String content) {
+		this.content = content;
 	}
 
 	public void validateIsAuthor(Long workspaceMemberId) {
@@ -85,18 +97,6 @@ public class Review extends WorkspaceContextBaseEntity {
 				)
 			);
 		}
-	}
-
-	public void updateTitle(String title) {
-		this.title = title;
-	}
-
-	public void updateContent(String content) {
-		this.content = content;
-	}
-
-	public String getWorkspaceCode() {
-		return issueReviewer.getReviewer().getWorkspaceCode();
 	}
 
 	private void validateCanUpdateStatus() {

--- a/backend/src/main/java/com/tissue/api/review/domain/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/tissue/api/review/domain/repository/ReviewRepository.java
@@ -1,8 +1,12 @@
 package com.tissue.api.review.domain.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.tissue.api.review.domain.Review;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+	Optional<Review> findByIdAndIssueKeyAndWorkspaceCode(Long reviewId, String issueKey, String workspaceCode);
 }

--- a/backend/src/main/java/com/tissue/api/review/service/command/ReviewCommandService.java
+++ b/backend/src/main/java/com/tissue/api/review/service/command/ReviewCommandService.java
@@ -59,8 +59,7 @@ public class ReviewCommandService {
 		Review review = issueReviewer.addReview(
 			request.status(),
 			request.title(),
-			request.content(),
-			issue.getCurrentReviewRound()
+			request.content()
 		);
 
 		Review savedReview = reviewRepository.save(review);
@@ -127,8 +126,7 @@ public class ReviewCommandService {
 	private Review findReview(Long id) {
 		return reviewRepository.findById(id)
 			.orElseThrow(
-				() -> new ResourceNotFoundException(String.format("Review was not found with reviewId: %d", id))
-			);
+				() -> new ResourceNotFoundException(String.format("Review was not found with reviewId: %d", id)));
 	}
 
 	private void updateIssueStatusBasedOnReviewStatus(Issue issue, ReviewStatus reviewStatus) {

--- a/backend/src/main/java/com/tissue/api/team/domain/repository/TeamRepository.java
+++ b/backend/src/main/java/com/tissue/api/team/domain/repository/TeamRepository.java
@@ -1,4 +1,4 @@
-package com.tissue.api.team.domain.respository;
+package com.tissue.api.team.domain.repository;
 
 import java.util.List;
 import java.util.Optional;

--- a/backend/src/main/java/com/tissue/api/team/service/command/TeamCommandService.java
+++ b/backend/src/main/java/com/tissue/api/team/service/command/TeamCommandService.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.tissue.api.common.enums.ColorType;
 import com.tissue.api.common.exception.type.ResourceNotFoundException;
 import com.tissue.api.team.domain.Team;
-import com.tissue.api.team.domain.respository.TeamRepository;
+import com.tissue.api.team.domain.repository.TeamRepository;
 import com.tissue.api.team.presentation.dto.request.CreateTeamRequest;
 import com.tissue.api.team.presentation.dto.request.UpdateTeamColorRequest;
 import com.tissue.api.team.presentation.dto.request.UpdateTeamRequest;

--- a/backend/src/main/java/com/tissue/api/team/service/query/TeamQueryService.java
+++ b/backend/src/main/java/com/tissue/api/team/service/query/TeamQueryService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.tissue.api.team.domain.Team;
-import com.tissue.api.team.domain.respository.TeamRepository;
+import com.tissue.api.team.domain.repository.TeamRepository;
 import com.tissue.api.team.presentation.dto.response.GetTeamsResponse;
 
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/tissue/api/team/validator/TeamValidator.java
+++ b/backend/src/main/java/com/tissue/api/team/validator/TeamValidator.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component;
 
 import com.tissue.api.common.exception.type.InvalidOperationException;
 import com.tissue.api.team.domain.Team;
-import com.tissue.api.team.domain.respository.TeamRepository;
+import com.tissue.api.team.domain.repository.TeamRepository;
 
 import lombok.RequiredArgsConstructor;
 

--- a/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceMemberCommandService.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceMemberCommandService.java
@@ -10,7 +10,7 @@ import com.tissue.api.common.exception.type.ResourceNotFoundException;
 import com.tissue.api.position.domain.Position;
 import com.tissue.api.position.domain.repository.PositionRepository;
 import com.tissue.api.team.domain.Team;
-import com.tissue.api.team.domain.respository.TeamRepository;
+import com.tissue.api.team.domain.repository.TeamRepository;
 import com.tissue.api.workspacemember.domain.WorkspaceMember;
 import com.tissue.api.workspacemember.domain.repository.WorkspaceMemberRepository;
 import com.tissue.api.workspacemember.exception.WorkspaceMemberNotFoundException;

--- a/backend/src/test/java/com/tissue/api/comment/service/command/IssueCommentCommandServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/comment/service/command/IssueCommentCommandServiceIT.java
@@ -86,7 +86,7 @@ class IssueCommentCommandServiceIT extends ServiceIntegrationTestHelper {
 	}
 
 	@Test
-	@DisplayName("댓글에 대한 대댓글 작성에 성공한다")
+	@DisplayName("이슈 댓글에 대한 대댓글 작성에 성공한다")
 	void createIssueReplyComment_success() {
 		// given
 		Long currentWorkspaceMemberId = 1L;

--- a/backend/src/test/java/com/tissue/api/comment/service/command/IssueCommentCommandServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/comment/service/command/IssueCommentCommandServiceIT.java
@@ -1,0 +1,263 @@
+package com.tissue.api.comment.service.command;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.tissue.api.comment.domain.Comment;
+import com.tissue.api.comment.domain.enums.CommentStatus;
+import com.tissue.api.comment.presentation.dto.request.CreateIssueCommentRequest;
+import com.tissue.api.comment.presentation.dto.request.UpdateIssueCommentRequest;
+import com.tissue.api.comment.presentation.dto.response.IssueCommentResponse;
+import com.tissue.api.common.exception.type.ForbiddenOperationException;
+import com.tissue.api.common.exception.type.InvalidOperationException;
+import com.tissue.api.issue.presentation.dto.request.create.CreateStoryRequest;
+import com.tissue.api.issue.presentation.dto.response.create.CreateStoryResponse;
+import com.tissue.api.member.presentation.dto.response.SignupMemberResponse;
+import com.tissue.api.workspace.presentation.dto.response.CreateWorkspaceResponse;
+import com.tissue.helper.ServiceIntegrationTestHelper;
+
+class IssueCommentCommandServiceIT extends ServiceIntegrationTestHelper {
+
+	String workspaceCode;
+	String issueKey;
+
+	@BeforeEach
+	void setUp() {
+		// 멤버 생성
+		SignupMemberResponse testUser = memberFixture.createMember("testuser", "test@test.com");
+		SignupMemberResponse testUser2 = memberFixture.createMember("testuser2", "test2@test.com");
+		SignupMemberResponse testUser3 = memberFixture.createMember("testuser3", "test3@test.com");
+
+		// 워크스페이스 생성
+		CreateWorkspaceResponse createWorkspace = workspaceFixture.createWorkspace(testUser.memberId());
+
+		workspaceCode = createWorkspace.code();
+
+		// 멤버가 워크스페이스에 참가
+		workspaceParticipationCommandService.joinWorkspace(workspaceCode, testUser2.memberId());
+		workspaceParticipationCommandService.joinWorkspace(workspaceCode, testUser3.memberId());
+
+		// Story 타입 이슈 생성
+		CreateStoryRequest createStoryRequest = CreateStoryRequest.builder()
+			.title("Test Story")
+			.content("Test Story")
+			.userStory("Test Story User Story")
+			.build();
+
+		CreateStoryResponse response = (CreateStoryResponse)issueCommandService.createIssue(
+			workspaceCode,
+			createStoryRequest
+		);
+
+		issueKey = response.issueKey();
+	}
+
+	@AfterEach
+	public void tearDown() {
+		databaseCleaner.execute();
+	}
+
+	@Test
+	@DisplayName("특정 이슈에 댓글 작성을 성공한다")
+	void createIssueComment_success() {
+		// given
+		Long currentWorkspaceMemberId = 1L;
+
+		CreateIssueCommentRequest request = new CreateIssueCommentRequest(
+			"Test Comment",
+			null
+		);
+
+		// when
+		IssueCommentResponse response = issueCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			request,
+			currentWorkspaceMemberId
+		);
+
+		// then
+		assertThat(response.author().workspaceMemberId()).isEqualTo(currentWorkspaceMemberId);
+		assertThat(response.content()).isEqualTo("Test Comment");
+	}
+
+	@Test
+	@DisplayName("댓글에 대한 대댓글 작성에 성공한다")
+	void createIssueReplyComment_success() {
+		// given
+		Long currentWorkspaceMemberId = 1L;
+
+		CreateIssueCommentRequest firstCommentRequest = new CreateIssueCommentRequest(
+			"Test Comment",
+			null
+		);
+
+		IssueCommentResponse firstCommentResponse = issueCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			firstCommentRequest,
+			currentWorkspaceMemberId
+		);
+
+		CreateIssueCommentRequest replyCommentRequest = new CreateIssueCommentRequest(
+			"Reply Comment",
+			firstCommentResponse.id()
+		);
+
+		// when
+		IssueCommentResponse response = issueCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			replyCommentRequest,
+			currentWorkspaceMemberId
+		);
+
+		// then
+		assertThat(response.content()).isEqualTo("Reply Comment");
+		assertThat(response.author().workspaceMemberId()).isEqualTo(currentWorkspaceMemberId);
+	}
+
+	@Test
+	@DisplayName("대댓글에 대한 대댓글 작성을 시도하면 예외가 발생한다")
+	void createReplyComment_ofReplyComment_throwsException() {
+		// given
+		Long currentWorkspaceMemberId = 1L;
+
+		CreateIssueCommentRequest parentCommentRequest = new CreateIssueCommentRequest(
+			"Test Comment",
+			null
+		);
+
+		IssueCommentResponse parentCommentResponse = issueCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			parentCommentRequest,
+			currentWorkspaceMemberId
+		);
+
+		CreateIssueCommentRequest childCommentRequest = new CreateIssueCommentRequest(
+			"Reply Comment",
+			parentCommentResponse.id()
+		);
+
+		IssueCommentResponse childCommentResponse = issueCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			childCommentRequest,
+			currentWorkspaceMemberId
+		);
+
+		// when & then
+		CreateIssueCommentRequest request = new CreateIssueCommentRequest(
+			"Reply comment of reply comment",
+			childCommentResponse.id()
+		);
+
+		assertThatThrownBy(() -> issueCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			request,
+			currentWorkspaceMemberId
+		)).isInstanceOf(InvalidOperationException.class);
+	}
+
+	@Test
+	@DisplayName("댓글 작성자는 자신의 댓글을 수정할 수 있다")
+	void updateComment_byAuthor_success() {
+		// given
+		Long currentWorkspaceMemberId = 1L;
+
+		CreateIssueCommentRequest createCommentRequest = new CreateIssueCommentRequest(
+			"Test Comment",
+			null
+		);
+
+		IssueCommentResponse createCommentResponse = issueCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			createCommentRequest,
+			currentWorkspaceMemberId
+		);
+
+		UpdateIssueCommentRequest request = new UpdateIssueCommentRequest("Update Comment");
+
+		// when
+		IssueCommentResponse response = issueCommentCommandService.updateComment(
+			workspaceCode,
+			issueKey,
+			createCommentResponse.id(),
+			request,
+			currentWorkspaceMemberId
+		);
+
+		// then
+		assertThat(response.author().workspaceMemberId()).isEqualTo(currentWorkspaceMemberId);
+		assertThat(response.content()).isEqualTo("Update Comment");
+	}
+
+	@Test
+	@DisplayName("댓글 작성자가 아니지만 댓글 수정을 시도하는 경우 예외가 발생한다")
+	void updateComment_notAuthor_throwsException() {
+		// given
+		Long currentWorkspaceMemberId = 1L;
+		Long notAuthorWorkspaceMemberId = 2L;
+
+		CreateIssueCommentRequest createCommentRequest = new CreateIssueCommentRequest(
+			"Test Comment",
+			null
+		);
+
+		IssueCommentResponse createCommentResponse = issueCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			createCommentRequest,
+			currentWorkspaceMemberId
+		);
+
+		UpdateIssueCommentRequest request = new UpdateIssueCommentRequest("Update Comment");
+
+		// when & then
+		assertThatThrownBy(() -> issueCommentCommandService.updateComment(
+			workspaceCode,
+			issueKey,
+			createCommentResponse.id(),
+			request,
+			notAuthorWorkspaceMemberId
+		)).isInstanceOf(ForbiddenOperationException.class);
+	}
+
+	@Test
+	@DisplayName("댓글을 삭제하면 삭제된 댓글의 상태는 DELETED로 변한다")
+	void deleteComment_success_commentStatusBecomesDELETED() {
+		// given
+		Long currentWorkspaceMemberId = 1L;
+
+		CreateIssueCommentRequest createCommentRequest = new CreateIssueCommentRequest(
+			"Test Comment",
+			null
+		);
+
+		IssueCommentResponse createCommentResponse = issueCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			createCommentRequest,
+			currentWorkspaceMemberId
+		);
+
+		// when
+		issueCommentCommandService.deleteComment(
+			workspaceCode,
+			issueKey,
+			createCommentResponse.id(),
+			currentWorkspaceMemberId
+		);
+
+		// then
+		Comment comment = commentRepository.findById(createCommentResponse.id()).get();
+		assertThat(comment.getStatus()).isEqualTo(CommentStatus.DELETED);
+	}
+}

--- a/backend/src/test/java/com/tissue/api/comment/service/command/ReviewCommentCommandServiceIT.java
+++ b/backend/src/test/java/com/tissue/api/comment/service/command/ReviewCommentCommandServiceIT.java
@@ -1,0 +1,206 @@
+package com.tissue.api.comment.service.command;
+
+import static com.tissue.api.review.domain.enums.ReviewStatus.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.tissue.api.comment.presentation.dto.request.CreateReviewCommentRequest;
+import com.tissue.api.comment.presentation.dto.request.UpdateReviewCommentRequest;
+import com.tissue.api.comment.presentation.dto.response.ReviewCommentResponse;
+import com.tissue.api.issue.domain.enums.IssueStatus;
+import com.tissue.api.issue.presentation.dto.request.UpdateIssueStatusRequest;
+import com.tissue.api.issue.presentation.dto.request.create.CreateStoryRequest;
+import com.tissue.api.issue.presentation.dto.response.create.CreateStoryResponse;
+import com.tissue.api.member.presentation.dto.response.SignupMemberResponse;
+import com.tissue.api.review.presentation.dto.request.CreateReviewRequest;
+import com.tissue.api.workspace.presentation.dto.response.CreateWorkspaceResponse;
+import com.tissue.helper.ServiceIntegrationTestHelper;
+
+class ReviewCommentCommandServiceIT extends ServiceIntegrationTestHelper {
+
+	String workspaceCode;
+	String issueKey;
+
+	@BeforeEach
+	void setUp() {
+		// 멤버 생성
+		SignupMemberResponse testUser = memberFixture.createMember("testuser", "test@test.com");
+		SignupMemberResponse testUser2 = memberFixture.createMember("testuser2", "test2@test.com");
+		SignupMemberResponse testUser3 = memberFixture.createMember("testuser3", "test3@test.com");
+
+		Long requesterWorkspaceMemberId = 1L; // testUser
+		Long reviewerWorkspaceMemberId = 2L; // testUser2
+
+		// 워크스페이스 생성
+		CreateWorkspaceResponse createWorkspace = workspaceFixture.createWorkspace(testUser.memberId());
+
+		workspaceCode = createWorkspace.code();
+
+		// 멤버가 워크스페이스에 참가
+		workspaceParticipationCommandService.joinWorkspace(workspaceCode, testUser2.memberId());
+		workspaceParticipationCommandService.joinWorkspace(workspaceCode, testUser3.memberId());
+
+		// Story 타입 이슈 생성
+		CreateStoryRequest createStoryRequest = CreateStoryRequest.builder()
+			.title("Test Story")
+			.content("Test Story")
+			.userStory("Test Story User Story")
+			.build();
+
+		CreateStoryResponse response = (CreateStoryResponse)issueCommandService.createIssue(
+			workspaceCode,
+			createStoryRequest
+		);
+
+		issueKey = response.issueKey();
+
+		// 작업자 등록
+		assigneeCommandService.addAssignee(
+			workspaceCode,
+			issueKey,
+			requesterWorkspaceMemberId
+		);
+
+		// 리뷰어 등록
+		reviewerCommandService.addReviewer(
+			workspaceCode,
+			issueKey,
+			reviewerWorkspaceMemberId, // testUser2를 리뷰어로 등록
+			requesterWorkspaceMemberId // testUser는 요청자
+		);
+
+		// 이슈 상태를 IN_PROGRESS로 변경
+		issueCommandService.updateIssueStatus(
+			workspaceCode,
+			issueKey,
+			requesterWorkspaceMemberId,
+			new UpdateIssueStatusRequest(IssueStatus.IN_PROGRESS)
+		);
+
+		// 리뷰 요청
+		reviewerCommandService.requestReview(
+			workspaceCode,
+			issueKey,
+			requesterWorkspaceMemberId
+		);
+
+		// 리뷰 등록
+		CreateReviewRequest createReviewRequest = new CreateReviewRequest(CHANGES_REQUESTED, "Title", "Content");
+
+		reviewCommandService.createReview(
+			workspaceCode,
+			issueKey,
+			reviewerWorkspaceMemberId,
+			createReviewRequest
+		);
+	}
+
+	@AfterEach
+	public void tearDown() {
+		databaseCleaner.execute();
+	}
+
+	@Test
+	@DisplayName("특정 리뷰에 댓글 작성을 성공한다")
+	void createReviewComment_success() {
+		// given
+		Long currentWorkspaceMemberId = 1L;
+		Long reviewId = 1L;
+
+		CreateReviewCommentRequest request = new CreateReviewCommentRequest(
+			"Test Comment",
+			null
+		);
+
+		// when
+		ReviewCommentResponse response = reviewCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			reviewId,
+			request,
+			currentWorkspaceMemberId
+		);
+
+		// then
+		assertThat(response.author().workspaceMemberId()).isEqualTo(currentWorkspaceMemberId);
+		assertThat(response.content()).isEqualTo("Test Comment");
+	}
+
+	@Test
+	@DisplayName("리뷰 댓글에 대한 대댓글 작성에 성공한다")
+	void createReviewReplyComment_success() {
+		// given
+		Long currentWorkspaceMemberId = 1L;
+		Long reviewId = 1L;
+
+		CreateReviewCommentRequest parentCommentRequest = new CreateReviewCommentRequest(
+			"Test Comment",
+			null
+		);
+
+		ReviewCommentResponse parentCommentResponse = reviewCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			reviewId,
+			parentCommentRequest,
+			currentWorkspaceMemberId
+		);
+
+		CreateReviewCommentRequest replyCommentRequest = new CreateReviewCommentRequest(
+			"Reply Comment",
+			parentCommentResponse.id()
+		);
+
+		// when
+		ReviewCommentResponse response = reviewCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			reviewId,
+			replyCommentRequest,
+			currentWorkspaceMemberId
+		);
+
+		// then
+		assertThat(response.content()).isEqualTo("Reply Comment");
+		assertThat(response.author().workspaceMemberId()).isEqualTo(currentWorkspaceMemberId);
+	}
+
+	@Test
+	@DisplayName("댓글 작성자는 자신의 댓글을 수정할 수 있다")
+	void updateReviewComment_byAuthor_success() {
+		// given
+		Long currentWorkspaceMemberId = 1L;
+		Long reviewId = 1L;
+
+		CreateReviewCommentRequest createRequest = new CreateReviewCommentRequest(
+			"Test Comment",
+			null
+		);
+
+		ReviewCommentResponse createResponse = reviewCommentCommandService.createComment(
+			workspaceCode,
+			issueKey,
+			reviewId,
+			createRequest,
+			currentWorkspaceMemberId
+		);
+
+		UpdateReviewCommentRequest updateRequest = new UpdateReviewCommentRequest("Update Comment");
+
+		ReviewCommentResponse updateResponse = reviewCommentCommandService.updateComment(
+			workspaceCode,
+			issueKey,
+			reviewId,
+			createResponse.id(),
+			updateRequest,
+			currentWorkspaceMemberId
+		);
+
+		// then
+		assertThat(updateResponse.content()).isEqualTo("Update Comment");
+	}
+}

--- a/backend/src/test/java/com/tissue/helper/ServiceIntegrationTestHelper.java
+++ b/backend/src/test/java/com/tissue/helper/ServiceIntegrationTestHelper.java
@@ -24,7 +24,7 @@ import com.tissue.api.review.domain.repository.ReviewRepository;
 import com.tissue.api.review.service.command.ReviewCommandService;
 import com.tissue.api.review.service.command.ReviewerCommandService;
 import com.tissue.api.security.PasswordEncoder;
-import com.tissue.api.team.domain.respository.TeamRepository;
+import com.tissue.api.team.domain.repository.TeamRepository;
 import com.tissue.api.team.service.command.TeamCommandService;
 import com.tissue.api.team.service.query.TeamQueryService;
 import com.tissue.api.util.WorkspaceCodeParser;

--- a/backend/src/test/java/com/tissue/helper/ServiceIntegrationTestHelper.java
+++ b/backend/src/test/java/com/tissue/helper/ServiceIntegrationTestHelper.java
@@ -6,6 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.tissue.api.assignee.service.command.AssigneeCommandService;
+import com.tissue.api.comment.domain.repository.CommentRepository;
+import com.tissue.api.comment.service.command.IssueCommentCommandService;
 import com.tissue.api.invitation.domain.repository.InvitationRepository;
 import com.tissue.api.invitation.service.command.InvitationCommandService;
 import com.tissue.api.invitation.service.query.InvitationQueryService;
@@ -114,6 +116,8 @@ public abstract class ServiceIntegrationTestHelper {
 	protected ReviewerCommandService reviewerCommandService;
 	@Autowired
 	protected AssigneeCommandService assigneeCommandService;
+	@Autowired
+	protected IssueCommentCommandService issueCommentCommandService;
 
 	/**
 	 * Validator
@@ -144,6 +148,8 @@ public abstract class ServiceIntegrationTestHelper {
 	protected ReviewRepository reviewRepository;
 	@Autowired
 	protected IssueReviewerRepository issueReviewerRepository;
+	@Autowired
+	protected CommentRepository commentRepository;
 
 	/**
 	 * Fixture

--- a/backend/src/test/java/com/tissue/helper/ServiceIntegrationTestHelper.java
+++ b/backend/src/test/java/com/tissue/helper/ServiceIntegrationTestHelper.java
@@ -8,6 +8,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.tissue.api.assignee.service.command.AssigneeCommandService;
 import com.tissue.api.comment.domain.repository.CommentRepository;
 import com.tissue.api.comment.service.command.IssueCommentCommandService;
+import com.tissue.api.comment.service.command.ReviewCommentCommandService;
 import com.tissue.api.invitation.domain.repository.InvitationRepository;
 import com.tissue.api.invitation.service.command.InvitationCommandService;
 import com.tissue.api.invitation.service.query.InvitationQueryService;
@@ -118,6 +119,8 @@ public abstract class ServiceIntegrationTestHelper {
 	protected AssigneeCommandService assigneeCommandService;
 	@Autowired
 	protected IssueCommentCommandService issueCommentCommandService;
+	@Autowired
+	protected ReviewCommentCommandService reviewCommentCommandService;
 
 	/**
 	 * Validator


### PR DESCRIPTION
## 🚀 설명
- `Comment`를 상속받는 `IssueComment`, `ReviewComment`를 통해 이슈 또는 리뷰에 대한 댓글 작성 기능을 구현

---
## ✅ 변경 사항
- [x] `IssueComment` 생성/수정/삭제 API
- [x] `ReviewComment` 생성/수정/삭제 API
- [x] `Issue` <-> `IssueReviewer` 양방향 관계로 변경
- [x] 관련 테스트 추가

---
## 🚩 관련 이슈, PR
- #196 

---
## 📖 참고