### PR TITLE
Feat/#201 `RandomNicknameGenerator` 추가, 기본 별칭 설정 방식 변경

### DIFF
--- a/backend/src/main/java/com/tissue/api/global/config/WorkspaceConfig.java
+++ b/backend/src/main/java/com/tissue/api/global/config/WorkspaceConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.tissue.api.member.service.query.MemberQueryService;
 import com.tissue.api.security.PasswordEncoder;
+import com.tissue.api.util.RandomNicknameGenerator;
 import com.tissue.api.util.WorkspaceCodeGenerator;
 import com.tissue.api.workspace.domain.repository.WorkspaceRepository;
 import com.tissue.api.workspace.service.command.create.RetryCodeGenerationOnExceptionService;
@@ -24,6 +25,7 @@ public class WorkspaceConfig {
 	private final WorkspaceRepository workspaceRepository;
 	private final WorkspaceMemberRepository workspaceMemberRepository;
 	private final WorkspaceCodeGenerator workspaceCodeGenerator;
+	private final RandomNicknameGenerator randomNicknameGenerator;
 	private final PasswordEncoder passwordEncoder;
 
 	/**
@@ -37,6 +39,7 @@ public class WorkspaceConfig {
 			workspaceRepository,
 			workspaceMemberRepository,
 			workspaceCodeGenerator,
+			randomNicknameGenerator,
 			passwordEncoder
 		);
 	}

--- a/backend/src/main/java/com/tissue/api/invitation/domain/Invitation.java
+++ b/backend/src/main/java/com/tissue/api/invitation/domain/Invitation.java
@@ -3,7 +3,6 @@ package com.tissue.api.invitation.domain;
 import com.tissue.api.common.entity.BaseEntity;
 import com.tissue.api.member.domain.Member;
 import com.tissue.api.workspace.domain.Workspace;
-import com.tissue.api.workspacemember.domain.WorkspaceMember;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -69,16 +68,7 @@ public class Invitation extends BaseEntity {
 		return addInvitation(member, workspace, InvitationStatus.PENDING);
 	}
 
-	public WorkspaceMember accept() {
-		changeStatus(InvitationStatus.ACCEPTED);
-		return WorkspaceMember.addCollaboratorWorkspaceMember(this.member, this.workspace);
-	}
-
-	public void reject() {
-		changeStatus(InvitationStatus.REJECTED);
-	}
-
-	private void changeStatus(InvitationStatus status) {
+	public void updateStatus(InvitationStatus status) {
 		this.status = status;
 	}
 }

--- a/backend/src/main/java/com/tissue/api/util/RandomNicknameGenerator.java
+++ b/backend/src/main/java/com/tissue/api/util/RandomNicknameGenerator.java
@@ -1,0 +1,65 @@
+package com.tissue.api.util;
+
+import java.util.Random;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RandomNicknameGenerator {
+
+	private static final int NUMERIC_SUFFIX_LENGTH = 3;
+
+	private enum Adjective {
+		HAPPY, SWIFT, CLEVER, BRIGHT, CALM, WISE, KIND, BOLD, BRAVE, CREATIVE, GENTLE,
+		HONEST, JOYFUL;
+
+		private static final Random RANDOM = new Random();
+
+		public static Adjective random() {
+			return values()[RANDOM.nextInt(values().length)];
+		}
+
+		@Override
+		public String toString() {
+			// HAPPY -> Happy 형태로 변환
+			return name().charAt(0) + name().substring(1).toLowerCase();
+		}
+	}
+
+	private enum Animal {
+		PANDA, EAGLE, TIGER, DOLPHIN, LION, WOLF, BEAR, FOX, DEER, ELEPHANT, FALCON,
+		GAZELLE, HAWK, IGUANA, JAGUAR, KOALA, PENGUIN, RABBIT, SEAL, TURTLE, UNICORN,
+		WHALE, ZEBRA;
+
+		private static final Random RANDOM = new Random();
+
+		public static Animal random() {
+			return values()[RANDOM.nextInt(values().length)];
+		}
+
+		@Override
+		public String toString() {
+			// PANDA -> Panda 형태로 변환
+			return name().charAt(0) + name().substring(1).toLowerCase();
+		}
+	}
+
+	public String generateNickname() {
+		String randomNumber = generateRandomNumber();
+		return Adjective.random().toString() + Animal.random().toString() + randomNumber;
+	}
+
+	private String generateRandomNumber() {
+		StringBuilder sb = new StringBuilder();
+		Random random = new Random();
+
+		for (int i = 0; i < NUMERIC_SUFFIX_LENGTH; i++) {
+			sb.append(random.nextInt(10));
+		}
+
+		return sb.toString();
+	}
+}

--- a/backend/src/main/java/com/tissue/api/workspacemember/domain/WorkspaceMember.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/domain/WorkspaceMember.java
@@ -86,6 +86,13 @@ public class WorkspaceMember extends BaseEntity {
 		this.workspaceCode = workspace.getCode();
 	}
 
+	/**
+	 * Todo
+	 *  - addOwnerWorkspaceMember, addMemberWorkspaceMember 등을 만들어서 사용하지 않고
+	 *  그냥 addWorkspaceMember 사용하기?
+	 *  - 권한에 따른 로직 전개는 분기문을 사용해도 괜찮을듯?
+	 *  - if OWNER -> increaseMyWorkspaceCount() 까지 포함
+	 */
 	public static WorkspaceMember addWorkspaceMember(
 		Member member,
 		Workspace workspace,
@@ -107,19 +114,21 @@ public class WorkspaceMember extends BaseEntity {
 
 	public static WorkspaceMember addOwnerWorkspaceMember(
 		Member member,
-		Workspace workspace
+		Workspace workspace,
+		String nickname
 	) {
 		member.increaseMyWorkspaceCount();
 		workspace.increaseMemberCount();
-		return addWorkspaceMember(member, workspace, WorkspaceRole.OWNER, member.getEmail());
+		return addWorkspaceMember(member, workspace, WorkspaceRole.OWNER, nickname);
 	}
 
-	public static WorkspaceMember addCollaboratorWorkspaceMember(
+	public static WorkspaceMember addMemberWorkspaceMember(
 		Member member,
-		Workspace workspace
+		Workspace workspace,
+		String nickname
 	) {
 		workspace.increaseMemberCount();
-		return addWorkspaceMember(member, workspace, WorkspaceRole.MEMBER, member.getEmail());
+		return addWorkspaceMember(member, workspace, WorkspaceRole.MEMBER, nickname);
 	}
 
 	public void remove() {

--- a/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceParticipationCommandService.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/service/command/WorkspaceParticipationCommandService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.tissue.api.common.exception.type.InvalidOperationException;
 import com.tissue.api.member.domain.Member;
 import com.tissue.api.member.service.query.MemberQueryService;
+import com.tissue.api.util.RandomNicknameGenerator;
 import com.tissue.api.workspace.domain.Workspace;
 import com.tissue.api.workspace.service.query.WorkspaceQueryService;
 import com.tissue.api.workspacemember.domain.WorkspaceMember;
@@ -24,6 +25,7 @@ public class WorkspaceParticipationCommandService {
 	private final WorkspaceQueryService workspaceQueryService;
 	private final MemberQueryService memberQueryService;
 	private final WorkspaceMemberRepository workspaceMemberRepository;
+	private final RandomNicknameGenerator randomNicknameGenerator;
 
 	/**
 	 * 참여할 워크스페이스의 코드를 통해
@@ -45,7 +47,21 @@ public class WorkspaceParticipationCommandService {
 					memberId, workspaceCode));
 		}
 
-		WorkspaceMember workspaceMember = WorkspaceMember.addCollaboratorWorkspaceMember(member, workspace);
+		/*
+		 * Todo
+		 *  - 워크스페이스 내에서 nickname에 대한 유일성을 보장해야 함
+		 *  - 방법1: existsByWorkspaceCodeAndNickname으로 WorkspaceMember 존재 여부 검사
+		 *    - 최악의 경우 타임스탬프를 사용해서 중복 닉네임 방지 가능 -> 예시: generateNickname + Sys.currentTimeMillis
+		 *    - 이 방법은 동시성 문제는 해결해주지 않음 -> Lock 사용
+		 *  - 방법2: 유일성 제약 예외를 잡아서 처리
+		 *    - Spring-retry를 사용하면 조금더 깔끔하고 선언적으로 처리 가능
+		 *    - Spring-retry는 back-off 옵션도 지원해줌
+		 */
+		WorkspaceMember workspaceMember = WorkspaceMember.addMemberWorkspaceMember(
+			member,
+			workspace,
+			randomNicknameGenerator.generateNickname()
+		);
 		workspaceMemberRepository.save(workspaceMember);
 
 		return JoinWorkspaceResponse.from(workspaceMember);

--- a/backend/src/test/java/com/tissue/integration/service/command/WorkspaceCreateServiceIT.java
+++ b/backend/src/test/java/com/tissue/integration/service/command/WorkspaceCreateServiceIT.java
@@ -84,10 +84,10 @@ class WorkspaceCreateServiceIT extends ServiceIntegrationTestHelper {
 		assertThat(workspaceMember.getRole()).isEqualTo(WorkspaceRole.OWNER);
 	}
 
-	// Todo: 워크스페이스 멤버 별칭 방식 변경 후 수정(이메일 -> 로그인 id)
+	// Todo: 워크스페이스 멤버 별칭 방식 변경 후 수정
 	@Test
 	@Transactional
-	@DisplayName("워크스페이스 생성 시 워크스페이스 멤버(WorkspaceMember)의 별칭(nickname)은 기본적으로 이메일로 설정된다")
+	@DisplayName("워크스페이스 생성 시 생성자인 워크스페이스 멤버(WorkspaceMember)의 별칭(nickname)이 기본적으로 설정된다")
 	void workspaceCreate_WorkspaceMemberDefaultNicknameIsEmail() {
 		// given
 		Member member = testDataFixture.createMember("member1");
@@ -103,10 +103,10 @@ class WorkspaceCreateServiceIT extends ServiceIntegrationTestHelper {
 		// then
 		Workspace workspace = workspaceRepository.findByCode(response.code()).get();
 		assertThat(workspace.getWorkspaceMembers().stream().findFirst().get().getNickname())
-			.isEqualTo(member.getEmail());
+			.isNotNull();
 
 		WorkspaceMember workspaceMember = workspaceMemberRepository.findById(1L).get();
-		assertThat(workspaceMember.getNickname()).isEqualTo(member.getEmail());
+		assertThat(workspaceMember.getNickname()).isNotNull();
 	}
 
 	@Test

--- a/backend/src/test/java/com/tissue/integration/service/command/WorkspaceMemberCommandServiceIT.java
+++ b/backend/src/test/java/com/tissue/integration/service/command/WorkspaceMemberCommandServiceIT.java
@@ -54,7 +54,7 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 	void canRemoveMemberFromWorkspace() {
 		// given
 		Member requesterMember = testDataFixture.createMember("requester");
-		WorkspaceMember requester = WorkspaceMember.addOwnerWorkspaceMember(requesterMember, workspace);
+		WorkspaceMember requester = WorkspaceMember.addOwnerWorkspaceMember(requesterMember, workspace, "testnickname");
 
 		Member targetMember = testDataFixture.createMember("target");
 		WorkspaceMember target = testDataFixture.createWorkspaceMember(targetMember, workspace, WorkspaceRole.MEMBER);
@@ -74,7 +74,7 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 	void cannotKickMemberFromWorkspaceWithInvalidMemberId() {
 		// given
 		Member requesterMember = testDataFixture.createMember("requester");
-		WorkspaceMember requester = WorkspaceMember.addOwnerWorkspaceMember(requesterMember, workspace);
+		WorkspaceMember requester = WorkspaceMember.addOwnerWorkspaceMember(requesterMember, workspace, "testnickname");
 
 		Long invalidMemberId = 999L;
 
@@ -92,7 +92,7 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 	void canUpdateWorkspaceRoleOfWorkspaceMember() {
 		// given
 		Member requesterMember = testDataFixture.createMember("requester");
-		WorkspaceMember requester = WorkspaceMember.addOwnerWorkspaceMember(requesterMember, workspace);
+		WorkspaceMember requester = WorkspaceMember.addOwnerWorkspaceMember(requesterMember, workspace, "testnickname");
 
 		Member targetMember = testDataFixture.createMember("target");
 		WorkspaceMember target = testDataFixture.createWorkspaceMember(targetMember, workspace, WorkspaceRole.MEMBER);
@@ -138,7 +138,7 @@ class WorkspaceMemberCommandServiceIT extends ServiceIntegrationTestHelper {
 	void cannotUpdateWorkspaceRoleToOwner() {
 		// given
 		Member requesterMember = testDataFixture.createMember("requester");
-		WorkspaceMember requester = WorkspaceMember.addOwnerWorkspaceMember(requesterMember, workspace);
+		WorkspaceMember requester = WorkspaceMember.addOwnerWorkspaceMember(requesterMember, workspace, "testnickname");
 
 		Member targetMember = testDataFixture.createMember("target");
 		WorkspaceMember target = testDataFixture.createWorkspaceMember(targetMember, workspace, WorkspaceRole.MEMBER);


### PR DESCRIPTION
## 🚀 설명
- (AsIs) 기존에는 `Member`의 이메일이 기본 별칭으로 사용되었음
  - `email`이나 `loginId`를 별칭으로 사용하고 싶지 않아서 다른 방식을 사용하려고 함
- (ToBe) 랜덤으로 미리 정해 놓은 단어를 조합하고, 랜덤한 숫자를 부여하는 방식으로 기본 별칭을 설정
  - `Animal`과 `Adjective`라는 내부 `enum`을 `RandomNicknameGenerator` 내부에서 정의해서 사용(어차피 강하게 결합 되어서 굳이 밖에서 `enum`을 정의할 필요는 없는 것 같음)
  - 생성되는 별칭은 다음과 같은 형식을 가짐: `Swift` + `Bear` + `123` = `SwiftBear123`
  - 숫자는 1~999 범위 내에서 랜덤하게 정해짐
  - 워크스페이스 내에서만 유일하면 되기 때문에 많은 조합은 필요 없을 거라고 가정하고 구현했음(312000 가지 조합이 가능함)
- 별칭 설정에 대한 동시성 문제는 해결해야 함
  - `Spring-retry` 라이브러리를 사용할 것 같음

## 고민 🤔
- 기존에는 `WorkspaceMember` 엔티티의 생성자나 팩토리 메서드에서 `this.nickname = member.getEmail()` 같은 방식으로 별칭 설정 로직을 캡슐화해서 사용했음
- 그러나 이제는 서비스 계층에서 `RandomNicknameGenerator`를 의존해서, 해당 서비스 계층에서 별칭을 설정해서 사용하는 방식으로 변경했음
- 이 방법으로 사용하게 되면서 `RandomNicknameGenerator`을 필요한 서비스 계층마다 주입해서 사용하는 현상이 반복적으로 나타나게 됨
- 이를 해결하기 위해서 `WorkspaceMemberFactory` 같은걸 만들어서 사용하는게 좋을지 고민이 됨

---
## ✅ 변경 사항
- [x] `RandomNicknameGenerator` 구현
- [x] `RandomNicknameGenerator` 적용

---
## 🚩 관련 이슈, PR
- #201 

---
## 📖 참고