### PR TITLE
Refactor/#207 설정(`XxxConfig`) 클래스에서 구현체를 선택한다

### DIFF
--- a/backend/src/main/java/com/tissue/api/issue/config/IssueConfig.java
+++ b/backend/src/main/java/com/tissue/api/issue/config/IssueConfig.java
@@ -3,24 +3,25 @@ package com.tissue.api.issue.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.tissue.api.common.exception.type.InvalidConfigurationException;
 import com.tissue.api.issue.config.properties.IssueProperties;
 import com.tissue.api.issue.validator.checker.CachedDfsCircularDependencyChecker;
 import com.tissue.api.issue.validator.checker.CircularDependencyChecker;
-import com.tissue.api.issue.validator.checker.DfsCircularDependencyChecker;
 
 @Configuration
 public class IssueConfig {
 
+	/**
+	 * Creates a component that checks circular dependencies between issues.
+	 * Uses a cached DFS implementation for better performance in repeated checks.
+	 *
+	 * @param properties issue properties containing circular dependency cache configurations
+	 * @return circular dependency checker implementation
+	 */
 	@Bean
 	public CircularDependencyChecker circularDependencyChecker(IssueProperties properties) {
-		return switch (properties.circularDependencyChecker().type()) {
-			case DFS -> new DfsCircularDependencyChecker();
-			case CACHED_DFS -> new CachedDfsCircularDependencyChecker(
-				properties.circularDependencyCache().size(),
-				properties.circularDependencyCache().duration()
-			);
-			default -> throw new InvalidConfigurationException("Unknown checker type");
-		};
+		return new CachedDfsCircularDependencyChecker(
+			properties.circularDependencyCache().size(),
+			properties.circularDependencyCache().duration()
+		);
 	}
 }

--- a/backend/src/main/java/com/tissue/api/issue/config/properties/IssueProperties.java
+++ b/backend/src/main/java/com/tissue/api/issue/config/properties/IssueProperties.java
@@ -4,20 +4,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 
 @ConfigurationProperties(prefix = "api.issue")
 public record IssueProperties(
-	@NotNull
-	CircularDependencyCheckerProperties circularDependencyChecker,
 	CircularDependencyCacheProperties circularDependencyCache
 ) {
-	public record CircularDependencyCheckerProperties(
-		@NotNull
-		CircularDependencyCheckerType type
-	) {
-	}
-
 	public record CircularDependencyCacheProperties(
 		@Min(100) @Max(10000)
 		int size,

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -39,8 +39,6 @@ spring:
 
 api:
   issue:
-    circular-dependency-checker:
-      type: CACHED_DFS
     circular-dependency-cache:
       size: 1000
       duration: 1
@@ -63,8 +61,6 @@ spring:
 
 api:
   issue:
-    circular-dependency-checker:
-      type: CACHED_DFS
     circular-dependency-cache:
       size: 1000
       duration: 1
@@ -100,8 +96,6 @@ logging.level:
 
 api:
   issue:
-    circular-dependency-checker:
-      type: CACHED_DFS
     circular-dependency-cache:
       size: 1000
       duration: 1

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -25,8 +25,6 @@ spring:
 
 api:
   issue:
-    circular-dependency-checker:
-      type: CACHED_DFS
     circular-dependency-cache:
       size: 1000
       duration: 1


### PR DESCRIPTION
## 🚀 설명
- (AsIs) `application.yml`에서 사용할 구현체 타입을 명시해서, 해당 설정값으로 설정 클래스에서 분기문으로 선택해서 사용
- (ToBe) 설정 클래스에서 바로 구현체 선택하고 반환

---
## ✅ 변경 사항
- [x] `application.yml`에서 구현체 선택에 대한 설정값 제거
- [x] `IssueConfig`에서 `CachedDfsCircularDependencyChecker` 선택
- [x] `IssueProperties`에서 `CircularDependencyCheckerProperties` 제거(타입 선택 불필요)

---
## 🚩 관련 이슈, PR
- #207 

---
## 📖 참고