### PR TITLE
Feat/#241 이메일 알림 인터페이스 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -76,7 +76,8 @@ jacocoTestReport {
                             "**/*Reader",
                             "**/*Handler",
                             "**/*Entity",
-                            "**/RandomNicknameGenerator*"
+                            "**/RandomNicknameGenerator*",
+                            "**/*Client*"
                     ])
                 })
         )
@@ -115,7 +116,8 @@ jacocoTestReport {
                         "**.*Reader",
                         "**.*Handler",
                         "**.*Entity",
-                        "**.RandomNicknameGenerator*"
+                        "**.RandomNicknameGenerator*",
+                        "**.*Client*"
                 ]
             }
         }

--- a/backend/src/main/java/com/tissue/api/notification/application/eventhandler/NotificationEventHandler.java
+++ b/backend/src/main/java/com/tissue/api/notification/application/eventhandler/NotificationEventHandler.java
@@ -24,9 +24,11 @@ import com.tissue.api.issue.domain.event.IssueUpdatedEvent;
 import com.tissue.api.notification.application.service.command.NotificationCommandService;
 import com.tissue.api.notification.application.service.command.NotificationProcessor;
 import com.tissue.api.notification.application.service.command.NotificationTargetService;
+import com.tissue.api.notification.domain.model.ActivityLog;
 import com.tissue.api.notification.domain.model.Notification;
 import com.tissue.api.notification.domain.model.vo.NotificationMessage;
 import com.tissue.api.notification.domain.service.message.NotificationMessageFactory;
+import com.tissue.api.notification.infrastructure.repository.ActivityLogRepository;
 import com.tissue.api.review.domain.event.ReviewSubmittedEvent;
 import com.tissue.api.sprint.domain.event.SprintCompletedEvent;
 import com.tissue.api.sprint.domain.event.SprintStartedEvent;
@@ -54,6 +56,7 @@ public class NotificationEventHandler {
 	private final NotificationProcessor notificationProcessor;
 	private final NotificationTargetService targetResolver;
 	private final NotificationMessageFactory notificationMessageFactory;
+	private final ActivityLogRepository activityLogRepository;
 
 	/**
 	 * 이슈 생성 이벤트 처리 - 워크스페이스 전체 멤버에게 알림
@@ -75,7 +78,6 @@ public class NotificationEventHandler {
 			event.getWorkspaceCode()
 		);
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -87,7 +89,6 @@ public class NotificationEventHandler {
 			event.getAssignedMemberId()
 		);
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -99,7 +100,6 @@ public class NotificationEventHandler {
 			event.getAssigneeMemberId()
 		);
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -111,7 +111,6 @@ public class NotificationEventHandler {
 			event.getWorkspaceCode()
 		);
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -123,7 +122,6 @@ public class NotificationEventHandler {
 			event.getWorkspaceCode()
 		);
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -135,7 +133,6 @@ public class NotificationEventHandler {
 			event.getWorkspaceCode()
 		);
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -147,7 +144,6 @@ public class NotificationEventHandler {
 			event.getWorkspaceCode()
 		);
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -159,7 +155,6 @@ public class NotificationEventHandler {
 			event.getWorkspaceCode()
 		);
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -171,7 +166,6 @@ public class NotificationEventHandler {
 			event.getWorkspaceCode()
 		);
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -183,7 +177,6 @@ public class NotificationEventHandler {
 			event.getWorkspaceCode()
 		);
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -195,7 +188,6 @@ public class NotificationEventHandler {
 			event.getWorkspaceCode()
 		);
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -204,7 +196,6 @@ public class NotificationEventHandler {
 
 		List<WorkspaceMember> targets = targetResolver.getWorkspaceWideMemberTargets(event.getWorkspaceCode());
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -213,7 +204,6 @@ public class NotificationEventHandler {
 
 		List<WorkspaceMember> targets = targetResolver.getWorkspaceWideMemberTargets(event.getWorkspaceCode());
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -222,7 +212,6 @@ public class NotificationEventHandler {
 
 		List<WorkspaceMember> targets = targetResolver.getWorkspaceWideMemberTargets(event.getWorkspaceCode());
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	@Async("notificationTaskExecutor")
@@ -234,16 +223,17 @@ public class NotificationEventHandler {
 			event.getTargetMemberId()
 		);
 		processNotifications(event, targets);
-		// notificationProcessor.processNotification(event, targets);
 	}
 
 	private <T extends DomainEvent> void processNotifications(T event, Collection<WorkspaceMember> targets) {
+
+		NotificationMessage message = notificationMessageFactory.createMessage(event);
+		activityLogRepository.save(ActivityLog.from(event, message));
+
 		if (targets == null || targets.isEmpty()) {
 			log.debug("No notification targets for event: {}", event.getEventId());
 			return;
 		}
-
-		NotificationMessage message = notificationMessageFactory.createMessage(event);
 
 		for (WorkspaceMember target : targets) {
 			Notification notification = commandService.createNotification(event, target.getMember().getId(), message);

--- a/backend/src/main/java/com/tissue/api/notification/application/service/command/NotificationCommandService.java
+++ b/backend/src/main/java/com/tissue/api/notification/application/service/command/NotificationCommandService.java
@@ -34,6 +34,11 @@ public class NotificationCommandService {
 			event.getWorkspaceCode()
 		);
 
+		WorkspaceMember receiver = workspaceMemberReader.findWorkspaceMember(
+			receiverMemberId,
+			event.getWorkspaceCode()
+		);
+
 		EntityReference entityReference = event.createEntityReference();
 
 		Notification notification = Notification.builder()
@@ -44,6 +49,7 @@ public class NotificationCommandService {
 			.actorDisplayName(actor.getDisplayName())
 			.message(message)
 			.receiverMemberId(receiverMemberId)
+			.receiverEmail(receiver.getEmail())
 			.build();
 
 		return notificationRepository.save(notification);

--- a/backend/src/main/java/com/tissue/api/notification/application/service/command/NotificationPreferenceService.java
+++ b/backend/src/main/java/com/tissue/api/notification/application/service/command/NotificationPreferenceService.java
@@ -1,0 +1,43 @@
+package com.tissue.api.notification.application.service.command;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.tissue.api.notification.domain.enums.NotificationChannel;
+import com.tissue.api.notification.domain.model.NotificationPreference;
+import com.tissue.api.notification.infrastructure.repository.NotificationPreferenceRepository;
+import com.tissue.api.notification.presentation.dto.request.UpdateNotificationPreferenceRequest;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationPreferenceService {
+
+	private final NotificationPreferenceRepository repository;
+
+	// TODO: 현재는 EMAIL로 채널이 하드코딩. 추후 채널이 늘어나면 request에서 꺼내서 사용하기.
+	@Transactional
+	public void updatePreference(
+		String workspaceCode,
+		Long memberId,
+		UpdateNotificationPreferenceRequest request
+	) {
+		NotificationPreference pref = repository.findByReceiver(
+			memberId,
+			workspaceCode,
+			request.type(),
+			NotificationChannel.EMAIL
+		).orElse(NotificationPreference.builder()
+			.receiverMemberId(memberId)
+			.workspaceCode(workspaceCode)
+			.type(request.type())
+			.channel(NotificationChannel.EMAIL)
+			.build()
+		);
+
+		pref.updateEnabled(request.enabled());
+
+		repository.save(pref);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/notification/application/service/command/NotificationProcessor.java
+++ b/backend/src/main/java/com/tissue/api/notification/application/service/command/NotificationProcessor.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 
 import com.tissue.api.notification.domain.enums.NotificationChannel;
 import com.tissue.api.notification.domain.model.Notification;
+import com.tissue.api.notification.domain.model.NotificationPreference;
 import com.tissue.api.notification.domain.service.sender.NotificationSender;
 import com.tissue.api.notification.infrastructure.repository.NotificationPreferenceRepository;
 
@@ -35,10 +36,7 @@ public class NotificationProcessor {
 				notification.getType(),
 				channel
 			)
-			.map(pref -> switch (channel) {
-				case IN_APP -> pref.isInAppEnabled();
-				case EMAIL -> pref.isEmailEnabled();
-			})
+			.map(NotificationPreference::isEnabled)
 			.orElse(true); // 설정 없으면 수신 허용
 	}
 }

--- a/backend/src/main/java/com/tissue/api/notification/domain/model/ActivityLog.java
+++ b/backend/src/main/java/com/tissue/api/notification/domain/model/ActivityLog.java
@@ -1,0 +1,73 @@
+package com.tissue.api.notification.domain.model;
+
+import java.util.UUID;
+
+import com.tissue.api.common.entity.BaseDateEntity;
+import com.tissue.api.common.event.DomainEvent;
+import com.tissue.api.notification.domain.enums.NotificationType;
+import com.tissue.api.notification.domain.model.vo.EntityReference;
+import com.tissue.api.notification.domain.model.vo.NotificationMessage;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActivityLog extends BaseDateEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	private UUID eventId;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	private NotificationType type;
+
+	@Embedded
+	private EntityReference entityReference;
+
+	@Embedded
+	private NotificationMessage message;
+
+	@Column(nullable = false)
+	private Long actorMemberId;
+
+	@Builder
+	public ActivityLog(
+		UUID eventId,
+		NotificationType type,
+		EntityReference entityReference,
+		NotificationMessage message,
+		Long actorMemberId
+	) {
+		this.eventId = eventId;
+		this.type = type;
+		this.entityReference = entityReference;
+		this.message = message;
+		this.actorMemberId = actorMemberId;
+	}
+
+	public static ActivityLog from(DomainEvent event, NotificationMessage message) {
+		return ActivityLog.builder()
+			.eventId(event.getEventId())
+			.type(event.getNotificationType())
+			.entityReference(event.createEntityReference())
+			.message(message)
+			.actorMemberId(event.getActorMemberId())
+			.build();
+	}
+}

--- a/backend/src/main/java/com/tissue/api/notification/domain/model/Notification.java
+++ b/backend/src/main/java/com/tissue/api/notification/domain/model/Notification.java
@@ -44,6 +44,9 @@ public class Notification extends BaseDateEntity {
 	@Column(nullable = false)
 	private Long receiverMemberId;
 
+	@Column(nullable = false)
+	private String receiverEmail;
+
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private NotificationType type;
@@ -70,6 +73,7 @@ public class Notification extends BaseDateEntity {
 		Long actorMemberId,
 		String actorDisplayName,
 		Long receiverMemberId,
+		String receiverEmail,
 		NotificationMessage message
 	) {
 		this.eventId = eventId;
@@ -78,6 +82,7 @@ public class Notification extends BaseDateEntity {
 		this.actorMemberId = actorMemberId;
 		this.actorDisplayName = actorDisplayName;
 		this.receiverMemberId = receiverMemberId;
+		this.receiverEmail = receiverEmail;
 		this.message = message;
 		this.isRead = false;
 	}

--- a/backend/src/main/java/com/tissue/api/notification/domain/model/NotificationPreference.java
+++ b/backend/src/main/java/com/tissue/api/notification/domain/model/NotificationPreference.java
@@ -48,10 +48,7 @@ public class NotificationPreference {
 	private NotificationChannel channel;
 
 	@Column(nullable = false)
-	private boolean inAppEnabled = true;
-
-	@Column(nullable = false)
-	private boolean emailEnabled = false;
+	private boolean enabled = true;
 
 	@Builder
 	public NotificationPreference(
@@ -59,14 +56,16 @@ public class NotificationPreference {
 		String workspaceCode,
 		NotificationType type,
 		NotificationChannel channel,
-		boolean inAppEnabled,
-		boolean emailEnabled
+		boolean enabled
 	) {
 		this.receiverMemberId = receiverMemberId;
 		this.workspaceCode = workspaceCode;
 		this.type = type;
 		this.channel = channel;
-		this.inAppEnabled = inAppEnabled;
-		this.emailEnabled = emailEnabled;
+		this.enabled = enabled;
+	}
+
+	public void updateEnabled(boolean enabled) {
+		this.enabled = enabled;
 	}
 }

--- a/backend/src/main/java/com/tissue/api/notification/domain/service/sender/EmailClient.java
+++ b/backend/src/main/java/com/tissue/api/notification/domain/service/sender/EmailClient.java
@@ -1,0 +1,5 @@
+package com.tissue.api.notification.domain.service.sender;
+
+public interface EmailClient {
+	void send(String to, String subject, String body);
+}

--- a/backend/src/main/java/com/tissue/api/notification/domain/service/sender/email/EmailSender.java
+++ b/backend/src/main/java/com/tissue/api/notification/domain/service/sender/email/EmailSender.java
@@ -30,11 +30,11 @@ public class EmailSender implements NotificationSender {
 		// TODO: 최선 노력 방식(best effort)이어도 Exception을 잡는게 좋은 방식인가?
 		//  일단 발생 가능성이 더 높은 세세한 예외를 위에서 잡아야 하는건 알겠음
 		try {
-			// String to = notification.getReceiverEmail();
+			String to = notification.getReceiverEmail();
 			String subject = notification.getTitle();
 			String body = notification.getContent();
 
-			emailClient.send("email@placeholder", subject, body);
+			emailClient.send(to, subject, body);
 		} catch (Exception e) {
 			log.warn("failed to send email notification: receiver member id={}, title={}, cause={}",
 				notification.getReceiverMemberId(),

--- a/backend/src/main/java/com/tissue/api/notification/domain/service/sender/email/EmailSender.java
+++ b/backend/src/main/java/com/tissue/api/notification/domain/service/sender/email/EmailSender.java
@@ -4,13 +4,18 @@ import org.springframework.stereotype.Component;
 
 import com.tissue.api.notification.domain.enums.NotificationChannel;
 import com.tissue.api.notification.domain.model.Notification;
+import com.tissue.api.notification.domain.service.sender.EmailClient;
 import com.tissue.api.notification.domain.service.sender.NotificationSender;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 @Component
+@Slf4j
+@RequiredArgsConstructor
 public class EmailSender implements NotificationSender {
 
-	// TODO: 이메일 클라이언트 인터페이스와 구현체 추가
-	// private final EmailClient emailClient;
+	private final EmailClient emailClient;
 
 	@Override
 	public NotificationChannel getChannel() {
@@ -21,5 +26,21 @@ public class EmailSender implements NotificationSender {
 	public void send(Notification notification) {
 		// TODO: EmailClient를 사용한 실제 알림 이메일 전송 작업
 		// TODO: try-catch로 예외 잡고 로깅
+		// TODO: 수신자(receiver)의 이메일 필드를 Notification에 추가하는게 좋읗 듯(여기서 조회하기 싫음)
+		// TODO: 최선 노력 방식(best effort)이어도 Exception을 잡는게 좋은 방식인가?
+		//  일단 발생 가능성이 더 높은 세세한 예외를 위에서 잡아야 하는건 알겠음
+		try {
+			// String to = notification.getReceiverEmail();
+			String subject = notification.getTitle();
+			String body = notification.getContent();
+
+			emailClient.send("email@placeholder", subject, body);
+		} catch (Exception e) {
+			log.warn("failed to send email notification: receiver member id={}, title={}, cause={}",
+				notification.getReceiverMemberId(),
+				notification.getTitle(),
+				e.getMessage(),
+				e);
+		}
 	}
 }

--- a/backend/src/main/java/com/tissue/api/notification/infrastructure/email/DummyEmailClient.java
+++ b/backend/src/main/java/com/tissue/api/notification/infrastructure/email/DummyEmailClient.java
@@ -1,0 +1,18 @@
+package com.tissue.api.notification.infrastructure.email;
+
+import org.springframework.stereotype.Component;
+
+import com.tissue.api.notification.domain.service.sender.EmailClient;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class DummyEmailClient implements EmailClient {
+
+	@Override
+	public void send(String to, String subject, String body) {
+		// 실제 전송하지 않고 로그로만 출력
+		log.info("[DummyEmailClient] Email sent - receiver: {}, title: {}\nbody: {}", to, subject, body);
+	}
+}

--- a/backend/src/main/java/com/tissue/api/notification/infrastructure/repository/ActivityLogRepository.java
+++ b/backend/src/main/java/com/tissue/api/notification/infrastructure/repository/ActivityLogRepository.java
@@ -1,0 +1,8 @@
+package com.tissue.api.notification.infrastructure.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.tissue.api.notification.domain.model.ActivityLog;
+
+public interface ActivityLogRepository extends JpaRepository<ActivityLog, Long> {
+}

--- a/backend/src/main/java/com/tissue/api/notification/presentation/controller/NotificationPreferenceController.java
+++ b/backend/src/main/java/com/tissue/api/notification/presentation/controller/NotificationPreferenceController.java
@@ -1,0 +1,37 @@
+package com.tissue.api.notification.presentation.controller;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.tissue.api.common.dto.ApiResponse;
+import com.tissue.api.notification.application.service.command.NotificationPreferenceService;
+import com.tissue.api.notification.presentation.dto.request.UpdateNotificationPreferenceRequest;
+import com.tissue.api.security.authentication.interceptor.LoginRequired;
+import com.tissue.api.security.authentication.resolver.ResolveLoginMember;
+import com.tissue.api.security.authorization.interceptor.RoleRequired;
+import com.tissue.api.workspacemember.domain.model.enums.WorkspaceRole;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/workspaces/{workspaceCode}/notifications/preferences")
+public class NotificationPreferenceController {
+
+	private final NotificationPreferenceService preferenceService;
+
+	@LoginRequired
+	@RoleRequired(role = WorkspaceRole.VIEWER)
+	@PostMapping
+	public ApiResponse<Void> updatePreferences(
+		@PathVariable String workspaceCode,
+		@ResolveLoginMember Long loginMemberId,
+		@RequestBody UpdateNotificationPreferenceRequest request
+	) {
+		preferenceService.updatePreference(workspaceCode, loginMemberId, request);
+		return ApiResponse.okWithNoContent("Updated notification preference.");
+	}
+}

--- a/backend/src/main/java/com/tissue/api/notification/presentation/controller/NotificationQueryController.java
+++ b/backend/src/main/java/com/tissue/api/notification/presentation/controller/NotificationQueryController.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/workspaces/{code}/notifications")
+@RequestMapping("/api/v1/workspaces/{workspaceCode}/notifications")
 public class NotificationQueryController {
 
 	/**

--- a/backend/src/main/java/com/tissue/api/notification/presentation/dto/request/UpdateNotificationPreferenceRequest.java
+++ b/backend/src/main/java/com/tissue/api/notification/presentation/dto/request/UpdateNotificationPreferenceRequest.java
@@ -1,0 +1,16 @@
+package com.tissue.api.notification.presentation.dto.request;
+
+import com.tissue.api.notification.domain.enums.NotificationType;
+
+import jakarta.validation.constraints.NotNull;
+
+// TODO: 추후에 notification channel에 따른 설정도 제공할 필요가 있음(Slack, Discord, 등...을 지원한다면)
+//  지금은 그냥 email의 알림 설정만 가능(inApp은 기본적으로 항상 true지만 이것도 변경 예정)
+public record UpdateNotificationPreferenceRequest(
+	@NotNull(message = "{valid.notnull}")
+	NotificationType type,
+
+	@NotNull(message = "{valid.notnull}")
+	boolean enabled
+) {
+}

--- a/backend/src/main/java/com/tissue/api/workspacemember/application/service/command/WorkspaceMemberReader.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/application/service/command/WorkspaceMemberReader.java
@@ -4,8 +4,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.tissue.api.workspacemember.domain.model.WorkspaceMember;
-import com.tissue.api.workspacemember.infrastructure.repository.WorkspaceMemberRepository;
 import com.tissue.api.workspacemember.exception.WorkspaceMemberNotFoundException;
+import com.tissue.api.workspacemember.infrastructure.repository.WorkspaceMemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,8 +22,8 @@ public class WorkspaceMemberReader {
 	}
 
 	@Transactional(readOnly = true)
-	public WorkspaceMember findWorkspaceMember(Long id, String code) {
-		return workspaceMemberRepository.findByMemberIdAndWorkspaceCode(id, code)
-			.orElseThrow(() -> new WorkspaceMemberNotFoundException(id, code));
+	public WorkspaceMember findWorkspaceMember(Long memberId, String code) {
+		return workspaceMemberRepository.findByMemberIdAndWorkspaceCode(memberId, code)
+			.orElseThrow(() -> new WorkspaceMemberNotFoundException(memberId, code));
 	}
 }

--- a/backend/src/main/java/com/tissue/api/workspacemember/domain/model/WorkspaceMember.java
+++ b/backend/src/main/java/com/tissue/api/workspacemember/domain/model/WorkspaceMember.java
@@ -63,6 +63,9 @@ public class WorkspaceMember extends BaseEntity {
 	@Column(nullable = false)
 	private String displayName;
 
+	@Column(nullable = false)
+	private String email;
+
 	// TODO: 캐싱은 추후에 고려
 	//  (클라이언트에서 displayName, username을 한번에 조회하고 조합해서 사용하는 방식 고려
 	// private String displayWithUsername;
@@ -77,6 +80,7 @@ public class WorkspaceMember extends BaseEntity {
 		this.workspace = workspace;
 		this.role = role;
 		this.displayName = member.getUsername();
+		this.email = member.getEmail();
 		this.workspaceCode = workspace.getCode();
 	}
 

--- a/backend/src/test/java/com/tissue/api/notification/application/service/command/NotificationPreferenceServiceTest.java
+++ b/backend/src/test/java/com/tissue/api/notification/application/service/command/NotificationPreferenceServiceTest.java
@@ -1,0 +1,87 @@
+package com.tissue.api.notification.application.service.command;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.tissue.api.notification.domain.enums.NotificationChannel;
+import com.tissue.api.notification.domain.enums.NotificationType;
+import com.tissue.api.notification.domain.model.NotificationPreference;
+import com.tissue.api.notification.infrastructure.repository.NotificationPreferenceRepository;
+import com.tissue.api.notification.presentation.dto.request.UpdateNotificationPreferenceRequest;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationPreferenceServiceTest {
+
+	@Mock
+	private NotificationPreferenceRepository repository;
+
+	@InjectMocks
+	private NotificationPreferenceService service;
+
+	@Test
+	@DisplayName("기존 알림 설정이 존재하지 않으면, 새로 생성한다")
+	void updatePreference_shouldCreateNewPreferenceIfNotExists() {
+		// given
+		String workspaceCode = "WS123";
+		Long memberId = 1L;
+		NotificationType type = NotificationType.ISSUE_CREATED;
+
+		UpdateNotificationPreferenceRequest request = new UpdateNotificationPreferenceRequest(type, true);
+
+		when(repository.findByReceiver(memberId, workspaceCode, type, NotificationChannel.EMAIL))
+			.thenReturn(Optional.empty());
+
+		// when
+		service.updatePreference(workspaceCode, memberId, request);
+
+		// then
+		ArgumentCaptor<NotificationPreference> captor = ArgumentCaptor.forClass(NotificationPreference.class);
+		verify(repository).save(captor.capture());
+
+		NotificationPreference saved = captor.getValue();
+		assertThat(saved.getReceiverMemberId()).isEqualTo(memberId);
+		assertThat(saved.getWorkspaceCode()).isEqualTo(workspaceCode);
+		assertThat(saved.getType()).isEqualTo(type);
+		assertThat(saved.getChannel()).isEqualTo(NotificationChannel.EMAIL);
+		assertThat(saved.isEnabled()).isTrue();
+	}
+
+	@Test
+	@DisplayName("알림 설정을 업데이트할 수 있다")
+	void updatePreference_shouldUpdateExistingPreference() {
+		// given
+		String workspaceCode = "WS123";
+		Long memberId = 1L;
+		NotificationType type = NotificationType.ISSUE_CREATED;
+
+		NotificationPreference existing = NotificationPreference.builder()
+			.receiverMemberId(memberId)
+			.workspaceCode(workspaceCode)
+			.type(type)
+			.channel(NotificationChannel.EMAIL)
+			.enabled(false)
+			.build();
+
+		UpdateNotificationPreferenceRequest request = new UpdateNotificationPreferenceRequest(type, true);
+
+		when(repository.findByReceiver(memberId, workspaceCode, type, NotificationChannel.EMAIL))
+			.thenReturn(Optional.of(existing));
+
+		// when
+		service.updatePreference(workspaceCode, memberId, request);
+
+		// then
+		assertThat(existing.isEnabled()).isTrue();
+		verify(repository).save(existing);
+	}
+}

--- a/backend/src/test/java/com/tissue/api/notification/application/service/command/NotificationProcessorTest.java
+++ b/backend/src/test/java/com/tissue/api/notification/application/service/command/NotificationProcessorTest.java
@@ -73,7 +73,7 @@ class NotificationProcessorTest {
 	}
 
 	@Test
-	@DisplayName("설정에서 이메일만 허용된 경우 이메일만 전송된다")
+	@DisplayName("설정에서 이메일을 비허용하면 인앱 알림만 발송된다")
 	void process_shouldOnlySendEmail_WhenPreferenceDisallowsInApp() {
 		// given
 		Notification notification = mock(Notification.class);
@@ -89,19 +89,19 @@ class NotificationProcessorTest {
 		when(preferenceRepository.findByReceiver(any(), any(), any(), eq(NotificationChannel.IN_APP)))
 			.thenReturn(Optional.of(
 				new NotificationPreference(1L, "TEST", NotificationType.ISSUE_CREATED, NotificationChannel.IN_APP,
-					false, false)));
+					true)));
 
 		when(preferenceRepository.findByReceiver(any(), any(), any(), eq(NotificationChannel.EMAIL)))
 			.thenReturn(Optional.of(
-				new NotificationPreference(1L, "TEST", NotificationType.ISSUE_CREATED, NotificationChannel.EMAIL, false,
-					true)));
+				new NotificationPreference(1L, "TEST", NotificationType.ISSUE_CREATED, NotificationChannel.EMAIL,
+					false)));
 
 		// when
 		notificationProcessor.process(notification);
 
 		// then
-		verify(inAppSender, never()).send(any());
-		verify(emailSender).send(notification);
+		verify(inAppSender).send(notification);
+		verify(emailSender, never()).send(any());
 	}
 
 	@Test
@@ -118,10 +118,15 @@ class NotificationProcessorTest {
 				.stringKey("ISSUE-1")
 				.build());
 
-		when(preferenceRepository.findByReceiver(any(), any(), any(), any()))
+		when(preferenceRepository.findByReceiver(any(), any(), any(), eq(NotificationChannel.IN_APP)))
 			.thenReturn(Optional.of(
 				new NotificationPreference(1L, "TEST", NotificationType.ISSUE_CREATED, NotificationChannel.IN_APP,
-					false, false)));
+					false)));
+
+		when(preferenceRepository.findByReceiver(any(), any(), any(), eq(NotificationChannel.EMAIL)))
+			.thenReturn(Optional.of(
+				new NotificationPreference(1L, "TEST", NotificationType.ISSUE_CREATED, NotificationChannel.EMAIL,
+					false)));
 
 		// when
 		notificationProcessor.process(notification);

--- a/backend/src/test/java/com/tissue/integration/service/command/NotificationPreferenceIT.java
+++ b/backend/src/test/java/com/tissue/integration/service/command/NotificationPreferenceIT.java
@@ -1,0 +1,123 @@
+package com.tissue.integration.service.command;
+
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.tissue.api.member.domain.model.Member;
+import com.tissue.api.notification.application.service.command.NotificationCommandService;
+import com.tissue.api.notification.application.service.command.NotificationPreferenceService;
+import com.tissue.api.notification.application.service.command.NotificationProcessor;
+import com.tissue.api.notification.domain.enums.NotificationChannel;
+import com.tissue.api.notification.domain.enums.NotificationType;
+import com.tissue.api.notification.domain.model.Notification;
+import com.tissue.api.notification.domain.model.vo.NotificationMessage;
+import com.tissue.api.notification.domain.service.sender.NotificationSender;
+import com.tissue.api.notification.infrastructure.message.SimpleNotificationMessageFactory;
+import com.tissue.api.notification.infrastructure.repository.NotificationPreferenceRepository;
+import com.tissue.api.notification.presentation.dto.request.UpdateNotificationPreferenceRequest;
+import com.tissue.api.workspace.domain.model.Workspace;
+import com.tissue.api.workspacemember.domain.model.WorkspaceMember;
+import com.tissue.api.workspacemember.domain.model.enums.WorkspaceRole;
+import com.tissue.support.dummy.DummyEvent;
+import com.tissue.support.fixture.TestDataFixture;
+import com.tissue.support.util.DatabaseCleaner;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class NotificationPreferenceIT {
+
+	@Autowired
+	private NotificationPreferenceService preferenceService;
+
+	@Autowired
+	private NotificationCommandService notificationCommandService;
+
+	@Autowired
+	private NotificationPreferenceRepository preferenceRepository;
+
+	@Autowired
+	private SimpleNotificationMessageFactory simpleNotificationMessageFactory;
+
+	@Autowired
+	protected TestDataFixture testDataFixture;
+
+	@Autowired
+	protected DatabaseCleaner databaseCleaner;
+
+	private NotificationProcessor notificationProcessor;
+
+	private NotificationSender mockEmailSender;
+
+	Workspace workspace;
+	Member member;
+	WorkspaceMember workspaceMember;
+
+	@BeforeEach
+	void setUp() {
+		// create workspace
+		workspace = testDataFixture.createWorkspace(
+			"test workspace",
+			null,
+			null
+		);
+
+		// create member
+		member = testDataFixture.createMember("member");
+
+		// add workspace member
+		workspaceMember = testDataFixture.createWorkspaceMember(
+			member,
+			workspace,
+			WorkspaceRole.MEMBER
+		);
+
+		mockEmailSender = mock(NotificationSender.class);
+		when(mockEmailSender.getChannel()).thenReturn(NotificationChannel.EMAIL);
+
+		// 실제 notificationProcessor에 직접 mockEmailSender를 주입함
+		notificationProcessor = new NotificationProcessor(
+			List.of(mockEmailSender),
+			preferenceRepository
+		);
+	}
+
+	@AfterEach
+	public void tearDown() {
+		databaseCleaner.execute();
+	}
+
+	@Test
+	@Transactional
+	void shouldNotSendEmail_WhenEmailPreferenceIsDisabled() {
+		// given
+		NotificationType type = NotificationType.ISSUE_CREATED;
+
+		// 알림 끄기
+		preferenceService.updatePreference(workspace.getCode(), member.getId(),
+			new UpdateNotificationPreferenceRequest(type, false));
+
+		NotificationMessage message = new NotificationMessage("test", "test");
+
+		// when
+		Notification notification = notificationCommandService.createNotification(
+			new DummyEvent(member.getId(), workspace.getCode(), type),
+			member.getId(),
+			message
+		);
+
+		// when
+		notificationProcessor.process(notification);
+
+		// then
+		verify(mockEmailSender, never()).send(any());
+	}
+}

--- a/backend/src/test/java/com/tissue/support/dummy/DummyEvent.java
+++ b/backend/src/test/java/com/tissue/support/dummy/DummyEvent.java
@@ -1,0 +1,59 @@
+package com.tissue.support.dummy;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.tissue.api.common.event.DomainEvent;
+import com.tissue.api.notification.domain.enums.NotificationType;
+import com.tissue.api.notification.domain.model.vo.EntityReference;
+
+import lombok.Builder;
+
+public class DummyEvent implements DomainEvent {
+
+	private final Long actorId;
+	private final String workspaceCode;
+	private final NotificationType type;
+
+	@Builder
+	public DummyEvent(Long actorId, String workspaceCode, NotificationType type) {
+		this.actorId = actorId;
+		this.workspaceCode = workspaceCode;
+		this.type = type;
+	}
+
+	@Override
+	public String getWorkspaceCode() {
+		return workspaceCode;
+	}
+
+	@Override
+	public Long getActorMemberId() {
+		return actorId;
+	}
+
+	@Override
+	public NotificationType getNotificationType() {
+		return type;
+	}
+
+	@Override
+	public String getEntityKey() {
+		return null;
+	}
+
+	@Override
+	public UUID getEventId() {
+		return UUID.randomUUID();
+	}
+
+	@Override
+	public LocalDateTime getOccurredAt() {
+		return LocalDateTime.now();
+	}
+
+	@Override
+	public EntityReference createEntityReference() {
+		return EntityReference.forWorkspace(workspaceCode);
+	}
+}

--- a/backend/src/test/java/com/tissue/unit/service/NotificationEventHandlerTest.java
+++ b/backend/src/test/java/com/tissue/unit/service/NotificationEventHandlerTest.java
@@ -23,6 +23,7 @@ import com.tissue.api.notification.application.service.command.NotificationTarge
 import com.tissue.api.notification.domain.model.Notification;
 import com.tissue.api.notification.domain.model.vo.NotificationMessage;
 import com.tissue.api.notification.domain.service.message.NotificationMessageFactory;
+import com.tissue.api.notification.infrastructure.repository.ActivityLogRepository;
 import com.tissue.api.workspacemember.application.service.command.WorkspaceMemberReader;
 import com.tissue.api.workspacemember.domain.model.WorkspaceMember;
 import com.tissue.api.workspacemember.infrastructure.repository.WorkspaceMemberRepository;
@@ -50,6 +51,9 @@ class NotificationEventHandlerTest {
 
 	@Mock
 	private NotificationMessageFactory notificationMessageFactory;
+
+	@Mock
+	private ActivityLogRepository activityLogRepository;
 
 	@InjectMocks
 	private NotificationEventHandler notificationEventHandler;

--- a/backend/src/test/java/com/tissue/unit/service/command/NotificationCommandServiceTest.java
+++ b/backend/src/test/java/com/tissue/unit/service/command/NotificationCommandServiceTest.java
@@ -60,9 +60,12 @@ class NotificationCommandServiceTest {
 		when(event.getWorkspaceCode()).thenReturn(workspaceCode);
 
 		// 액터 모의 설정
-		WorkspaceMember actorMember = mock(WorkspaceMember.class);
-		when(actorMember.getDisplayName()).thenReturn("TestUser");
-		when(workspaceMemberReader.findWorkspaceMember(actorId, workspaceCode)).thenReturn(actorMember);
+		WorkspaceMember actor = mock(WorkspaceMember.class);
+		when(actor.getDisplayName()).thenReturn("TestUser");
+		when(workspaceMemberReader.findWorkspaceMember(actorId, workspaceCode)).thenReturn(actor);
+		WorkspaceMember receiver = mock(WorkspaceMember.class);
+		when(workspaceMemberReader.findWorkspaceMember(receiverId, workspaceCode)).thenReturn(receiver);
+		when(receiver.getEmail()).thenReturn("receiver_email");
 
 		// when
 		notificationCommandService.createNotification(


### PR DESCRIPTION
## 🚀 설명
- `NotificationPreference`를 설정하는 API 구현
  - `NotificationPreferenceController`
  - `NotificationPreferenceService` 
- 이메일 클라이언트(`EmailClient`) 인터페이스 추가 
- `EmailSender`는 `EmailClient`를 의존
- `EmailClient`의 구현체인 `DummyEmailClient` 구현(테스트용)
- 추후에 AWS SES를 사용하는 구현체를 추가할 예정
- 이벤트를 기록하는 `ActivityLog` 엔티티 추가
- 이벤트 기록 로직 추가
---
## ✅ 변경 사항
- [x] `NotificationPreference`를 설정하는 API 구현
- [x] `EmailClient` 추가
  - [x] `DummyEmailClient` 구현
- [x] `ActivityLog` 추가
- [x] `ActivityLog` 저장 로직을 `NotificationEventHandler`에서 처리

---
## 🚩 관련 이슈, PR
- #241 
- #242 

---
## 📖 참고
- 