### PR TITLE
Refactor/#237 알림(`Notification`) 관련 리팩토링

### DIFF
--- a/backend/src/main/java/com/tissue/api/notification/application/eventhandler/NotificationEventHandler.java
+++ b/backend/src/main/java/com/tissue/api/notification/application/eventhandler/NotificationEventHandler.java
@@ -1,5 +1,6 @@
 package com.tissue.api.notification.application.eventhandler;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -10,6 +11,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.tissue.api.comment.domain.event.IssueCommentAddedEvent;
 import com.tissue.api.comment.domain.event.ReviewCommentAddedEvent;
+import com.tissue.api.common.event.DomainEvent;
 import com.tissue.api.issue.domain.event.IssueAssignedEvent;
 import com.tissue.api.issue.domain.event.IssueCreatedEvent;
 import com.tissue.api.issue.domain.event.IssueParentAssignedEvent;
@@ -19,8 +21,12 @@ import com.tissue.api.issue.domain.event.IssueReviewerAddedEvent;
 import com.tissue.api.issue.domain.event.IssueStatusChangedEvent;
 import com.tissue.api.issue.domain.event.IssueUnassignedEvent;
 import com.tissue.api.issue.domain.event.IssueUpdatedEvent;
+import com.tissue.api.notification.application.service.command.NotificationCommandService;
 import com.tissue.api.notification.application.service.command.NotificationProcessor;
 import com.tissue.api.notification.application.service.command.NotificationTargetService;
+import com.tissue.api.notification.domain.model.Notification;
+import com.tissue.api.notification.domain.model.vo.NotificationMessage;
+import com.tissue.api.notification.domain.service.message.NotificationMessageFactory;
 import com.tissue.api.review.domain.event.ReviewSubmittedEvent;
 import com.tissue.api.sprint.domain.event.SprintCompletedEvent;
 import com.tissue.api.sprint.domain.event.SprintStartedEvent;
@@ -44,8 +50,10 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class NotificationEventHandler {
 
+	private final NotificationCommandService commandService;
 	private final NotificationProcessor notificationProcessor;
 	private final NotificationTargetService targetResolver;
+	private final NotificationMessageFactory notificationMessageFactory;
 
 	/**
 	 * 이슈 생성 이벤트 처리 - 워크스페이스 전체 멤버에게 알림
@@ -55,8 +63,7 @@ public class NotificationEventHandler {
 	public void handleIssueCreated(IssueCreatedEvent event) {
 
 		List<WorkspaceMember> targets = targetResolver.getWorkspaceWideMemberTargets(event.getWorkspaceCode());
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -67,14 +74,10 @@ public class NotificationEventHandler {
 			event.getIssueKey(),
 			event.getWorkspaceCode()
 		);
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
 	}
 
-	// TODO: workspaceCode + id 대신 id만 사용해서 WorkspaceMember 조회
-	//  -> 굳이 workspaceCode를 같이 사용해서 WorkspaceMember를 조회해야 할까?
-	//  -> id만 사용하는게 더 빠른데?
-	//  -> workspace에 속하는 것은 이미 서비스 계층에서 보장해주는데?
 	@Async("notificationTaskExecutor")
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handleIssueAssigned(IssueAssignedEvent event) {
@@ -83,8 +86,8 @@ public class NotificationEventHandler {
 			event.getWorkspaceCode(),
 			event.getAssignedMemberId()
 		);
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -95,8 +98,8 @@ public class NotificationEventHandler {
 			event.getWorkspaceCode(),
 			event.getAssigneeMemberId()
 		);
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -107,8 +110,8 @@ public class NotificationEventHandler {
 			event.getIssueKey(),
 			event.getWorkspaceCode()
 		);
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -119,8 +122,8 @@ public class NotificationEventHandler {
 			event.getIssueKey(),
 			event.getWorkspaceCode()
 		);
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -131,8 +134,8 @@ public class NotificationEventHandler {
 			event.getIssueKey(),
 			event.getWorkspaceCode()
 		);
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -143,8 +146,8 @@ public class NotificationEventHandler {
 			event.getIssueKey(),
 			event.getWorkspaceCode()
 		);
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -155,8 +158,8 @@ public class NotificationEventHandler {
 			event.getIssueKey(),
 			event.getWorkspaceCode()
 		);
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -167,8 +170,8 @@ public class NotificationEventHandler {
 			event.getIssueKey(),
 			event.getWorkspaceCode()
 		);
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -179,8 +182,8 @@ public class NotificationEventHandler {
 			event.getIssueKey(),
 			event.getWorkspaceCode()
 		);
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -191,8 +194,8 @@ public class NotificationEventHandler {
 			event.getIssueKey(),
 			event.getWorkspaceCode()
 		);
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -200,8 +203,8 @@ public class NotificationEventHandler {
 	public void handleSprintStarted(SprintStartedEvent event) {
 
 		List<WorkspaceMember> targets = targetResolver.getWorkspaceWideMemberTargets(event.getWorkspaceCode());
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -209,8 +212,8 @@ public class NotificationEventHandler {
 	public void handleSprintCompleted(SprintCompletedEvent event) {
 
 		List<WorkspaceMember> targets = targetResolver.getWorkspaceWideMemberTargets(event.getWorkspaceCode());
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -218,8 +221,8 @@ public class NotificationEventHandler {
 	public void handleMemberJoinedWorkspace(MemberJoinedWorkspaceEvent event) {
 
 		List<WorkspaceMember> targets = targetResolver.getWorkspaceWideMemberTargets(event.getWorkspaceCode());
-
-		notificationProcessor.processNotification(event, targets);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -230,7 +233,21 @@ public class NotificationEventHandler {
 			event.getWorkspaceCode(),
 			event.getTargetMemberId()
 		);
+		processNotifications(event, targets);
+		// notificationProcessor.processNotification(event, targets);
+	}
 
-		notificationProcessor.processNotification(event, targets);
+	private <T extends DomainEvent> void processNotifications(T event, Collection<WorkspaceMember> targets) {
+		if (targets == null || targets.isEmpty()) {
+			log.debug("No notification targets for event: {}", event.getEventId());
+			return;
+		}
+
+		NotificationMessage message = notificationMessageFactory.createMessage(event);
+
+		for (WorkspaceMember target : targets) {
+			Notification notification = commandService.createNotification(event, target.getMember().getId(), message);
+			notificationProcessor.process(notification);
+		}
 	}
 }

--- a/backend/src/main/java/com/tissue/api/notification/application/service/command/NotificationCommandService.java
+++ b/backend/src/main/java/com/tissue/api/notification/application/service/command/NotificationCommandService.java
@@ -41,7 +41,7 @@ public class NotificationCommandService {
 			.notificationType(event.getNotificationType())
 			.entityReference(entityReference)
 			.actorMemberId(event.getActorMemberId())
-			.actorNickname(actor.getDisplayName())
+			.actorDisplayName(actor.getDisplayName())
 			.message(message)
 			.receiverMemberId(receiverMemberId)
 			.build();

--- a/backend/src/main/java/com/tissue/api/notification/application/service/command/NotificationCommandService.java
+++ b/backend/src/main/java/com/tissue/api/notification/application/service/command/NotificationCommandService.java
@@ -24,7 +24,7 @@ public class NotificationCommandService {
 	private final WorkspaceMemberReader workspaceMemberReader;
 
 	@Transactional
-	public void createNotification(
+	public Notification createNotification(
 		DomainEvent event,
 		Long receiverMemberId,
 		NotificationMessage message
@@ -46,7 +46,7 @@ public class NotificationCommandService {
 			.receiverMemberId(receiverMemberId)
 			.build();
 
-		notificationRepository.save(notification);
+		return notificationRepository.save(notification);
 	}
 
 	@Transactional

--- a/backend/src/main/java/com/tissue/api/notification/application/service/command/NotificationProcessor.java
+++ b/backend/src/main/java/com/tissue/api/notification/application/service/command/NotificationProcessor.java
@@ -1,15 +1,13 @@
 package com.tissue.api.notification.application.service.command;
 
-import java.util.Collection;
+import java.util.List;
 
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
-import com.tissue.api.common.event.DomainEvent;
-import com.tissue.api.common.exception.type.ResourceNotFoundException;
-import com.tissue.api.notification.domain.model.vo.NotificationMessage;
-import com.tissue.api.notification.domain.service.message.NotificationMessageFactory;
-import com.tissue.api.workspacemember.domain.model.WorkspaceMember;
+import com.tissue.api.notification.domain.enums.NotificationChannel;
+import com.tissue.api.notification.domain.model.Notification;
+import com.tissue.api.notification.domain.service.sender.NotificationSender;
+import com.tissue.api.notification.infrastructure.repository.NotificationPreferenceRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,45 +17,28 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class NotificationProcessor {
 
-	private final NotificationCommandService notificationService;
-	private final NotificationMessageFactory notificationMessageFactory;
+	private final List<NotificationSender> senders;
+	private final NotificationPreferenceRepository preferenceRepository;
 
-	/**
-	 * Handles notification processing for the given event and target members.
-	 * Targets are injected externally.
-	 * <p>
-	 * This method uses a best-effort approach.
-	 * Notifications are attempted for all targets, and failures are logged without retry logic.
-	 */
-	// TODO: Consider using Transactional Outbox Pattern
-	public <T extends DomainEvent> void processNotification(
-		T event,
-		Collection<WorkspaceMember> targets
-	) {
-		NotificationMessage message = notificationMessageFactory.createMessage(event);
-
-		int totalTargets = targets.size();
-		int successCount = 0;
-		int failCount = 0;
-
-		for (WorkspaceMember target : targets) {
-			try {
-				notificationService.createNotification(event, target.getId(), message);
-				successCount++;
-			} catch (ResourceNotFoundException e) {
-				failCount++;
-				log.warn("Resource not found while creating notification for member: {}", target.getId(), e);
-			} catch (DataIntegrityViolationException e) {
-				failCount++;
-				log.warn("Data integrity violation while creating notification for member: {}", target.getId(), e);
-			} catch (RuntimeException e) {
-				failCount++;
-				log.error("Failed to create notification for member: {}, message: {}",
-					target.getId(), e.getMessage(), e);
+	public void process(Notification notification) {
+		for (NotificationSender sender : senders) {
+			if (shouldSend(notification, sender.getChannel())) {
+				sender.send(notification);
 			}
 		}
+	}
 
-		log.info("Notification creation summary - type: {}, total: {}, success: {}, fail: {}, event: {}",
-			event.getNotificationType(), totalTargets, successCount, failCount, event.getEventId());
+	private boolean shouldSend(Notification notification, NotificationChannel channel) {
+		return preferenceRepository.findByReceiver(
+				notification.getReceiverMemberId(),
+				notification.getEntityReference().getWorkspaceCode(),
+				notification.getType(),
+				channel
+			)
+			.map(pref -> switch (channel) {
+				case IN_APP -> pref.isInAppEnabled();
+				case EMAIL -> pref.isEmailEnabled();
+			})
+			.orElse(true); // 설정 없으면 수신 허용
 	}
 }

--- a/backend/src/main/java/com/tissue/api/notification/config/NotificationConfig.java
+++ b/backend/src/main/java/com/tissue/api/notification/config/NotificationConfig.java
@@ -12,6 +12,7 @@ import com.tissue.api.workspacemember.application.service.command.WorkspaceMembe
 import lombok.RequiredArgsConstructor;
 
 @Configuration
+// @ComponentScan(basePackageClasses = NotificationSender.class)
 @RequiredArgsConstructor
 public class NotificationConfig {
 
@@ -23,4 +24,6 @@ public class NotificationConfig {
 	public NotificationMessageFactory notificationMessageFactory() {
 		return new SimpleNotificationMessageFactory(messageSource, workspaceMemberReader, argumentFormatter);
 	}
+
+	// TODO(고민중): 사용할 EmailClient 구현체 선택? notification 도메인은 별도의 모듈로 분리 예정?
 }

--- a/backend/src/main/java/com/tissue/api/notification/domain/enums/NotificationChannel.java
+++ b/backend/src/main/java/com/tissue/api/notification/domain/enums/NotificationChannel.java
@@ -1,0 +1,6 @@
+package com.tissue.api.notification.domain.enums;
+
+public enum NotificationChannel {
+	IN_APP,
+	EMAIL
+}

--- a/backend/src/main/java/com/tissue/api/notification/domain/model/Notification.java
+++ b/backend/src/main/java/com/tissue/api/notification/domain/model/Notification.java
@@ -57,7 +57,7 @@ public class Notification extends BaseDateEntity {
 	@Column(nullable = false)
 	private Long actorMemberId;
 
-	private String actorNickname;
+	private String actorDisplayName;
 
 	@Column(nullable = false)
 	private boolean isRead;
@@ -68,7 +68,7 @@ public class Notification extends BaseDateEntity {
 		NotificationType notificationType,
 		EntityReference entityReference,
 		Long actorMemberId,
-		String actorNickname,
+		String actorDisplayName,
 		Long receiverMemberId,
 		NotificationMessage message
 	) {
@@ -76,7 +76,7 @@ public class Notification extends BaseDateEntity {
 		this.type = notificationType;
 		this.entityReference = entityReference;
 		this.actorMemberId = actorMemberId;
-		this.actorNickname = actorNickname;
+		this.actorDisplayName = actorDisplayName;
 		this.receiverMemberId = receiverMemberId;
 		this.message = message;
 		this.isRead = false;

--- a/backend/src/main/java/com/tissue/api/notification/domain/model/NotificationPreference.java
+++ b/backend/src/main/java/com/tissue/api/notification/domain/model/NotificationPreference.java
@@ -1,0 +1,72 @@
+package com.tissue.api.notification.domain.model;
+
+import com.tissue.api.notification.domain.enums.NotificationChannel;
+import com.tissue.api.notification.domain.enums.NotificationType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+	uniqueConstraints = {
+		@UniqueConstraint(
+			name = "UK_NOTIFICATION_PREF",
+			columnNames = {"receiverMemberId", "workspaceCode", "type", "channel"})
+	}
+)
+public class NotificationPreference {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private Long receiverMemberId;
+
+	@Column(nullable = false)
+	private String workspaceCode;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private NotificationType type;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private NotificationChannel channel;
+
+	@Column(nullable = false)
+	private boolean inAppEnabled = true;
+
+	@Column(nullable = false)
+	private boolean emailEnabled = false;
+
+	@Builder
+	public NotificationPreference(
+		Long receiverMemberId,
+		String workspaceCode,
+		NotificationType type,
+		NotificationChannel channel,
+		boolean inAppEnabled,
+		boolean emailEnabled
+	) {
+		this.receiverMemberId = receiverMemberId;
+		this.workspaceCode = workspaceCode;
+		this.type = type;
+		this.channel = channel;
+		this.inAppEnabled = inAppEnabled;
+		this.emailEnabled = emailEnabled;
+	}
+}

--- a/backend/src/main/java/com/tissue/api/notification/domain/service/sender/NotificationSender.java
+++ b/backend/src/main/java/com/tissue/api/notification/domain/service/sender/NotificationSender.java
@@ -1,0 +1,10 @@
+package com.tissue.api.notification.domain.service.sender;
+
+import com.tissue.api.notification.domain.enums.NotificationChannel;
+import com.tissue.api.notification.domain.model.Notification;
+
+public interface NotificationSender {
+	NotificationChannel getChannel();
+
+	void send(Notification notification);
+}

--- a/backend/src/main/java/com/tissue/api/notification/domain/service/sender/email/EmailSender.java
+++ b/backend/src/main/java/com/tissue/api/notification/domain/service/sender/email/EmailSender.java
@@ -1,0 +1,25 @@
+package com.tissue.api.notification.domain.service.sender.email;
+
+import org.springframework.stereotype.Component;
+
+import com.tissue.api.notification.domain.enums.NotificationChannel;
+import com.tissue.api.notification.domain.model.Notification;
+import com.tissue.api.notification.domain.service.sender.NotificationSender;
+
+@Component
+public class EmailSender implements NotificationSender {
+
+	// TODO: 이메일 클라이언트 인터페이스와 구현체 추가
+	// private final EmailClient emailClient;
+
+	@Override
+	public NotificationChannel getChannel() {
+		return NotificationChannel.EMAIL;
+	}
+
+	@Override
+	public void send(Notification notification) {
+		// TODO: EmailClient를 사용한 실제 알림 이메일 전송 작업
+		// TODO: try-catch로 예외 잡고 로깅
+	}
+}

--- a/backend/src/main/java/com/tissue/api/notification/domain/service/sender/inapp/InAppSender.java
+++ b/backend/src/main/java/com/tissue/api/notification/domain/service/sender/inapp/InAppSender.java
@@ -1,0 +1,21 @@
+package com.tissue.api.notification.domain.service.sender.inapp;
+
+import org.springframework.stereotype.Component;
+
+import com.tissue.api.notification.domain.enums.NotificationChannel;
+import com.tissue.api.notification.domain.model.Notification;
+import com.tissue.api.notification.domain.service.sender.NotificationSender;
+
+@Component
+public class InAppSender implements NotificationSender {
+
+	@Override
+	public NotificationChannel getChannel() {
+		return NotificationChannel.IN_APP;
+	}
+
+	@Override
+	public void send(Notification notification) {
+		// TODO: 인앱 알림은 DB 저장만으로 충분, 필요하면 추가적인 작업 수행
+	}
+}

--- a/backend/src/main/java/com/tissue/api/notification/infrastructure/repository/NotificationPreferenceRepository.java
+++ b/backend/src/main/java/com/tissue/api/notification/infrastructure/repository/NotificationPreferenceRepository.java
@@ -1,0 +1,27 @@
+package com.tissue.api.notification.infrastructure.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.tissue.api.notification.domain.enums.NotificationChannel;
+import com.tissue.api.notification.domain.enums.NotificationType;
+import com.tissue.api.notification.domain.model.NotificationPreference;
+
+public interface NotificationPreferenceRepository extends JpaRepository<NotificationPreference, Long> {
+	@Query("""
+		SELECT p FROM NotificationPreference p
+		WHERE p.receiverMemberId = :memberId
+		AND p.workspaceCode = :workspaceCode
+		AND p.type = :type
+		AND p.channel = :channel
+		""")
+	Optional<NotificationPreference> findByReceiver(
+		@Param("memberId") Long memberId,
+		@Param("workspaceCode") String workspaceCode,
+		@Param("type") NotificationType type,
+		@Param("channel") NotificationChannel channel
+	);
+}

--- a/backend/src/test/java/com/tissue/api/notification/application/service/command/NotificationProcessorTest.java
+++ b/backend/src/test/java/com/tissue/api/notification/application/service/command/NotificationProcessorTest.java
@@ -1,0 +1,133 @@
+package com.tissue.api.notification.application.service.command;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.tissue.api.notification.domain.enums.NotificationChannel;
+import com.tissue.api.notification.domain.enums.NotificationType;
+import com.tissue.api.notification.domain.enums.ResourceType;
+import com.tissue.api.notification.domain.model.Notification;
+import com.tissue.api.notification.domain.model.NotificationPreference;
+import com.tissue.api.notification.domain.model.vo.EntityReference;
+import com.tissue.api.notification.domain.service.sender.NotificationSender;
+import com.tissue.api.notification.infrastructure.repository.NotificationPreferenceRepository;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationProcessorTest {
+	@Mock
+	private NotificationPreferenceRepository preferenceRepository;
+
+	@Mock
+	private NotificationSender inAppSender;
+
+	@Mock
+	private NotificationSender emailSender;
+
+	@InjectMocks
+	private NotificationProcessor notificationProcessor;
+
+	@BeforeEach
+	void setup() {
+		when(inAppSender.getChannel()).thenReturn(NotificationChannel.IN_APP);
+		when(emailSender.getChannel()).thenReturn(NotificationChannel.EMAIL);
+
+		// injectMocks 안에서 직접 sender list 주입이 안 되므로
+		notificationProcessor = new NotificationProcessor(
+			List.of(inAppSender, emailSender), preferenceRepository
+		);
+	}
+
+	@Test
+	@DisplayName("설정이 없으면 기본적으로 전송된다")
+	void process_shouldSend_WhenPreferenceNotExists() {
+		// given
+		Notification notification = mock(Notification.class);
+		when(notification.getReceiverMemberId()).thenReturn(1L);
+		when(notification.getType()).thenReturn(NotificationType.ISSUE_CREATED);
+		when(notification.getEntityReference()).thenReturn(
+			EntityReference.builder()
+				.workspaceCode("TESTCODE")
+				.resourceType(ResourceType.ISSUE)
+				.stringKey("ISSUE-1")
+				.build());
+
+		when(preferenceRepository.findByReceiver(any(), any(), any(), any()))
+			.thenReturn(Optional.empty());
+
+		// when
+		notificationProcessor.process(notification);
+
+		// then
+		verify(inAppSender).send(notification);
+		verify(emailSender).send(notification);
+	}
+
+	@Test
+	@DisplayName("설정에서 이메일만 허용된 경우 이메일만 전송된다")
+	void process_shouldOnlySendEmail_WhenPreferenceDisallowsInApp() {
+		// given
+		Notification notification = mock(Notification.class);
+		when(notification.getReceiverMemberId()).thenReturn(1L);
+		when(notification.getType()).thenReturn(NotificationType.ISSUE_CREATED);
+		when(notification.getEntityReference()).thenReturn(
+			EntityReference.builder()
+				.workspaceCode("TESTCODE")
+				.resourceType(ResourceType.ISSUE)
+				.stringKey("ISSUE-1")
+				.build());
+
+		when(preferenceRepository.findByReceiver(any(), any(), any(), eq(NotificationChannel.IN_APP)))
+			.thenReturn(Optional.of(
+				new NotificationPreference(1L, "TEST", NotificationType.ISSUE_CREATED, NotificationChannel.IN_APP,
+					false, false)));
+
+		when(preferenceRepository.findByReceiver(any(), any(), any(), eq(NotificationChannel.EMAIL)))
+			.thenReturn(Optional.of(
+				new NotificationPreference(1L, "TEST", NotificationType.ISSUE_CREATED, NotificationChannel.EMAIL, false,
+					true)));
+
+		// when
+		notificationProcessor.process(notification);
+
+		// then
+		verify(inAppSender, never()).send(any());
+		verify(emailSender).send(notification);
+	}
+
+	@Test
+	@DisplayName("설정에서 모두 차단된 경우 아무 채널도 전송되지 않는다")
+	void process_shouldSendNothing_WhenAllChannelsDisabled() {
+		// given
+		Notification notification = mock(Notification.class);
+		when(notification.getReceiverMemberId()).thenReturn(1L);
+		when(notification.getType()).thenReturn(NotificationType.ISSUE_CREATED);
+		when(notification.getEntityReference()).thenReturn(
+			EntityReference.builder()
+				.workspaceCode("TESTCODE")
+				.resourceType(ResourceType.ISSUE)
+				.stringKey("ISSUE-1")
+				.build());
+
+		when(preferenceRepository.findByReceiver(any(), any(), any(), any()))
+			.thenReturn(Optional.of(
+				new NotificationPreference(1L, "TEST", NotificationType.ISSUE_CREATED, NotificationChannel.IN_APP,
+					false, false)));
+
+		// when
+		notificationProcessor.process(notification);
+
+		// then
+		verify(inAppSender, never()).send(any());
+		verify(emailSender, never()).send(any());
+	}
+}

--- a/backend/src/test/java/com/tissue/unit/service/NotificationEventHandlerTest.java
+++ b/backend/src/test/java/com/tissue/unit/service/NotificationEventHandlerTest.java
@@ -1,9 +1,7 @@
 package com.tissue.unit.service;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -15,13 +13,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.tissue.api.issue.application.service.reader.IssueReader;
 import com.tissue.api.issue.domain.event.IssueCreatedEvent;
-import com.tissue.api.issue.domain.event.IssueUpdatedEvent;
 import com.tissue.api.issue.domain.model.Issue;
 import com.tissue.api.issue.domain.model.enums.IssueType;
+import com.tissue.api.member.domain.model.Member;
 import com.tissue.api.notification.application.eventhandler.NotificationEventHandler;
 import com.tissue.api.notification.application.service.command.NotificationCommandService;
 import com.tissue.api.notification.application.service.command.NotificationProcessor;
 import com.tissue.api.notification.application.service.command.NotificationTargetService;
+import com.tissue.api.notification.domain.model.Notification;
+import com.tissue.api.notification.domain.model.vo.NotificationMessage;
 import com.tissue.api.notification.domain.service.message.NotificationMessageFactory;
 import com.tissue.api.workspacemember.application.service.command.WorkspaceMemberReader;
 import com.tissue.api.workspacemember.domain.model.WorkspaceMember;
@@ -58,118 +58,38 @@ class NotificationEventHandlerTest {
 	@DisplayName("이슈 생성 이벤트 발생 시 워크스페이스 멤버들에게 알림이 처리되어야 함")
 	void handleIssueCreated_ShouldProcessNotificationForAllWorkspaceMembers() {
 		// given
-		Long issueId = 1L;
-		String issueKey = "ISSUE-1";
 		String workspaceCode = "TESTCODE";
 		Long actorId = 123L;
-		IssueType issueType = IssueType.STORY;
 
-		// Issue 모의 설정
 		Issue issue = mock(Issue.class);
-		when(issue.getId()).thenReturn(issueId);
-		when(issue.getIssueKey()).thenReturn(issueKey);
+		when(issue.getIssueKey()).thenReturn("ISSUE-1");
 		when(issue.getWorkspaceCode()).thenReturn(workspaceCode);
-		when(issue.getType()).thenReturn(issueType);
+		when(issue.getType()).thenReturn(IssueType.STORY);
 
-		// 이벤트 생성
 		IssueCreatedEvent event = IssueCreatedEvent.createEvent(issue, actorId);
 
-		// 워크스페이스 멤버 모의 설정
-		List<WorkspaceMember> members = Arrays.asList(
-			mock(WorkspaceMember.class),
-			mock(WorkspaceMember.class)
-		);
+		WorkspaceMember wm1 = mock(WorkspaceMember.class);
+		WorkspaceMember wm2 = mock(WorkspaceMember.class);
+		when(wm1.getMember()).thenReturn(mock(Member.class));
+		when(wm2.getMember()).thenReturn(mock(Member.class));
+		List<WorkspaceMember> members = List.of(wm1, wm2);
 
-		// targetResolver가 워크스페이스 멤버 목록을 반환하도록 설정
 		when(targetService.getWorkspaceWideMemberTargets(workspaceCode)).thenReturn(members);
+
+		NotificationMessage msg = new NotificationMessage("title", "body");
+		when(notificationMessageFactory.createMessage(event)).thenReturn(msg);
+
+		Notification notification1 = mock(Notification.class);
+		Notification notification2 = mock(Notification.class);
+
+		when(notificationService.createNotification(eq(event), anyLong(), eq(msg)))
+			.thenReturn(notification1, notification2);
 
 		// when
 		notificationEventHandler.handleIssueCreated(event);
 
 		// then
-		verify(targetService).getWorkspaceWideMemberTargets(workspaceCode);
-		verify(notificationProcessor).processNotification(event, members);
-	}
-
-	@Test
-	@DisplayName("이슈 업데이트 이벤트 발생 시 이슈 구독자에게 알림이 처리되어야 함")
-	void handleIssueUpdated_ShouldProcessNotificationForIssueSubscribers() {
-		// given
-		Long issueId = 1L;
-		String issueKey = "ISSUE-1";
-		String workspaceCode = "TESTCODE";
-		Long actorId = 123L;
-		IssueType issueType = IssueType.STORY;
-		String title = "Test Issue";
-
-		// Issue 모의 설정
-		Issue issue = mock(Issue.class);
-		when(issue.getId()).thenReturn(issueId);
-		when(issue.getIssueKey()).thenReturn(issueKey);
-		when(issue.getWorkspaceCode()).thenReturn(workspaceCode);
-		when(issue.getType()).thenReturn(issueType);
-		when(issue.getTitle()).thenReturn(title);
-		when(issue.getStoryPoint()).thenReturn(5);
-
-		// 이벤트 생성
-		IssueUpdatedEvent event = IssueUpdatedEvent.createEvent(issue, null, actorId);
-
-		// 이슈 구독자 모의 설정
-		List<WorkspaceMember> subscribers = Arrays.asList(
-			mock(WorkspaceMember.class),
-			mock(WorkspaceMember.class)
-		);
-
-		// targetResolver가 이슈 구독자 목록을 반환하도록 설정
-		when(targetService.getIssueSubscriberTargets(issueKey, workspaceCode)).thenReturn(subscribers);
-
-		// when
-		notificationEventHandler.handleIssueUpdated(event);
-
-		// then
-		verify(targetService).getIssueSubscriberTargets(issueKey, workspaceCode);
-		verify(notificationProcessor).processNotification(event, subscribers);
-	}
-
-	@Test
-	@DisplayName("NotificationProcessor에서 예외가 발생해도 이벤트 핸들러는 예외를 전파하지 않아야 함")
-	void handleIssueCreated_WhenProcessorThrowsException_ShouldNotPropagateException() {
-		// given
-		Long issueId = 1L;
-		String issueKey = "ISSUE-1";
-		String workspaceCode = "TESTCODE";
-		Long actorId = 123L;
-		IssueType issueType = IssueType.STORY;
-
-		// Issue 모의 설정
-		Issue issue = mock(Issue.class);
-		when(issue.getId()).thenReturn(issueId);
-		when(issue.getIssueKey()).thenReturn(issueKey);
-		when(issue.getWorkspaceCode()).thenReturn(workspaceCode);
-		when(issue.getType()).thenReturn(issueType);
-
-		// 이벤트 생성
-		IssueCreatedEvent event = IssueCreatedEvent.createEvent(issue, actorId);
-
-		// 워크스페이스 멤버 모의 설정
-		List<WorkspaceMember> members = Arrays.asList(
-			mock(WorkspaceMember.class),
-			mock(WorkspaceMember.class)
-		);
-
-		// targetResolver가 워크스페이스 멤버 목록을 반환하도록 설정
-		when(targetService.getWorkspaceWideMemberTargets(workspaceCode)).thenReturn(members);
-
-		// processor가 예외를 던지도록 설정
-		doThrow(new RuntimeException("Test exception"))
-			.when(notificationProcessor).processNotification(event, members);
-
-		// when & then
-		assertThatThrownBy(() -> notificationEventHandler.handleIssueCreated(event))
-			.isInstanceOf(RuntimeException.class);
-
-		// 호출 확인
-		verify(targetService).getWorkspaceWideMemberTargets(workspaceCode);
-		verify(notificationProcessor).processNotification(event, members);
+		verify(notificationService, times(2)).createNotification(eq(event), anyLong(), eq(msg));
+		verify(notificationProcessor, times(2)).process(any(Notification.class));
 	}
 }

--- a/backend/src/test/java/com/tissue/unit/service/command/NotificationCommandServiceTest.java
+++ b/backend/src/test/java/com/tissue/unit/service/command/NotificationCommandServiceTest.java
@@ -84,7 +84,7 @@ class NotificationCommandServiceTest {
 		assertThat(savedNotification.getTitle()).isEqualTo(message.title());
 		assertThat(savedNotification.getContent()).isEqualTo(message.content());
 		assertThat(savedNotification.getActorMemberId()).isEqualTo(actorId);
-		assertThat(savedNotification.getActorNickname()).isEqualTo("TestUser");
+		assertThat(savedNotification.getActorDisplayName()).isEqualTo("TestUser");
 		assertThat(savedNotification.isRead()).isFalse();
 	}
 


### PR DESCRIPTION
## 🚀 설명
- `NotificationEventHandler`에서 이벤트에 대한 알림 처리 로직 개선
  - 일부 중복 제거
- `NotificationPreference`를 통해 사용자의 선호에 따라 이벤트와 채널에 따른 알림 수신 여부 설정

---
## ✅ 변경 사항
- [x] `NotificationEventHandler` 리팩토링
- [x] `NotificationProcessor`의 `process()` 추가 및 사용
  - [x] `NotificationSender` 추가 
- [x] `NotificationPreference` 추가
  - [x] `NotificationChannel` 추가

---
## 추가적으로 구현해야 할 것
- `EmailClient` 구현체 필요
  - Amazon SES 사용?
- `NotificationPreference` 자체를 설정(업데이트)하는 서비스 구현 필요

---
## 🚩 관련 이슈, PR
- #237 

---
## 📖 참고
- 